### PR TITLE
feat: add true parallel chunked validation with workers flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ cm3-batch validate -f data/files/p327_sample_errored.txt -m config/mappings/p327
   --use-chunked --strict-fixed-width --strict-level format --progress \
   -o reports/p327_chunked_strict_validation.html
 
+# Parallel chunked strict validation (multi-core)
+cm3-batch validate -f data/files/p327_sample_errored.txt -m config/mappings/p327_mapping.json \
+  --use-chunked --chunk-size 50000 --workers 3 --strict-fixed-width --strict-level format --progress \
+  -o reports/p327_chunked_strict_parallel_validation.html
+
 # Compare files
 cm3-batch compare -f1 file1.txt -f2 file2.txt -k customer_id -o report.html
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -272,6 +272,7 @@ cm3-batch validate \
 - `--detailed/--basic`: Report depth
 - `--strict-fixed-width`: Enable strict fixed-width field checks
 - `--strict-level [basic|format|all]`: Strict validation depth
+- `--workers <n>`: Parallel worker processes for chunked validation (default: 1)
 
 #### Strict field-level validation (fixed-width)
 
@@ -307,6 +308,19 @@ cm3-batch validate \
 ```
 
 > Chunked validation supports strict fixed-width field checks, row-level mismatch detection, and progress display.
+
+#### Parallel chunked validation
+
+```bash
+cm3-batch validate \
+  -f data/files/p327_sample_errored.txt \
+  -m config/mappings/p327_mapping.json \
+  --use-chunked --chunk-size 50000 --workers 3 \
+  --strict-fixed-width --strict-level format \
+  -o reports/p327_chunked_strict_parallel_validation.html
+```
+
+> In parallel mode (`--workers > 1`), duplicate-row detection is disabled for performance.
 
 #### Validation Report Features
 

--- a/src/commands/validate_command.py
+++ b/src/commands/validate_command.py
@@ -31,6 +31,7 @@ def run_validate_command(
     progress,
     strict_fixed_width=False,
     strict_level='format',
+    workers=1,
     logger=None,
 ):
     from src.parsers.format_detector import FormatDetector
@@ -100,6 +101,7 @@ def run_validate_command(
             strict_fixed_width=bool(strict_fixed_width),
             strict_level=str(strict_level or 'format'),
             strict_fields=strict_fields,
+            workers=int(workers or 1),
         )
 
         if mapping_config:

--- a/src/main.py
+++ b/src/main.py
@@ -72,8 +72,10 @@ def parse(file, mapping, format, output, use_chunked, chunk_size):
               help='Enable strict fixed-width field-level validation checks')
 @click.option('--strict-level', type=click.Choice(['basic', 'format', 'all']), default='format',
               help='Strict fixed-width validation depth')
+@click.option('--workers', default=1, type=int, show_default=True,
+              help='Parallel worker processes for chunked validation (1 disables parallel mode)')
 def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
-             strict_fixed_width, strict_level):
+             strict_fixed_width, strict_level, workers):
     """Validate file format and content."""
     logger = setup_logger('cm3-batch', log_to_file=False)
 
@@ -81,7 +83,7 @@ def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, pr
         from src.commands.validate_command import run_validate_command
         run_validate_command(
             file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
-            strict_fixed_width, strict_level, logger,
+            strict_fixed_width, strict_level, workers, logger,
         )
     except Exception as e:
         logger.error(f"Error validating file: {e}")


### PR DESCRIPTION
## Summary
Add true parallel chunked validation for strict large-file runs.

## Changes
- Added `--workers <n>` CLI option for `cm3-batch validate`.
- Implemented process-based parallel chunk validation in `ChunkedFileValidator` when:
  - chunked mode is enabled, and
  - `workers > 1`.
- Added explicit behavior notes:
  - duplicate-row detection disabled in parallel mode for performance.
  - if business rules are enabled, validator falls back to sequential mode.
- Updated docs:
  - `README.md`
  - `docs/USAGE_GUIDE.md`
- Added unit coverage for parallel mode stats/warnings.

## Validation
- Full test suite: `150 passed`
- Coverage gate: `82.09%` (>= 80)

## Motivation
Strict chunked validation on large files (e.g., 600k rows) was taking too long in single-process mode. This change enables multi-core execution.
