### PR TITLE
[SECURITY] Add pluggable secrets provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,16 @@
 # Oracle Database Configuration
 # DSN format: hostname:port/service_name  (e.g. localhost:1521/FREEPDB1)
 # NOTE: Oracle Instant Client is NOT required — uses oracledb thin mode.
+SECRETS_PROVIDER=env
 ORACLE_USER=your_username
 ORACLE_PASSWORD=your_password
 ORACLE_DSN=hostname:1521/service_name
+
+# CyberArk CCP (optional; used when SECRETS_PROVIDER=cyberark)
+CYBERARK_CCP_URL=https://cyberark.internal.example.com
+CYBERARK_APP_ID=cm3-batch-automations
+CYBERARK_SAFE=CM3-Batch-Dev
+CYBERARK_OBJECT=Oracle-DEV-Credentials
 
 # Application Configuration
 ENVIRONMENT=dev

--- a/docs/secrets-setup.md
+++ b/docs/secrets-setup.md
@@ -1,0 +1,30 @@
+# Secrets provider setup
+
+CM3 Batch Automations supports pluggable secrets providers via `SECRETS_PROVIDER`.
+
+## Providers
+
+- `env` (default): reads `ORACLE_USER`, `ORACLE_PASSWORD`, `ORACLE_DSN` directly from environment variables.
+- `cyberark`: fetches Oracle credentials from CyberArk Central Credential Provider (CCP).
+- `hashicorp`, `azure_keyvault`: placeholders for future integrations.
+
+## Environment provider (default)
+
+```bash
+SECRETS_PROVIDER=env
+ORACLE_USER=CM3INT
+ORACLE_PASSWORD=***
+ORACLE_DSN=localhost:1521/FREEPDB1
+```
+
+## CyberArk provider
+
+```bash
+SECRETS_PROVIDER=cyberark
+CYBERARK_CCP_URL=https://cyberark.internal.bank.com
+CYBERARK_APP_ID=cm3-batch-automations
+CYBERARK_SAFE=CM3-Batch-Dev
+CYBERARK_OBJECT=Oracle-DEV-Credentials
+```
+
+`OracleConnection.from_env()` resolves secrets through the configured provider. Secret *values* must never be logged; only key names and provider metadata are safe to log.

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -2,7 +2,7 @@
 
 import oracledb
 from typing import Optional
-import os
+from src.utils.secrets import load_oracle_credentials
 
 # Backward-compatible alias for older tests/code that patch cx_Oracle.
 cx_Oracle = oracledb
@@ -68,14 +68,15 @@ class OracleConnection:
 
     @staticmethod
     def from_env() -> "OracleConnection":
-        """Create connection from environment variables.
-        
+        """Create connection from environment/vault-backed secrets.
+
         Returns:
             OracleConnection instance
         """
+        creds = load_oracle_credentials()
         return OracleConnection(
-            username=os.getenv("ORACLE_USER", ""),
-            password=os.getenv("ORACLE_PASSWORD", ""),
-            dsn=os.getenv("ORACLE_DSN", ""),
+            username=creds["ORACLE_USER"],
+            password=creds["ORACLE_PASSWORD"],
+            dsn=creds["ORACLE_DSN"],
         )
 

--- a/src/utils/secrets.py
+++ b/src/utils/secrets.py
@@ -1,0 +1,104 @@
+"""Secrets provider abstraction for environment and vault-backed credentials."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import json
+import os
+from typing import Dict, Optional
+from urllib import parse, request
+
+
+class SecretsProvider(ABC):
+    """Interface for retrieving secrets by key."""
+
+    @abstractmethod
+    def get_secret(self, key: str) -> str:
+        """Return a secret value for key or raise KeyError/RuntimeError."""
+
+
+class EnvSecretsProvider(SecretsProvider):
+    """Read secrets from environment variables (backward-compatible default)."""
+
+    def get_secret(self, key: str) -> str:
+        value = os.getenv(key)
+        if value is None or value == "":
+            raise KeyError(f"Missing required secret: {key}")
+        return value
+
+
+class CyberArkSecretsProvider(SecretsProvider):
+    """Fetch secrets from CyberArk CCP REST API."""
+
+    def __init__(self, ccp_url: Optional[str] = None, app_id: Optional[str] = None):
+        self.ccp_url = (ccp_url or os.getenv("CYBERARK_CCP_URL", "")).rstrip("/")
+        self.app_id = app_id or os.getenv("CYBERARK_APP_ID", "")
+        if not self.ccp_url:
+            raise ValueError("CYBERARK_CCP_URL is required for cyberark provider")
+        if not self.app_id:
+            raise ValueError("CYBERARK_APP_ID is required for cyberark provider")
+
+    def get_secret(self, key: str) -> str:
+        safe = os.getenv("CYBERARK_SAFE", "")
+        obj = os.getenv("CYBERARK_OBJECT", "")
+        if not safe or not obj:
+            raise ValueError("CYBERARK_SAFE and CYBERARK_OBJECT are required for cyberark provider")
+
+        params = {
+            "AppID": self.app_id,
+            "Safe": safe,
+            "Object": obj,
+            "Reason": f"cm3-batch/{key}",
+        }
+        query = parse.urlencode(params)
+        url = f"{self.ccp_url}/AIMWebService/api/Accounts?{query}"
+        with request.urlopen(url, timeout=10) as resp:  # nosec B310 (controlled URL from env)
+            payload = json.loads(resp.read().decode("utf-8"))
+
+        candidate = payload.get(key)
+        if candidate:
+            return candidate
+
+        content = payload.get("Content")
+        if content:
+            return content
+
+        raise KeyError(f"CyberArk secret not found for requested key: {key}")
+
+
+class HashiCorpVaultSecretsProvider(SecretsProvider):
+    """Placeholder provider for future Vault integration."""
+
+    def get_secret(self, key: str) -> str:
+        raise NotImplementedError("HashiCorp Vault provider not configured in this environment")
+
+
+class AzureKeyVaultSecretsProvider(SecretsProvider):
+    """Placeholder provider for future Azure Key Vault integration."""
+
+    def get_secret(self, key: str) -> str:
+        raise NotImplementedError("Azure Key Vault provider not configured in this environment")
+
+
+def get_secrets_provider(provider_name: Optional[str] = None) -> SecretsProvider:
+    """Return a provider instance based on SECRETS_PROVIDER (default: env)."""
+    name = (provider_name or os.getenv("SECRETS_PROVIDER", "env")).strip().lower()
+    if name == "env":
+        return EnvSecretsProvider()
+    if name == "cyberark":
+        return CyberArkSecretsProvider()
+    if name in {"hashicorp", "vault"}:
+        return HashiCorpVaultSecretsProvider()
+    if name in {"azure_keyvault", "azure", "akv"}:
+        return AzureKeyVaultSecretsProvider()
+    raise ValueError(f"Unsupported SECRETS_PROVIDER: {name}")
+
+
+def load_oracle_credentials(provider: Optional[SecretsProvider] = None) -> Dict[str, str]:
+    """Resolve Oracle credentials using configured provider without logging values."""
+    resolver = provider or get_secrets_provider()
+    return {
+        "ORACLE_USER": resolver.get_secret("ORACLE_USER"),
+        "ORACLE_PASSWORD": resolver.get_secret("ORACLE_PASSWORD"),
+        "ORACLE_DSN": resolver.get_secret("ORACLE_DSN"),
+    }

--- a/tests/unit/test_secrets_provider.py
+++ b/tests/unit/test_secrets_provider.py
@@ -1,0 +1,54 @@
+import json
+
+from src.utils.secrets import (
+    EnvSecretsProvider,
+    get_secrets_provider,
+    load_oracle_credentials,
+    CyberArkSecretsProvider,
+)
+
+
+def test_env_provider_reads_oracle_creds(monkeypatch):
+    monkeypatch.setenv("SECRETS_PROVIDER", "env")
+    monkeypatch.setenv("ORACLE_USER", "u1")
+    monkeypatch.setenv("ORACLE_PASSWORD", "p1")
+    monkeypatch.setenv("ORACLE_DSN", "dsn1")
+
+    creds = load_oracle_credentials()
+    assert creds == {
+        "ORACLE_USER": "u1",
+        "ORACLE_PASSWORD": "p1",
+        "ORACLE_DSN": "dsn1",
+    }
+
+
+def test_get_secrets_provider_default_env(monkeypatch):
+    monkeypatch.delenv("SECRETS_PROVIDER", raising=False)
+    assert isinstance(get_secrets_provider(), EnvSecretsProvider)
+
+
+def test_cyberark_provider_uses_content_field(monkeypatch):
+    monkeypatch.setenv("CYBERARK_CCP_URL", "https://vault.local")
+    monkeypatch.setenv("CYBERARK_APP_ID", "cm3")
+    monkeypatch.setenv("CYBERARK_SAFE", "safe1")
+    monkeypatch.setenv("CYBERARK_OBJECT", "obj1")
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self):
+            return json.dumps({"Content": "secret-from-cyberark"}).encode("utf-8")
+
+    def _fake_urlopen(url, timeout=10):
+        assert "AIMWebService/api/Accounts" in url
+        assert "AppID=cm3" in url
+        return _Resp()
+
+    monkeypatch.setattr("src.utils.secrets.request.urlopen", _fake_urlopen)
+
+    provider = CyberArkSecretsProvider()
+    assert provider.get_secret("ORACLE_PASSWORD") == "secret-from-cyberark"


### PR DESCRIPTION
Implements vault-ready secrets retrieval for Oracle credentials.

## What changed
- Added SecretsProvider abstraction in `src/utils/secrets.py`
- Added providers:
  - EnvSecretsProvider (default/backward compatible)
  - CyberArkSecretsProvider (CCP REST retrieval)
  - placeholders for HashiCorp Vault and Azure Key Vault
- Updated `OracleConnection.from_env()` to resolve credentials via configured provider
- Added docs: `docs/secrets-setup.md`
- Updated `.env.example` with provider configuration
- Added unit tests for env + mocked CyberArk retrieval

## Notes
- Secrets are never logged by this code path (only key names/provider selection should be logged at call sites).
- Local test execution was blocked in this environment because `pytest` is not installed.

Fixes #29
