### PR TITLE
feat: add infer-mapping command for draft universal mappings

### DIFF
--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -50,3 +50,5 @@ This is the **single source of truth** for docs navigation.
 
 ## Redundancy Policy
 When two docs overlap, keep details in the canonical doc above and reduce other files to short pointers.
+
+- `infer-mapping` CLI usage: see `USAGE_GUIDE.md`.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1309,3 +1309,14 @@ python -m src.main submit-task \
 ```
 
 If input is invalid, CLI exits non-zero and prints machine-readable errors when `--machine-errors` is set.
+
+
+## infer-mapping
+
+Generate a draft mapping from a sample file:
+
+```bash
+cm3-batch infer-mapping --file sample.txt --format fixed_width --output config/mappings/sample_draft.json
+```
+
+Use `--format pipe_delimited` for delimited files.

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -216,3 +216,8 @@ Reporting & Utilities
 .. automodule:: src.utils.archive
    :members:
    :undoc-members:
+
+.. automodule:: src.services.mapping_inference_service
+   :members:
+   :undoc-members:
+

--- a/src/commands/infer_mapping_command.py
+++ b/src/commands/infer_mapping_command.py
@@ -1,0 +1,11 @@
+"""CLI command implementation for infer-mapping."""
+
+from __future__ import annotations
+
+from src.services.mapping_inference_service import InferenceOptions, infer_mapping_from_sample, write_mapping_json
+
+
+def run_infer_mapping_command(file: str, format: str, output: str) -> str:
+    """Infer mapping from sample file and write JSON output."""
+    mapping = infer_mapping_from_sample(file, InferenceOptions(format=format))
+    return write_mapping_json(mapping, output)

--- a/src/main.py
+++ b/src/main.py
@@ -891,3 +891,15 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
+@cli.command('infer-mapping')
+@click.option('--file', 'file_path', required=True, type=click.Path(exists=True), help='Sample file path')
+@click.option('--format', 'file_format', default='fixed_width', type=click.Choice(['fixed_width', 'pipe_delimited']), show_default=True)
+@click.option('--output', 'output_path', required=True, type=click.Path(), help='Output mapping JSON path')
+def infer_mapping_cli(file_path: str, file_format: str, output_path: str):
+    """Infer a draft mapping from a sample file."""
+    from src.commands.infer_mapping_command import run_infer_mapping_command
+
+    result = run_infer_mapping_command(file=file_path, format=file_format, output=output_path)
+    click.echo(f"✅ Inferred mapping written: {result}")

--- a/src/services/mapping_inference_service.py
+++ b/src/services/mapping_inference_service.py
@@ -1,0 +1,86 @@
+"""Generate draft mapping contracts from sample files."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class InferenceOptions:
+    """Options controlling mapping inference."""
+
+    format: str = "fixed_width"
+    delimiter: str = "|"
+    sample_lines: int = 10
+
+
+def _infer_data_type(value: str) -> tuple[str, str | None]:
+    value = value.strip()
+    if value.isdigit() and len(value) == 8 and value.startswith(("19", "20")):
+        return "Date", "CCYYMMDD"
+    if value.isdigit():
+        return "Numeric", None
+    return "String", None
+
+
+def infer_mapping_from_sample(file_path: str, opts: InferenceOptions) -> dict[str, Any]:
+    """Infer a universal mapping draft from a sample input file."""
+    lines = [l.rstrip("\n") for l in Path(file_path).read_text(encoding="utf-8").splitlines()[: opts.sample_lines] if l.strip()]
+    fields: list[dict[str, Any]] = []
+
+    if opts.format == "pipe_delimited":
+        max_cols = max((len(line.split(opts.delimiter)) for line in lines), default=0)
+        for idx in range(max_cols):
+            sample_val = ""
+            for line in lines:
+                parts = line.split(opts.delimiter)
+                if idx < len(parts):
+                    sample_val = parts[idx]
+                    break
+            dtype, fmt = _infer_data_type(sample_val)
+            fld = {
+                "name": f"FIELD_{idx+1:03d}",
+                "position": idx + 1,
+                "length": max((len(line.split(opts.delimiter)[idx]) for line in lines if idx < len(line.split(opts.delimiter))), default=0),
+                "data_type": dtype,
+                "_inferred": True,
+            }
+            if fmt:
+                fld["format"] = fmt
+            fields.append(fld)
+    else:
+        width = max((len(line) for line in lines), default=0)
+        pos = 1
+        for idx in range(0, width, 8):
+            seg = [line[idx:idx+8] for line in lines]
+            sample_val = next((s for s in seg if s.strip()), "")
+            dtype, fmt = _infer_data_type(sample_val)
+            fld = {
+                "name": f"FIELD_{(idx//8)+1:03d}",
+                "position": pos,
+                "length": 8,
+                "data_type": dtype,
+                "_inferred": True,
+            }
+            if fmt:
+                fld["format"] = fmt
+            fields.append(fld)
+            pos += 8
+
+    return {
+        "mapping_name": "inferred_draft",
+        "_note": "DRAFT — review and rename fields before use",
+        "source": {"format": opts.format},
+        "fields": fields,
+    }
+
+
+def write_mapping_json(mapping: dict[str, Any], output_path: str) -> str:
+    """Persist inferred mapping JSON to disk."""
+    target = Path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(mapping, indent=2), encoding="utf-8")
+    return str(target)

--- a/tests/unit/test_mapping_inference_service.py
+++ b/tests/unit/test_mapping_inference_service.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from src.services.mapping_inference_service import InferenceOptions, infer_mapping_from_sample, write_mapping_json
+
+
+def test_infers_pipe_delimited(tmp_path):
+    sample = tmp_path / 'sample.txt'
+    sample.write_text('123|20260301|ABC\n456|20251231|DEF\n', encoding='utf-8')
+    mapping = infer_mapping_from_sample(str(sample), InferenceOptions(format='pipe_delimited'))
+    assert mapping['source']['format'] == 'pipe_delimited'
+    assert mapping['fields'][0]['data_type'] == 'Numeric'
+    assert mapping['fields'][1]['data_type'] == 'Date'
+    assert all(f['_inferred'] for f in mapping['fields'])
+
+
+def test_writes_json(tmp_path):
+    data = {'mapping_name': 'x', 'fields': []}
+    out = tmp_path / 'out.json'
+    write_mapping_json(data, str(out))
+    assert json.loads(out.read_text())['mapping_name'] == 'x'


### PR DESCRIPTION
Fixes #27

## Summary
- Added `infer-mapping` CLI command wiring in `src/main.py`
- Added `src/services/mapping_inference_service.py` for draft inference and JSON write-out
- Added `src/commands/infer_mapping_command.py` command wrapper
- Added unit tests for pipe-delimited inference and JSON output
- Updated docs (`USAGE_GUIDE`, `DOCUMENTATION_INDEX`, Sphinx modules)

## Current gaps / TODOs before merge
- [ ] Replace simplified fixed-width 8-char chunk heuristic with parser-driven boundary inference (`FixedWidthParser.analyze_line_lengths()` + variability flags)
- [ ] Add companion Excel output (`--output-excel`) with requested columns
- [ ] Expand format auto-detection integration (`FormatDetector`)

## Validation status
- Full test/coverage and docs build are currently blocked in this environment due missing CI-equivalent dependencies/tooling in this worktree.

This is a draft PR for iterative completion and environment-backed validation.