### PR TITLE
Fix standard validate exit code on invalid results

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -322,6 +322,10 @@ def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, pr
             reporter.generate(result, output)
             click.echo(f"\n✓ Validation report generated: {output}")
 
+        # Align exit behavior with chunked validation path and CI expectations.
+        if not result['valid']:
+            sys.exit(1)
+
     except Exception as e:
         logger.error(f"Error validating file: {e}")
         import traceback


### PR DESCRIPTION
## Summary\nEnsure non-chunked `validate` exits with code 1 when validation fails.\n\n## Why\nCI needs non-zero exit status for invalid validation outcomes, consistent with chunked path.\n\n## Verified\n- p327 validate with rules now prints validation failure and returns exit code 1.