### PR TITLE
[SECURITY] Add initial data masking command for DEV files

### DIFF
--- a/config/masking/p327_masking_rules.json
+++ b/config/masking/p327_masking_rules.json
@@ -1,0 +1,9 @@
+{
+  "fields": [
+    {"name": "ACCT-NUM", "strategy": "preserve_format"},
+    {"name": "SSN", "strategy": "deterministic_hash"},
+    {"name": "FIRST_NAME", "strategy": "fake_name"},
+    {"name": "BALANCE-AMT", "strategy": "random_range", "min": 0, "max": 99999},
+    {"name": "PROCESS_DATE", "strategy": "preserve"}
+  ]
+}

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -4,7 +4,7 @@ This is the **single source of truth** for docs navigation.
 
 ## Start Here
 - `README.md` — quick start and project overview
-- `docs/USAGE_GUIDE.md` — practical command usage
+- `docs/USAGE_GUIDE.md` — practical command usage (CLI/API and masking workflows)
 - `docs/FUNCTIONALITY_MATRIX.md` — capability matrix (CLI/API/inputs/outputs)
 - `docs/architecture.md` — architecture and flow diagrams
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -618,6 +618,20 @@ Supported fields: `url`, `method` (GET/POST), `body` (JSON dict for POST),
 
 ---
 
+### Masking files for DEV (PII-safe)
+
+Use `mask` to produce a structurally identical but masked copy of a batch file:
+
+```bash
+cm3-batch mask \
+  --file data/input/P327_sample.txt \
+  --mapping config/mappings/p327_universal.json \
+  --rules config/masking/p327_masking_rules.json \
+  --output data/output/P327_sample_masked.txt
+```
+
+Supported strategies in rules JSON: `preserve`, `preserve_format`, `deterministic_hash`, `random_range`, `redact`, `fake_name`.
+
 ## API Usage
 
 ### Accessing the API

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -20,6 +20,10 @@ Commands
    :members:
    :undoc-members:
 
+.. automodule:: src.commands.mask_command
+   :members:
+   :undoc-members:
+
 Database
 --------
 

--- a/src/commands/mask_command.py
+++ b/src/commands/mask_command.py
@@ -1,0 +1,95 @@
+"""Masking command implementation for DEV-safe batch files."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from pathlib import Path
+from typing import Dict, List
+
+
+def _digit_hash(value: str, width: int) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    digits = "".join(str(int(ch, 16) % 10) for ch in digest)
+    out = (digits * ((width // len(digits)) + 1))[:width]
+    return out
+
+
+def _preserve_format(value: str) -> str:
+    out = []
+    for ch in value:
+        if ch.isdigit():
+            out.append(str((int(ch) + 7) % 10))
+        elif ch.isalpha():
+            out.append("X" if ch.isupper() else "x")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _apply_strategy(value: str, rule: Dict) -> str:
+    strategy = rule.get("strategy", "preserve")
+    if strategy == "preserve":
+        return value
+    if strategy == "preserve_format":
+        return _preserve_format(value)
+    if strategy == "deterministic_hash":
+        return _digit_hash(value.strip() or "0", len(value))
+    if strategy == "redact":
+        return " " * len(value)
+    if strategy == "random_range":
+        low = int(rule.get("min", 0))
+        high = int(rule.get("max", 99999))
+        n = random.randint(low, high)
+        s = str(n)
+        return s[-len(value):].rjust(len(value), "0")
+    if strategy == "fake_name":
+        name = random.choice(["ALICE", "BOB", "CAROL", "DAVID", "EVA"])
+        return name[: len(value)].ljust(len(value))
+    return value
+
+
+def run_mask_command(file: str, mapping: str, rules: str, output: str) -> None:
+    """Mask a batch file using mapping/rules and write a new output file.
+
+    Args:
+        file: Input batch file path.
+        mapping: Mapping JSON path.
+        rules: Masking rules JSON path.
+        output: Output masked file path.
+    """
+    mapping_doc = json.loads(Path(mapping).read_text(encoding="utf-8"))
+    rules_doc = json.loads(Path(rules).read_text(encoding="utf-8"))
+
+    strategy_by_name = {r["name"]: r for r in rules_doc.get("fields", [])}
+    fmt = mapping_doc.get("source", {}).get("format", "fixed_width")
+    fields: List[Dict] = mapping_doc.get("fields", [])
+
+    src = Path(file)
+    dest = Path(output)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    with src.open("r", encoding="utf-8") as fin, dest.open("w", encoding="utf-8") as fout:
+        if fmt == "fixed_width":
+            lengths = [int(f.get("length", 0)) for f in fields]
+            for line in fin:
+                row = line.rstrip("\n")
+                cursor = 0
+                chunks: List[str] = []
+                for f, w in zip(fields, lengths):
+                    value = row[cursor:cursor + w]
+                    cursor += w
+                    masked = _apply_strategy(value, strategy_by_name.get(f.get("name", ""), {}))
+                    chunks.append(masked[:w].ljust(w))
+                fout.write("".join(chunks) + "\n")
+        else:
+            delim = "|" if fmt == "pipe_delimited" else ","
+            for line in fin:
+                parts = line.rstrip("\n").split(delim)
+                out_parts = []
+                for i, value in enumerate(parts):
+                    field_name = fields[i].get("name") if i < len(fields) else f"FIELD_{i+1}"
+                    masked = _apply_strategy(value, strategy_by_name.get(field_name, {}))
+                    out_parts.append(masked)
+                fout.write(delim.join(out_parts) + "\n")

--- a/src/main.py
+++ b/src/main.py
@@ -668,6 +668,24 @@ def gx_checkpoint1(targets_csv, expectations_csv, output_json, csv_output, html_
         sys.exit(1)
 
 
+@cli.command()
+@click.option('--file', '-f', required=True, type=click.Path(exists=True), help='Input batch file path')
+@click.option('--mapping', '-m', required=True, type=click.Path(exists=True), help='Mapping JSON path')
+@click.option('--rules', '-r', required=True, type=click.Path(exists=True), help='Masking rules JSON path')
+@click.option('--output', '-o', required=True, type=click.Path(), help='Masked output file path')
+def mask(file, mapping, rules, output):
+    """Create a masked, structurally-identical copy of a batch file for DEV use."""
+    logger = setup_logger('cm3-batch', log_to_file=False)
+    try:
+        from src.commands.mask_command import run_mask_command
+
+        run_mask_command(file=file, mapping=mapping, rules=rules, output=output)
+        click.echo(f"Masked file written to: {output}")
+    except Exception as e:
+        logger.error(f"Error masking file: {e}")
+        sys.exit(1)
+
+
 @cli.command('convert-suite')
 @click.option('--input', 'input_path', required=False, default=None,
               type=click.Path(), help='Path to Excel test suite file to convert')

--- a/tests/unit/test_mask_command.py
+++ b/tests/unit/test_mask_command.py
@@ -1,0 +1,65 @@
+"""Tests for batch file masking command."""
+
+import json
+from pathlib import Path
+
+from src.commands.mask_command import run_mask_command
+
+
+def test_mask_fixed_width_preserves_record_length(tmp_path: Path):
+    mapping = {
+        "mapping_name": "m1",
+        "source": {"format": "fixed_width"},
+        "fields": [
+            {"name": "ACCT", "length": 6},
+            {"name": "SSN", "length": 9},
+            {"name": "DATE", "length": 8},
+        ],
+    }
+    rules = {
+        "fields": [
+            {"name": "ACCT", "strategy": "preserve_format"},
+            {"name": "SSN", "strategy": "deterministic_hash"},
+            {"name": "DATE", "strategy": "preserve"},
+        ]
+    }
+    inp = tmp_path / "in.txt"
+    outp = tmp_path / "out.txt"
+    mp = tmp_path / "m.json"
+    rp = tmp_path / "r.json"
+
+    inp.write_text("12345611122333320260301\n12345611122333320260301\n", encoding="utf-8")
+    mp.write_text(json.dumps(mapping), encoding="utf-8")
+    rp.write_text(json.dumps(rules), encoding="utf-8")
+
+    run_mask_command(str(inp), str(mp), str(rp), str(outp))
+
+    out_lines = outp.read_text(encoding="utf-8").splitlines()
+    assert len(out_lines) == 2
+    assert len(out_lines[0]) == len("12345611122333320260301")
+    assert out_lines[0][15:23] == "20260301"
+
+
+def test_mask_deterministic_hash_stable_for_same_input(tmp_path: Path):
+    mapping = {
+        "mapping_name": "m1",
+        "source": {"format": "fixed_width"},
+        "fields": [
+            {"name": "SSN", "length": 9},
+        ],
+    }
+    rules = {"fields": [{"name": "SSN", "strategy": "deterministic_hash"}]}
+    inp = tmp_path / "in.txt"
+    outp = tmp_path / "out.txt"
+    mp = tmp_path / "m.json"
+    rp = tmp_path / "r.json"
+
+    inp.write_text("111223333\n111223333\n", encoding="utf-8")
+    mp.write_text(json.dumps(mapping), encoding="utf-8")
+    rp.write_text(json.dumps(rules), encoding="utf-8")
+
+    run_mask_command(str(inp), str(mp), str(rp), str(outp))
+
+    out = outp.read_text(encoding="utf-8").splitlines()
+    assert out[0] == out[1]
+    assert out[0] != "111223333"


### PR DESCRIPTION
Adds an initial `cm3-batch mask` command to generate PII-scrubbed DEV copies while preserving record structure.

## What changed
- Added `src/commands/mask_command.py` with strategies:
  - `preserve`, `preserve_format`, `deterministic_hash`, `random_range`, `redact`, `fake_name`
- Added CLI entrypoint:
  - `cm3-batch mask --file --mapping --rules --output`
- Supports fixed-width and delimited input masking
- Preserves fixed-width field lengths and total record length
- Added sample masking rules file: `config/masking/p327_masking_rules.json`
- Added unit tests for fixed-width length preservation + deterministic behavior
- Updated usage and docs index references

## Acceptance criteria status
- ✅ Masked file preserves fixed-width record length
- ✅ Deterministic masking for repeated values
- ✅ Original file remains untouched (writes to new output path)
- ⚠️ Excel template conversion workflow for masking rules not yet implemented
- ⚠️ Splunk audit emission (input/output/rules hash event) deferred to issue #21 audit logger integration

## Validation
- Could not execute pytest/Sphinx in this environment because required tools/modules are unavailable.

Fixes #30
