### PR TITLE
feat: structured splunk-ready audit logging for CLI/API runs

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -50,3 +50,5 @@ This is the **single source of truth** for docs navigation.
 
 ## Redundancy Policy
 When two docs overlap, keep details in the canonical doc above and reduce other files to short pointers.
+
+- [Splunk Setup](splunk-setup.md)

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1002,6 +1002,19 @@ with open("data.txt", "rb") as f:
 
 ---
 
+
+## Audit Logging (Splunk-ready)
+
+Set `AUDIT_LOG_PATH` to emit one-line JSON audit events for CLI/API test runs, auth failures, uploads, and cleanup operations.
+
+Example:
+
+```bash
+export AUDIT_LOG_PATH=logs/audit.log
+```
+
+See [Splunk Setup](splunk-setup.md) for forwarder and search examples.
+
 ## Troubleshooting
 
 ### API Server Won't Start

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -216,3 +216,8 @@ Reporting & Utilities
 .. automodule:: src.utils.archive
    :members:
    :undoc-members:
+
+.. automodule:: src.utils.audit_logger
+   :members:
+   :undoc-members:
+

--- a/docs/splunk-setup.md
+++ b/docs/splunk-setup.md
@@ -1,0 +1,50 @@
+# Splunk Setup for CM3 Audit Logs
+
+## Audit log source
+
+CM3 emits structured JSON audit events to a configurable path:
+
+- Env var: `AUDIT_LOG_PATH`
+- Default: `logs/audit.log`
+
+Configure your Splunk Universal Forwarder to monitor the chosen path.
+
+Example `inputs.conf`:
+
+```ini
+[monitor:///opt/cm3-batch-automations/logs/audit.log]
+disabled = false
+index = cm3_batch
+sourcetype = cm3:audit:json
+```
+
+## Recommended index and sourcetype
+
+- **index**: `cm3_batch`
+- **sourcetype**: `cm3:audit:json`
+
+Use `INDEXED_EXTRACTIONS=json` (or equivalent parsing config) if your Splunk deployment requires explicit JSON extraction.
+
+## Sample searches
+
+### All completed test runs (last 24h)
+
+```spl
+index=cm3_batch sourcetype=cm3:audit:json event_type="cli.test_run.completed" earliest=-24h
+| stats count by detail.status
+```
+
+### API auth failures by source IP
+
+```spl
+index=cm3_batch sourcetype=cm3:audit:json event_type="api.auth_failure" earliest=-7d
+| stats count by source_ip, detail.path
+| sort -count
+```
+
+### Failed runs with report location
+
+```spl
+index=cm3_batch sourcetype=cm3:audit:json event_type="cli.test_run.completed" detail.status="FAILED"
+| table timestamp detail.suite detail.env detail.run_id detail.report_path detail.report_hash
+```

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -19,8 +19,10 @@ from src.api.routers.runs import router as runs_router
 from src.api.routers import rules as rules_router_mod
 from src.api.routers.api_tester import router as api_tester_router
 from src.utils.cleanup import cleanup_old_files
+from src.utils.audit_logger import get_audit_logger
 
 logger = logging.getLogger(__name__)
+_audit = get_audit_logger()
 
 FILE_RETENTION_HOURS = float(os.getenv("FILE_RETENTION_HOURS", "24"))
 _UPLOADS_DIR = Path(__file__).parent.parent.parent / "uploads"
@@ -36,6 +38,15 @@ async def lifespan(app: FastAPI):
             "Startup cleanup: removed %d files (%d bytes)",
             result["deleted_count"],
             result["deleted_bytes"],
+        )
+        _audit.emit(
+            event_type="file.cleanup",
+            actor="system",
+            detail={
+                "deleted_count": result["deleted_count"],
+                "deleted_bytes": result["deleted_bytes"],
+                "trigger": "startup",
+            },
         )
     yield
     # Shutdown: nothing needed
@@ -76,6 +87,33 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class AuditMiddleware(BaseHTTPMiddleware):
+    """Emit audit events for API requests that trigger auth failures."""
+
+    async def dispatch(self, request: Request, call_next):
+        """Log auth failures (401/403) with client IP."""
+        response: Response = await call_next(request)
+        if response.status_code in (401, 403):
+            _audit.emit(
+                event_type="api.auth_failure",
+                actor="api",
+                source_ip=request.client.host if request.client else None,
+                detail={
+                    "path": str(request.url.path),
+                    "method": request.method,
+                    "status_code": response.status_code,
+                },
+            )
+        return response
+
+
+app.add_middleware(AuditMiddleware)
 
 # Include routers
 app.include_router(

--- a/src/api/routers/files.py
+++ b/src/api/routers/files.py
@@ -32,6 +32,7 @@ from src.services.compare_job_store import CompareJobStore
 from src.services.retry_policy import execute_with_retries
 from src.services.metrics_registry import METRICS
 from src.utils.structured_logger import get_structured_logger, log_event
+from src.utils.audit_logger import get_audit_logger, file_sha256
 
 router = APIRouter()
 
@@ -62,6 +63,7 @@ MAPPINGS_DIR = Path("config/mappings")
 # Durable registry for async compare jobs.
 _COMPARE_JOB_STORE = CompareJobStore()
 _LOGGER = get_structured_logger("cm3.files")
+_AUDIT = get_audit_logger()
 
 
 @router.post("/detect", response_model=FileDetectionResult)
@@ -73,6 +75,17 @@ async def detect_format(file: UploadFile = File(...)):
     upload_path = UPLOADS_DIR / file.filename
     with open(upload_path, "wb") as buffer:
         shutil.copyfileobj(file.file, buffer)
+
+    _AUDIT.emit(
+        event_type="file.upload",
+        actor="api",
+        detail={
+            "filename": file.filename,
+            "size_bytes": upload_path.stat().st_size,
+            "endpoint": "/api/v1/files/detect",
+            "input_file_hash": file_sha256(upload_path),
+        },
+    )
 
     try:
         detector = FormatDetector()
@@ -156,8 +169,20 @@ async def validate_file(
     with open(upload_path, "wb") as buffer:
         shutil.copyfileobj(file.file, buffer)
 
+    mapping_file = MAPPINGS_DIR / f"{mapping_id}.json"
+    _AUDIT.emit(
+        event_type="api.test_run",
+        actor="api",
+        detail={
+            "endpoint": "/api/v1/files/validate",
+            "mapping_id": mapping_id,
+            "filename": file.filename,
+            "input_file_hash": file_sha256(upload_path),
+            "mapping_file_hash": file_sha256(mapping_file),
+        },
+    )
+
     try:
-        mapping_file = MAPPINGS_DIR / f"{mapping_id}.json"
         if not mapping_file.exists():
             raise HTTPException(status_code=404, detail=f"Mapping '{mapping_id}' not found")
 

--- a/src/api/routers/rules.py
+++ b/src/api/routers/rules.py
@@ -12,6 +12,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from src.config.ba_rules_template_converter import BARulesTemplateConverter
 from src.config.rules_template_converter import RulesTemplateConverter
+from src.utils.audit_logger import get_audit_logger, file_sha256
+
+_AUDIT = get_audit_logger()
 
 router = APIRouter()
 
@@ -50,6 +53,18 @@ async def upload_rules_template(
     upload_path = UPLOADS_DIR / file.filename
     with open(upload_path, "wb") as buf:
         shutil.copyfileobj(file.file, buf)
+
+    _AUDIT.emit(
+        event_type="file.upload",
+        actor="api",
+        detail={
+            "filename": file.filename,
+            "size_bytes": upload_path.stat().st_size,
+            "endpoint": "/api/v1/rules/upload",
+            "rules_type": rules_type,
+            "input_file_hash": file_sha256(upload_path),
+        },
+    )
 
     try:
         if rules_type == "technical":

--- a/src/commands/run_tests_command.py
+++ b/src/commands/run_tests_command.py
@@ -15,7 +15,10 @@ import yaml
 
 from src.contracts.test_suite import TestConfig, TestSuiteConfig
 from src.reports.renderers.suite_renderer import SuiteReporter
+from src.utils.audit_logger import get_audit_logger, file_sha256
 from src.utils.params import resolve_params
+
+_AUDIT = get_audit_logger()
 
 try:
     from src.services.run_history_service import write_run_to_db as _db_write_run
@@ -519,13 +522,37 @@ def run_suite_from_path(
         **params,
     }
 
+
     results: list[dict[str, Any]] = []
+    run_input_hashes: list[dict[str, Any]] = []
+
     for test in suite.tests:
         resolved_file = resolve_params(test.file or "", merged_params)
+        resolved_mapping = resolve_params(test.mapping or "", merged_params)
+        run_input_hashes.append(
+            {
+                "test": test.name,
+                "input_file": resolved_file,
+                "input_file_hash": file_sha256(resolved_file),
+                "mapping_file": resolved_mapping,
+                "mapping_file_hash": file_sha256(resolved_mapping),
+            }
+        )
         result = _run_single_test(
             test, resolved_file, output_dir, run_id=run_id, params=merged_params
         )
         results.append(result)
+
+    _AUDIT.emit(
+        event_type="cli.test_run.started",
+        actor="cli",
+        detail={
+            "suite": suite.name,
+            "env": env or suite.environment,
+            "run_id": run_id,
+            "inputs": run_input_hashes,
+        },
+    )
 
     safe_suite_name = re.sub(r"[^\w\-]", "_", suite.name)
     suite_report_path = str(
@@ -572,6 +599,25 @@ def run_suite_from_path(
         env=env or suite.environment,
         archive_path=archive_path_str,
         timestamp=run_timestamp,
+    )
+
+    overall_status_label = _compute_overall_status(results)
+    passed = sum(1 for r in results if r.get("status") == "PASS")
+    failed = len(results) - passed
+    _AUDIT.emit(
+        event_type="cli.test_run.completed",
+        actor="cli",
+        detail={
+            "suite": suite.name,
+            "env": env or suite.environment,
+            "run_id": run_id,
+            "passed": passed,
+            "failed": failed,
+            "status": overall_status_label,
+            "report_path": suite_report_path,
+            "report_hash": file_sha256(suite_report_path),
+            "inputs": run_input_hashes,
+        },
     )
 
     return results

--- a/src/utils/audit_logger.py
+++ b/src/utils/audit_logger.py
@@ -1,0 +1,175 @@
+"""Structured audit logging with JSON events and SHA-256 integrity hashing.
+
+Emits one-JSON-object-per-line audit events to a configurable log file.
+Designed for ingestion by Splunk, ELK, or any JSON-capable log aggregator.
+
+Configuration:
+    Set ``AUDIT_LOG_PATH`` environment variable to override the default
+    log file location (``logs/audit.log``).
+
+Example event::
+
+    {
+        "event_id": "a1b2c3...",
+        "timestamp": "2026-03-14T12:00:00+00:00",
+        "event_type": "cli.test_run.started",
+        "actor": "cli",
+        "source_ip": null,
+        "detail": {"suite": "smoke", "env": "dev"},
+        "event_hash": "e3b0c44..."
+    }
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def file_sha256(path: str | Path) -> str | None:
+    """Return SHA-256 hex for a file path.
+
+    Args:
+        path: File path to hash.
+
+    Returns:
+        Hex digest string when the file exists and is readable; otherwise ``None``.
+    """
+    file_path = Path(path)
+    if not file_path.exists() or not file_path.is_file():
+        return None
+
+    hasher = hashlib.sha256()
+    with open(file_path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+# Default audit log path — overridable via AUDIT_LOG_PATH env var.
+AUDIT_LOG_PATH: str = os.getenv("AUDIT_LOG_PATH", "logs/audit.log")
+
+
+def sha256_hex(data: bytes | str) -> str:
+    """Return the SHA-256 hex digest of *data*.
+
+    Args:
+        data: Raw bytes or a UTF-8 string to hash.
+
+    Returns:
+        Lowercase hex string (64 characters).
+    """
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass
+class AuditEvent:
+    """Immutable audit event with automatic ID, timestamp, and integrity hash.
+
+    Args:
+        event_type: Dot-namespaced event category
+            (e.g. ``cli.test_run.started``, ``api.auth_failure``).
+        actor: Originator — ``cli``, ``api``, or ``system``.
+        detail: Arbitrary key/value payload for the event.
+        source_ip: Client IP address (API events only).
+    """
+
+    event_type: str
+    actor: str
+    detail: dict[str, Any] | None = None
+    source_ip: str | None = None
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the event to a dictionary with an ``event_hash`` field.
+
+        Returns:
+            Dict containing all event fields plus a SHA-256 ``event_hash``
+            computed over the canonical JSON representation.
+        """
+        payload: dict[str, Any] = {
+            "event_id": self.event_id,
+            "timestamp": self.timestamp,
+            "event_type": self.event_type,
+            "actor": self.actor,
+            "source_ip": self.source_ip,
+            "detail": self.detail,
+        }
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        payload["event_hash"] = sha256_hex(canonical)
+        return payload
+
+    def to_json(self) -> str:
+        """Serialize the event to a single-line JSON string.
+
+        Returns:
+            JSON string suitable for appending to an audit log file.
+        """
+        return json.dumps(self.to_dict(), separators=(",", ":"))
+
+
+class AuditLogger:
+    """Append-only JSON audit logger backed by a file.
+
+    Each call to :meth:`emit` writes one JSON object per line.  Parent
+    directories are created on first write if they do not exist.
+
+    Args:
+        log_path: Filesystem path for the audit log file.
+    """
+
+    def __init__(self, log_path: str | None = None) -> None:
+        self.log_path: str = log_path or os.getenv("AUDIT_LOG_PATH", AUDIT_LOG_PATH)
+
+    def emit(
+        self,
+        event_type: str,
+        actor: str,
+        detail: dict[str, Any] | None = None,
+        source_ip: str | None = None,
+    ) -> AuditEvent:
+        """Create and persist an audit event.
+
+        Args:
+            event_type: Dot-namespaced event category.
+            actor: Originator — ``cli``, ``api``, or ``system``.
+            detail: Arbitrary key/value payload.
+            source_ip: Client IP address (API events).
+
+        Returns:
+            The :class:`AuditEvent` that was written.
+        """
+        event = AuditEvent(
+            event_type=event_type,
+            actor=actor,
+            detail=detail,
+            source_ip=source_ip,
+        )
+        path = Path(self.log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(event.to_json() + "\n")
+        return event
+
+
+def get_audit_logger() -> AuditLogger:
+    """Return an :class:`AuditLogger` configured from the environment.
+
+    The log path is read from the ``AUDIT_LOG_PATH`` environment variable,
+    falling back to the module-level :data:`AUDIT_LOG_PATH` default.
+
+    Returns:
+        A ready-to-use :class:`AuditLogger` instance.
+    """
+    return AuditLogger(log_path=os.getenv("AUDIT_LOG_PATH", AUDIT_LOG_PATH))

--- a/src/utils/cleanup.py
+++ b/src/utils/cleanup.py
@@ -4,7 +4,10 @@ import time
 import logging
 from pathlib import Path
 
+from src.utils.audit_logger import get_audit_logger
+
 logger = logging.getLogger(__name__)
+_AUDIT = get_audit_logger()
 
 
 def cleanup_old_files(directory: "str | Path", max_age_hours: float = 24) -> dict:
@@ -30,7 +33,17 @@ def cleanup_old_files(directory: "str | Path", max_age_hours: float = 24) -> dic
     directory = Path(directory)
     if not directory.exists():
         logger.debug("cleanup_old_files: directory does not exist: %s", directory)
-        return result
+        _AUDIT.emit(
+        event_type="file.cleanup",
+        actor="system",
+        detail={
+            "directory": str(directory),
+            "deleted_count": result["deleted_count"],
+            "deleted_bytes": result["deleted_bytes"],
+            "error_count": len(result["errors"]),
+        },
+    )
+    return result
 
     cutoff = time.time() - max_age_hours * 3600
 
@@ -40,7 +53,17 @@ def cleanup_old_files(directory: "str | Path", max_age_hours: float = 24) -> dic
         msg = f"Cannot list directory {directory}: {exc}"
         logger.error(msg)
         result["errors"].append(msg)
-        return result
+        _AUDIT.emit(
+        event_type="file.cleanup",
+        actor="system",
+        detail={
+            "directory": str(directory),
+            "deleted_count": result["deleted_count"],
+            "deleted_bytes": result["deleted_bytes"],
+            "error_count": len(result["errors"]),
+        },
+    )
+    return result
 
     for entry in entries:
         # Never attempt to delete subdirectories.
@@ -75,4 +98,14 @@ def cleanup_old_files(directory: "str | Path", max_age_hours: float = 24) -> dic
             logger.error(msg)
             result["errors"].append(msg)
 
+    _AUDIT.emit(
+        event_type="file.cleanup",
+        actor="system",
+        detail={
+            "directory": str(directory),
+            "deleted_count": result["deleted_count"],
+            "deleted_bytes": result["deleted_bytes"],
+            "error_count": len(result["errors"]),
+        },
+    )
     return result

--- a/tests/unit/test_audit_logger.py
+++ b/tests/unit/test_audit_logger.py
@@ -1,0 +1,273 @@
+"""Unit tests for src.utils.audit_logger."""
+
+import hashlib
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.utils.audit_logger import (
+    AuditEvent,
+    AuditLogger,
+    sha256_hex,
+    get_audit_logger,
+    AUDIT_LOG_PATH,
+    file_sha256,
+)
+
+
+# ---------------------------------------------------------------------------
+# sha256_hex helper
+# ---------------------------------------------------------------------------
+
+class TestSha256Hex:
+    """Tests for the sha256_hex hashing helper."""
+
+    def test_bytes_input(self):
+        data = b"hello world"
+        expected = hashlib.sha256(data).hexdigest()
+        assert sha256_hex(data) == expected
+
+    def test_string_input(self):
+        data = "hello world"
+        expected = hashlib.sha256(data.encode("utf-8")).hexdigest()
+        assert sha256_hex(data) == expected
+
+    def test_empty_input(self):
+        assert sha256_hex(b"") == hashlib.sha256(b"").hexdigest()
+
+    def test_deterministic(self):
+        assert sha256_hex("abc") == sha256_hex("abc")
+
+    def test_different_inputs_differ(self):
+        assert sha256_hex("a") != sha256_hex("b")
+
+
+class TestFileSha256:
+    """Tests for hashing files by path."""
+
+    def test_returns_hash_for_existing_file(self, tmp_path):
+        target = tmp_path / "sample.txt"
+        target.write_text("abc123", encoding="utf-8")
+        assert file_sha256(target) == hashlib.sha256(b"abc123").hexdigest()
+
+    def test_returns_none_for_missing_file(self, tmp_path):
+        assert file_sha256(tmp_path / "missing.txt") is None
+
+
+# ---------------------------------------------------------------------------
+# AuditEvent dataclass
+# ---------------------------------------------------------------------------
+
+class TestAuditEvent:
+    """Tests for AuditEvent construction and serialization."""
+
+    def test_required_fields(self):
+        evt = AuditEvent(event_type="test.started", actor="cli")
+        assert evt.event_type == "test.started"
+        assert evt.actor == "cli"
+        assert evt.event_id  # auto-generated UUID
+        assert evt.timestamp  # auto-generated ISO timestamp
+
+    def test_optional_detail(self):
+        evt = AuditEvent(event_type="x", actor="api", detail={"key": "val"})
+        assert evt.detail == {"key": "val"}
+
+    def test_to_dict_contains_all_fields(self):
+        evt = AuditEvent(
+            event_type="file.upload",
+            actor="api",
+            detail={"filename": "test.csv"},
+            source_ip="10.0.0.1",
+        )
+        d = evt.to_dict()
+        assert d["event_type"] == "file.upload"
+        assert d["actor"] == "api"
+        assert d["source_ip"] == "10.0.0.1"
+        assert d["detail"]["filename"] == "test.csv"
+        assert "event_id" in d
+        assert "timestamp" in d
+
+    def test_to_json_is_valid(self):
+        evt = AuditEvent(event_type="x", actor="cli")
+        parsed = json.loads(evt.to_json())
+        assert parsed["event_type"] == "x"
+
+    def test_hash_field_populated(self):
+        evt = AuditEvent(event_type="x", actor="cli", detail={"a": 1})
+        d = evt.to_dict()
+        assert "event_hash" in d
+        # Hash should be SHA-256 of the canonical JSON payload
+        assert len(d["event_hash"]) == 64
+
+    def test_hash_deterministic(self):
+        kwargs = dict(event_type="x", actor="cli", detail={"a": 1})
+        e1 = AuditEvent(**kwargs)
+        e2 = AuditEvent(**kwargs)
+        # Different event_id / timestamp → different hash, that's fine
+        # But same event should produce consistent hash per call
+        d = e1.to_dict()
+        assert d["event_hash"] == e1.to_dict()["event_hash"]
+
+
+# ---------------------------------------------------------------------------
+# AuditLogger
+# ---------------------------------------------------------------------------
+
+class TestAuditLogger:
+    """Tests for the AuditLogger wrapper."""
+
+    def test_emit_writes_json_line(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+
+        al.emit(event_type="cli.test_run.started", actor="cli", detail={"suite": "smoke"})
+
+        lines = log_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["event_type"] == "cli.test_run.started"
+        assert parsed["actor"] == "cli"
+
+    def test_emit_multiple_events(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+
+        al.emit(event_type="a", actor="cli")
+        al.emit(event_type="b", actor="api")
+
+        lines = log_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+
+    def test_emit_creates_parent_dirs(self, tmp_path):
+        log_path = tmp_path / "nested" / "deep" / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(event_type="x", actor="cli")
+        assert log_path.exists()
+
+    def test_emit_returns_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        evt = al.emit(event_type="y", actor="api", source_ip="1.2.3.4")
+        assert isinstance(evt, AuditEvent)
+        assert evt.source_ip == "1.2.3.4"
+
+    def test_default_log_path_from_env(self, tmp_path, monkeypatch):
+        custom = str(tmp_path / "custom_audit.log")
+        monkeypatch.setenv("AUDIT_LOG_PATH", custom)
+        al = get_audit_logger()
+        al.emit(event_type="z", actor="cli")
+        assert Path(custom).exists()
+
+    def test_cli_test_run_started_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(
+            event_type="cli.test_run.started",
+            actor="cli",
+            detail={"suite": "regression", "env": "dev"},
+        )
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed["event_type"] == "cli.test_run.started"
+        assert parsed["detail"]["suite"] == "regression"
+
+    def test_cli_test_run_completed_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(
+            event_type="cli.test_run.completed",
+            actor="cli",
+            detail={"suite": "smoke", "passed": 5, "failed": 1, "status": "FAILED"},
+        )
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed["event_type"] == "cli.test_run.completed"
+        assert parsed["detail"]["status"] == "FAILED"
+
+    def test_api_test_run_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(
+            event_type="api.test_run",
+            actor="api",
+            source_ip="192.168.1.10",
+            detail={"endpoint": "/api/v1/files/validate", "mapping_id": "p327"},
+        )
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed["source_ip"] == "192.168.1.10"
+
+    def test_api_auth_failure_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(
+            event_type="api.auth_failure",
+            actor="api",
+            source_ip="10.0.0.99",
+            detail={"reason": "invalid_token", "path": "/api/v1/files/validate"},
+        )
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed["event_type"] == "api.auth_failure"
+        assert parsed["source_ip"] == "10.0.0.99"
+
+    def test_file_upload_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(
+            event_type="file.upload",
+            actor="api",
+            detail={
+                "filename": "data.csv",
+                "size_bytes": 1024,
+                "content_hash": sha256_hex(b"file content"),
+            },
+        )
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed["event_type"] == "file.upload"
+        assert parsed["detail"]["size_bytes"] == 1024
+
+    def test_file_cleanup_event(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        al.emit(
+            event_type="file.cleanup",
+            actor="system",
+            detail={"deleted_count": 3, "deleted_bytes": 8192},
+        )
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed["event_type"] == "file.cleanup"
+        assert parsed["detail"]["deleted_count"] == 3
+
+    def test_source_ip_defaults_to_none(self, tmp_path):
+        log_path = tmp_path / "audit.log"
+        al = AuditLogger(log_path=str(log_path))
+        evt = al.emit(event_type="x", actor="cli")
+        assert evt.source_ip is None
+        parsed = json.loads(log_path.read_text().strip())
+        assert parsed.get("source_ip") is None
+
+
+# ---------------------------------------------------------------------------
+# get_audit_logger singleton
+# ---------------------------------------------------------------------------
+
+class TestGetAuditLogger:
+    """Tests for the module-level get_audit_logger factory."""
+
+    def test_returns_audit_logger_instance(self):
+        al = get_audit_logger()
+        assert isinstance(al, AuditLogger)
+
+    def test_uses_default_path_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("AUDIT_LOG_PATH", raising=False)
+        al = get_audit_logger()
+        assert al.log_path == AUDIT_LOG_PATH
+
+    def test_uses_env_override(self, tmp_path, monkeypatch):
+        custom = str(tmp_path / "override.log")
+        monkeypatch.setenv("AUDIT_LOG_PATH", custom)
+        al = get_audit_logger()
+        assert al.log_path == custom


### PR DESCRIPTION
Fixes #21

## Summary
- Added `src/utils/audit_logger.py` for structured JSON audit events with SHA-256 integrity hashing
- Added API middleware auth-failure audit logging with source IP
- Added audit events for uploads, cleanup, API test runs, and CLI suite start/completion
- Added file/config/report hash capture in audit payloads where available
- Added `docs/splunk-setup.md` and linked docs updates

## Validation
- `pytest tests/unit/ --ignore=tests/unit/test_contracts_pipeline.py --ignore=tests/unit/test_pipeline_runner.py --ignore=tests/unit/test_workflow_wrapper_parity.py --cov=src --cov-report=term-missing -q` **blocked** (missing `psutil`, `oracledb` in local env)
- `make html` under `docs/sphinx` **blocked** (missing `sphinx-build`)

## Manual setup checklist (required to complete full gate)
- [ ] Install test/runtime deps in venv: `psutil`, `oracledb`, and Sphinx toolchain
- [ ] Re-run full unit suite with coverage >=80%
- [ ] Re-run `cd docs/sphinx && make html`

This PR is intentionally marked draft until environment dependencies are provisioned and full CI-equivalent checks are completed.