### PR TITLE
[SECURITY] Suppress PII in validation HTML and CSV reports

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -303,6 +303,7 @@ cm3-batch validate \
 - `--strict-fixed-width`: Enable strict fixed-width field checks
 - `--strict-level [basic|format|all]`: Strict validation depth
 - `--workers <n>`: Parallel worker processes for chunked validation (default: 1)
+- `--suppress-pii/--no-suppress-pii`: Redact raw field values in HTML/CSV reports (default: suppress)
 
 #### Strict field-level validation (fixed-width)
 

--- a/src/commands/validate_command.py
+++ b/src/commands/validate_command.py
@@ -79,6 +79,7 @@ def run_validate_command(
     strict_fixed_width=False,
     strict_level='format',
     workers=1,
+    suppress_pii=True,
     logger=None,
 ):
     from src.parsers.format_detector import FormatDetector
@@ -190,7 +191,7 @@ def run_validate_command(
             elif output.lower().endswith('.html') or output.lower().endswith('.htm'):
                 reporter = ValidationReporter()
                 adapted = adapt_chunked_validation_result(result, file_path=file, mapping=mapping)
-                reporter.generate(adapted, output)
+                reporter.generate(adapted, output, suppress_pii=suppress_pii)
                 click.echo(f"\n✓ Chunked validation HTML report generated: {output}")
             else:
                 click.echo(click.style("\nUnsupported output type for chunked validation. Use .json or .html", fg='yellow'))
@@ -238,7 +239,7 @@ def run_validate_command(
             click.echo(f"\n✓ Validation JSON report generated: {output}")
         elif output.lower().endswith('.html') or output.lower().endswith('.htm'):
             reporter = ValidationReporter()
-            reporter.generate(result, output)
+            reporter.generate(result, output, suppress_pii=suppress_pii)
             click.echo(f"\n✓ Validation HTML report generated: {output}")
         else:
             click.echo(click.style("\nUnsupported output type for validation. Use .json or .html", fg='yellow'))

--- a/src/main.py
+++ b/src/main.py
@@ -75,8 +75,10 @@ def parse(file, mapping, format, output, use_chunked, chunk_size):
               help='Strict fixed-width validation depth')
 @click.option('--workers', default=1, type=int, show_default=True,
               help='Parallel worker processes for chunked validation (1 disables parallel mode)')
+@click.option('--suppress-pii/--no-suppress-pii', default=True,
+              help='Suppress raw values in HTML/CSV validation reports')
 def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
-             strict_fixed_width, strict_level, workers):
+             strict_fixed_width, strict_level, workers, suppress_pii):
     """Validate file format and content."""
     logger = setup_logger('cm3-batch', log_to_file=False)
 
@@ -84,7 +86,7 @@ def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, pr
         from src.commands.validate_command import run_validate_command
         run_validate_command(
             file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
-            strict_fixed_width, strict_level, workers, logger,
+            strict_fixed_width, strict_level, workers, suppress_pii, logger,
         )
     except Exception as e:
         logger.error(f"Error validating file: {e}")

--- a/src/reports/renderers/validation_renderer.py
+++ b/src/reports/renderers/validation_renderer.py
@@ -23,21 +23,22 @@ class ValidationReporter:
     ERROR_DISPLAY_LIMIT = 10
     WARNING_DISPLAY_LIMIT = 100
 
-    def generate(self, validation_results: Dict[str, Any], output_path: str) -> None:
+    def generate(self, validation_results: Dict[str, Any], output_path: str, suppress_pii: bool = True) -> None:
         """Generate HTML validation report.
-        
+
         Args:
-            validation_results: Validation results from EnhancedFileValidator
-            output_path: Path to save HTML report
+            validation_results: Validation results from EnhancedFileValidator.
+            output_path: Path to save HTML report.
+            suppress_pii: Whether to redact raw values in report output.
         """
-        html = self._generate_html(validation_results)
+        html = self._generate_html(validation_results, suppress_pii=suppress_pii)
 
         with open(output_path, 'w', encoding='utf-8') as f:
             f.write(html)
 
         # Export full issue lists to CSV sidecars to keep HTML report concise.
-        self._write_errors_csv(validation_results, output_path)
-        self._write_warnings_csv(validation_results, output_path)
+        self._write_errors_csv(validation_results, output_path, suppress_pii=suppress_pii)
+        self._write_warnings_csv(validation_results, output_path, suppress_pii=suppress_pii)
 
     def _sort_issues(self, issues):
         """Sort issues by row (numeric), then field, then code/severity."""
@@ -54,7 +55,16 @@ class ValidationReporter:
 
         return sorted(issues, key=_key)
 
-    def _write_errors_csv(self, validation_results: Dict[str, Any], output_path: str) -> None:
+    def _mask_message(self, message: str, suppress_pii: bool) -> str:
+        """Mask sensitive value tokens in validation messages when requested."""
+        if not suppress_pii:
+            return message
+        text = str(message)
+        text = re.sub(r"(?i)(value\s+)([^\s,;]+)", r"\1[REDACTED]", text)
+        text = re.sub(r"'[^']{3,}'", "'[REDACTED]'", text)
+        return text
+
+    def _write_errors_csv(self, validation_results: Dict[str, Any], output_path: str, suppress_pii: bool = True) -> None:
         """Write all errors to a CSV sidecar next to the HTML report.
 
         The sidecar includes a ``source_row`` column so users can trace each
@@ -77,17 +87,17 @@ class ValidationReporter:
                         'source_row': error.get('source_row', error.get('row', '')),
                         'index': idx,
                         'severity': error.get('severity', 'error'),
-                        'message': error.get('message', ''),
+                        'message': self._mask_message(error.get('message', ''), suppress_pii=suppress_pii),
                     })
                 else:
                     writer.writerow({
                         'source_row': '',
                         'index': idx,
                         'severity': 'error',
-                        'message': str(error),
+                        'message': self._mask_message(str(error), suppress_pii=suppress_pii),
                     })
 
-    def _write_warnings_csv(self, validation_results: Dict[str, Any], output_path: str) -> None:
+    def _write_warnings_csv(self, validation_results: Dict[str, Any], output_path: str, suppress_pii: bool = True) -> None:
         """Write all warnings to a CSV sidecar next to the HTML report.
 
         The sidecar includes a ``source_row`` column so users can trace each
@@ -110,17 +120,17 @@ class ValidationReporter:
                         'source_row': warning.get('source_row', warning.get('row', '')),
                         'index': idx,
                         'severity': warning.get('severity', 'warning'),
-                        'message': warning.get('message', ''),
+                        'message': self._mask_message(warning.get('message', ''), suppress_pii=suppress_pii),
                     })
                 else:
                     writer.writerow({
                         'source_row': '',
                         'index': idx,
                         'severity': 'warning',
-                        'message': str(warning),
+                        'message': self._mask_message(str(warning), suppress_pii=suppress_pii),
                     })
 
-    def _generate_html(self, results: Dict[str, Any]) -> str:
+    def _generate_html(self, results: Dict[str, Any], suppress_pii: bool = True) -> str:
         """Generate complete HTML report."""
         return f"""<!DOCTYPE html>
 <html lang="en">
@@ -138,7 +148,7 @@ class ValidationReporter:
         {self._generate_header(results)}
         {self._generate_dashboard_bar(results)}
         {self._generate_full_metrics_details(results)}
-        {self._generate_issues(results)}
+        {self._generate_issues(results, suppress_pii=suppress_pii)}
         {self._generate_required_fields(results)}
         {self._wrap_collapsible_section('Field-Level Analysis', self._generate_field_analysis(results))}
         {self._wrap_collapsible_section('Date Field Analysis', self._generate_date_analysis(results))}
@@ -819,7 +829,7 @@ class ValidationReporter:
         </div>
         """
 
-    def _generate_issues(self, results: Dict[str, Any]) -> str:
+    def _generate_issues(self, results: Dict[str, Any], suppress_pii: bool = True) -> str:
         """Generate issues and warnings section with collapsible groups."""
         errors = self._sort_issues(results.get('errors', []))
         warnings = self._sort_issues(results.get('warnings', []))
@@ -838,6 +848,7 @@ class ValidationReporter:
             for item in items:
                 severity = item.get('severity', 'info') if isinstance(item, dict) else 'info'
                 message = item.get('message', '') if isinstance(item, dict) else str(item)
+                message = self._mask_message(message, suppress_pii=suppress_pii)
                 # Surface source_row (physical line number) when available.
                 source_row = None
                 if isinstance(item, dict):
@@ -870,7 +881,9 @@ class ValidationReporter:
                 issue_count = row_info.get('issue_count', 0)
                 issues = row_info.get('issues', [])
 
-                issues_list = ''.join(f'<li>{issue}</li>' for issue in issues[:5])
+                issues_list = ''.join(
+                    f"<li>{self._mask_message(issue, suppress_pii=suppress_pii)}</li>" for issue in issues[:5]
+                )
                 if len(issues) > 5:
                     issues_list += f'<li><em>... and {len(issues) - 5} more issues</em></li>'
 

--- a/tests/unit/test_validation_renderer.py
+++ b/tests/unit/test_validation_renderer.py
@@ -128,6 +128,22 @@ def test_validation_renderer_renders_chunked_telemetry_rows(tmp_path):
     assert "Rows / Second" in html
 
 
+def test_validation_renderer_suppresses_pii_in_html_and_csv_by_default(tmp_path):
+    out = tmp_path / "report_pii.html"
+    payload = _sample_result()
+    payload["errors"] = [{"severity": "error", "message": "value 123456789 failed regex for field SSN"}]
+
+    reporter = ValidationReporter()
+    reporter.generate(payload, str(out))
+
+    html = out.read_text(encoding="utf-8")
+    assert "123456789" not in html
+    assert "[REDACTED]" in html
+
+    err_csv = (tmp_path / "report_pii_errors.csv").read_text(encoding="utf-8")
+    assert "123456789" not in err_csv
+
+
 def test_validation_renderer_required_field_error_summary(tmp_path):
     out = tmp_path / "report_required.html"
     payload = _sample_result()


### PR DESCRIPTION
Defaults validation report output to PII-suppressed mode.

## What changed
- Added `suppress_pii` support to `ValidationReporter.generate(...)` (default `True`)
- Added masking of sensitive tokens in:
  - HTML issue messages
  - affected-rows issue summaries
  - `_errors.csv` and `_warnings.csv` sidecars
- Added CLI toggle on `validate` command:
  - `--suppress-pii` (default)
  - `--no-suppress-pii` (explicit opt-in to raw values)
- Wired suppression flag through `run_validate_command`
- Added renderer test coverage for redaction behavior
- Updated usage docs for new CLI option

## Acceptance criteria mapping
- ✅ `suppress_pii=True` default behavior
- ✅ No raw values in HTML/CSV outputs in default mode
- ✅ Row numbers and error structure preserved
- ✅ Added CLI flag for suppression toggle
- ⚠️ Regex masking is pattern-based; recommend follow-up pass for domain-specific PII patterns if needed

## Validation
- Could not execute pytest/Sphinx in this environment because required tools/modules are unavailable.

Fixes #18
