### PR TITLE
feat: add notification service and configurable Oracle DSN (#35, #48)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
 # Oracle Database Configuration
 # DSN format: hostname:port/service_name  (e.g. localhost:1521/FREEPDB1)
 # NOTE: Oracle Instant Client is NOT required — uses oracledb thin mode.
-ORACLE_USER=your_username
-ORACLE_PASSWORD=your_password
-ORACLE_DSN=hostname:1521/service_name
+ORACLE_USER=CM3INT
+ORACLE_PASSWORD=your_password_here
+ORACLE_DSN=localhost:1521/FREEPDB1
+# Schema prefix for SQL table references (defaults to ORACLE_USER if unset)
+ORACLE_SCHEMA=CM3INT
 
 # Application Configuration
 ENVIRONMENT=dev

--- a/config/suites/example_daily.yaml
+++ b/config/suites/example_daily.yaml
@@ -14,3 +14,19 @@ steps:
     rules: null
 thresholds:
   max_errors: 0
+
+# --- Notifications (uncomment to enable) ---
+# notifications:
+#   on_failure:
+#     - type: email
+#       to:
+#         - qa-team@example.com
+#         - dev-lead@example.com
+#     - type: teams
+#       url: https://outlook.office.com/webhook/YOUR-TEAMS-WEBHOOK-URL
+#     - type: slack
+#       url: https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
+#   on_success:
+#     - type: email
+#       to:
+#         - qa-team@example.com

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1165,15 +1165,14 @@ python -m json.tool config/mappings/my_mapping.json
 ### Oracle Connection Issues
 
 ```bash
-# Test Oracle client
-python -c "import cx_Oracle; print(cx_Oracle.clientversion())"
+# Verify oracledb is installed (thin mode — no Instant Client needed)
+python -c "import oracledb; print(oracledb.__version__)"
 
 # Check environment variables
-echo $ORACLE_HOME
-echo $LD_LIBRARY_PATH
+echo $ORACLE_USER $ORACLE_DSN
 
-# Test connection
-python -c "import cx_Oracle; conn = cx_Oracle.connect('user/pass@dsn'); print('Connected')"
+# Test connection using centralised config
+python -c "from src.config.db_config import get_connection; c = get_connection(); print('Connected'); c.close()"
 ```
 
 ### File Parsing Errors
@@ -1196,10 +1195,11 @@ python src/config/universal_mapping_parser.py config/mappings/my_mapping.json
 Create a `.env` file in the project root:
 
 ```bash
-# Oracle Database
-ORACLE_USER=your_username
-ORACLE_PASSWORD=your_password
-ORACLE_DSN=hostname:port/service_name
+# Oracle Database Connection
+ORACLE_USER=CM3INT                       # Default: CM3INT
+ORACLE_PASSWORD=your_password_here       # Required for any DB operation
+ORACLE_DSN=localhost:1521/FREEPDB1       # Default: localhost:1521/FREEPDB1
+ORACLE_SCHEMA=CM3INT                     # Default: value of ORACLE_USER
 
 # API Configuration
 API_PORT=8000
@@ -1209,6 +1209,29 @@ API_WORKERS=4
 # Logging
 LOG_LEVEL=INFO
 LOG_DIR=logs
+```
+
+### Database Configuration
+
+All Oracle connection parameters are read from environment variables in one
+place (`src/config/db_config.py`).  No Oracle Instant Client is required --
+connections use **oracledb thin mode**.
+
+| Variable | Default | Description |
+|---|---|---|
+| `ORACLE_USER` | `CM3INT` | Database username |
+| `ORACLE_PASSWORD` | *(none)* | Database password -- **required** before any DB call |
+| `ORACLE_DSN` | `localhost:1521/FREEPDB1` | Easy Connect string (`host:port/service`) |
+| `ORACLE_SCHEMA` | value of `ORACLE_USER` | Schema prefix for SQL table references (e.g. `CM3INT.CM3_RUN_HISTORY`) |
+
+If `ORACLE_PASSWORD` is not set and a command attempts a database connection,
+it will fail immediately with a clear error message rather than hanging on a
+network timeout.
+
+**Quick connection test:**
+
+```bash
+python -c "from src.config.db_config import get_connection; c = get_connection(); print('Connected'); c.close()"
 ```
 
 ---
@@ -1348,6 +1371,51 @@ thresholds:
 | `file_pattern` | yes | File path or glob pattern passed to the validate service |
 | `mapping` | no | Path to mapping JSON config |
 | `rules` | no | Path to rules config JSON |
+
+### Notifications
+
+Suites can optionally send notifications when they complete.  Add a
+`notifications` block to the suite YAML with `on_failure` and/or
+`on_success` target lists.
+
+**Supported channels:**
+
+| Type | Required fields | Description |
+|------|----------------|-------------|
+| `email` | `to` (list of addresses) | Sends plain-text email via SMTP |
+| `teams` | `url` (webhook URL) | Posts a MessageCard to Microsoft Teams |
+| `slack` | `url` (webhook URL) | Posts a message to a Slack channel |
+
+**Example configuration:**
+
+```yaml
+notifications:
+  on_failure:
+    - type: email
+      to:
+        - qa-team@example.com
+        - dev-lead@example.com
+    - type: teams
+      url: https://outlook.office.com/webhook/YOUR-TEAMS-WEBHOOK-URL
+    - type: slack
+      url: https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK
+  on_success:
+    - type: email
+      to:
+        - qa-team@example.com
+```
+
+**Email environment variables:**
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SMTP_HOST` | Yes | — | SMTP server hostname |
+| `SMTP_PORT` | No | `587` | SMTP server port |
+| `SMTP_FROM` | Yes | — | Sender email address |
+| `SMTP_USER` | No | — | SMTP auth username |
+| `SMTP_PASSWORD` | No | — | SMTP auth password |
+
+Notification failures are logged as warnings but never crash the suite run.
 
 ### CLI commands
 

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -195,6 +195,10 @@ Services
    :members:
    :undoc-members:
 
+.. automodule:: src.services.notification_service
+   :members:
+   :undoc-members:
+
 Contracts & Adapters
 --------------------
 

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,6 +1,7 @@
 """Configuration management."""
 
 from .loader import ConfigLoader
+from .db_config import DbConfig, get_db_config, get_connection
 from .mapping_parser import MappingParser, MappingProcessor, MappingDocument, ColumnMapping
 from .models import (
     FieldConfig,
@@ -13,6 +14,10 @@ from .models import (
 
 __all__ = [
     "ConfigLoader",
+    # Database configuration (issue #48)
+    "DbConfig",
+    "get_db_config",
+    "get_connection",
     "MappingParser",
     "MappingProcessor",
     "MappingDocument",

--- a/src/config/db_config.py
+++ b/src/config/db_config.py
@@ -1,0 +1,105 @@
+"""Centralised Oracle database configuration.
+
+Reads connection parameters from environment variables with sensible defaults
+for local development.  All database code should use :func:`get_db_config` or
+:func:`get_connection` instead of reading env vars directly.
+
+Environment variables
+---------------------
+``ORACLE_USER``
+    Database username.  Default: ``CM3INT``.
+``ORACLE_PASSWORD``
+    Database password.  **No default** -- must be set before connecting.
+``ORACLE_DSN``
+    Oracle Easy Connect string.  Default: ``localhost:1521/FREEPDB1``.
+``ORACLE_SCHEMA``
+    Schema prefix used in SQL statements (e.g. ``CM3INT.TABLE``).
+    Default: value of ``ORACLE_USER`` (or ``CM3INT`` if unset).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+import oracledb
+
+
+_DEFAULT_USER = "CM3INT"
+_DEFAULT_DSN = "localhost:1521/FREEPDB1"
+
+
+@dataclass(frozen=True)
+class DbConfig:
+    """Immutable container for Oracle connection parameters.
+
+    Attributes:
+        user: Database username.
+        password: Database password (may be empty when only reading config).
+        dsn: Oracle Easy Connect string (``host:port/service``).
+        schema: Schema qualifier for SQL table references.
+    """
+
+    user: str
+    password: str
+    dsn: str
+    schema: str
+
+
+def get_db_config() -> DbConfig:
+    """Build a :class:`DbConfig` from environment variables.
+
+    Falls back to sensible defaults for local development when variables are
+    not set.  ``ORACLE_SCHEMA`` defaults to the resolved ``ORACLE_USER``.
+
+    Returns:
+        Populated :class:`DbConfig` instance.
+
+    Example::
+
+        cfg = get_db_config()
+        print(cfg.user, cfg.dsn)
+    """
+    user = os.getenv("ORACLE_USER", _DEFAULT_USER)
+    password = os.getenv("ORACLE_PASSWORD", "")
+    dsn = os.getenv("ORACLE_DSN", _DEFAULT_DSN)
+    schema = os.getenv("ORACLE_SCHEMA", user)
+    return DbConfig(user=user, password=password, dsn=dsn, schema=schema)
+
+
+def get_connection(config: DbConfig | None = None) -> oracledb.Connection:
+    """Create an ``oracledb`` thin-mode connection.
+
+    Args:
+        config: Optional pre-built config.  When *None*, :func:`get_db_config`
+            is called to read from environment variables.
+
+    Returns:
+        A live :class:`oracledb.Connection` in thin mode.
+
+    Raises:
+        RuntimeError: If ``ORACLE_PASSWORD`` is empty/unset (fail-fast).
+        ConnectionError: If the underlying ``oracledb.connect`` call fails.
+    """
+    if config is None:
+        config = get_db_config()
+
+    if not config.password:
+        raise RuntimeError(
+            "ORACLE_PASSWORD is not set.  "
+            "Set it in your .env file or export it as an environment variable "
+            "before attempting a database connection."
+        )
+
+    try:
+        return oracledb.connect(
+            user=config.user,
+            password=config.password,
+            dsn=config.dsn,
+        )
+    except oracledb.Error as exc:
+        raise ConnectionError(
+            f"Failed to connect to Oracle (user={config.user!r}, "
+            f"dsn={config.dsn!r}): {exc}"
+        ) from exc

--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -1,15 +1,26 @@
-"""Oracle database connection management."""
+"""Oracle database connection management.
+
+Uses :mod:`src.config.db_config` for centralised configuration so that
+connection parameters (user, password, DSN) are read from environment
+variables in exactly one place.
+"""
 
 import oracledb
 from typing import Optional
-import os
+
+from src.config.db_config import get_db_config, DbConfig
 
 # Backward-compatible alias for older tests/code that patch cx_Oracle.
 cx_Oracle = oracledb
 
 
 class OracleConnection:
-    """Manages Oracle database connections."""
+    """Manages Oracle database connections.
+
+    Prefer :meth:`from_env` to create instances — it reads ``ORACLE_USER``,
+    ``ORACLE_PASSWORD``, and ``ORACLE_DSN`` from the environment via
+    :func:`~src.config.db_config.get_db_config`.
+    """
 
     def __init__(
         self,
@@ -19,12 +30,12 @@ class OracleConnection:
         encoding: str = "UTF-8",
     ):
         """Initialize Oracle connection parameters.
-        
+
         Args:
-            username: Database username
-            password: Database password
-            dsn: Data Source Name (TNS or Easy Connect)
-            encoding: Character encoding (default: UTF-8)
+            username: Database username.
+            password: Database password.
+            dsn: Data Source Name (TNS or Easy Connect).
+            encoding: Character encoding (default: UTF-8).
         """
         self.username = username
         self.password = password
@@ -34,10 +45,20 @@ class OracleConnection:
 
     def connect(self) -> oracledb.Connection:
         """Establish database connection.
-        
+
         Returns:
-            Oracle connection object
+            Oracle connection object.
+
+        Raises:
+            RuntimeError: If password is empty (fail-fast before network call).
+            ConnectionError: If oracledb cannot connect.
         """
+        if not self.password:
+            raise RuntimeError(
+                "ORACLE_PASSWORD is not set.  "
+                "Set it in your .env file or export it as an environment "
+                "variable before attempting a database connection."
+            )
         try:
             self.connection = cx_Oracle.connect(
                 user=self.username,
@@ -69,13 +90,18 @@ class OracleConnection:
     @staticmethod
     def from_env() -> "OracleConnection":
         """Create connection from environment variables.
-        
+
+        Reads ``ORACLE_USER``, ``ORACLE_PASSWORD``, and ``ORACLE_DSN`` via
+        :func:`~src.config.db_config.get_db_config`.  Defaults are applied
+        there (``CM3INT`` / ``localhost:1521/FREEPDB1``).
+
         Returns:
-            OracleConnection instance
+            OracleConnection instance configured from the environment.
         """
+        cfg = get_db_config()
         return OracleConnection(
-            username=os.getenv("ORACLE_USER", ""),
-            password=os.getenv("ORACLE_PASSWORD", ""),
-            dsn=os.getenv("ORACLE_DSN", ""),
+            username=cfg.user,
+            password=cfg.password,
+            dsn=cfg.dsn,
         )
 

--- a/src/database/run_history.py
+++ b/src/database/run_history.py
@@ -1,16 +1,24 @@
-"""Oracle-backed persistence for test suite run history."""
+"""Oracle-backed persistence for test suite run history.
+
+The schema prefix (e.g. ``CM3INT``) is read from the ``ORACLE_SCHEMA``
+environment variable via :func:`~src.config.db_config.get_db_config`.
+"""
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from src.config.db_config import get_db_config
 from .connection import OracleConnection
 
 logger = logging.getLogger(__name__)
 
-_INSERT_RUN = """
-INSERT INTO CM3INT.CM3_RUN_HISTORY
+
+def _sql_insert_run(schema: str) -> str:
+    """Return the INSERT statement for run history, qualified by *schema*."""
+    return f"""
+INSERT INTO {schema}.CM3_RUN_HISTORY
   (RUN_ID, SUITE_NAME, ENVIRONMENT, RUN_TIMESTAMP, STATUS,
    PASS_COUNT, FAIL_COUNT, SKIP_COUNT, TOTAL_COUNT, REPORT_URL, ARCHIVE_PATH)
 VALUES
@@ -18,17 +26,23 @@ VALUES
    :pass_count, :fail_count, :skip_count, :total_count, :report_url, :archive_path)
 """
 
-_INSERT_TEST = """
-INSERT INTO CM3INT.CM3_RUN_TESTS
+
+def _sql_insert_test(schema: str) -> str:
+    """Return the INSERT statement for run tests, qualified by *schema*."""
+    return f"""
+INSERT INTO {schema}.CM3_RUN_TESTS
   (RUN_ID, TEST_NAME, TEST_TYPE, STATUS, ROW_COUNT, ERROR_COUNT, DURATION_SECS, REPORT_PATH)
 VALUES
   (:run_id, :test_name, :test_type, :status, :row_count, :error_count, :duration_secs, :report_path)
 """
 
-_FETCH_HISTORY = """
+
+def _sql_fetch_history(schema: str) -> str:
+    """Return the SELECT statement for recent run history, qualified by *schema*."""
+    return f"""
 SELECT RUN_ID, SUITE_NAME, ENVIRONMENT, RUN_TIMESTAMP, STATUS,
        PASS_COUNT, FAIL_COUNT, SKIP_COUNT, TOTAL_COUNT, REPORT_URL, ARCHIVE_PATH
-FROM CM3INT.CM3_RUN_HISTORY
+FROM {schema}.CM3_RUN_HISTORY
 ORDER BY RUN_TIMESTAMP DESC
 FETCH FIRST :limit ROWS ONLY
 """
@@ -71,7 +85,10 @@ class RunHistoryRepository:
     """Reads and writes suite run history to/from Oracle.
 
     Args:
-        conn: Optional OracleConnection to use. Defaults to OracleConnection.from_env().
+        conn: Optional OracleConnection to use. Defaults to
+            ``OracleConnection.from_env()``.
+        schema: Optional schema override.  Defaults to the ``ORACLE_SCHEMA``
+            environment variable (which itself defaults to ``ORACLE_USER``).
 
     Example::
 
@@ -81,18 +98,23 @@ class RunHistoryRepository:
         history = repo.fetch_history(limit=20)
     """
 
-    def __init__(self, conn: OracleConnection | None = None) -> None:
+    def __init__(
+        self,
+        conn: OracleConnection | None = None,
+        schema: str | None = None,
+    ) -> None:
         self._conn = conn if conn is not None else OracleConnection.from_env()
+        self._schema = schema if schema is not None else get_db_config().schema
 
     def insert_run(self, entry: dict[str, Any]) -> None:
-        """Insert one run summary row into CM3INT.CM3_RUN_HISTORY.
+        """Insert one run summary row into the CM3_RUN_HISTORY table.
 
         Args:
             entry: Dict with keys matching run_history.json entries.
         """
         with self._conn as conn:
             cursor = conn.cursor()
-            cursor.execute(_INSERT_RUN, {
+            cursor.execute(_sql_insert_run(self._schema), {
                 "run_id":        entry["run_id"],
                 "suite_name":    entry["suite_name"],
                 "environment":   entry["environment"],
@@ -108,7 +130,7 @@ class RunHistoryRepository:
             conn.commit()
 
     def insert_tests(self, run_id: str, results: list[dict[str, Any]]) -> None:
-        """Insert one row per test into CM3INT.CM3_RUN_TESTS.
+        """Insert one row per test into the CM3_RUN_TESTS table.
 
         Args:
             run_id: The parent run UUID.
@@ -131,11 +153,11 @@ class RunHistoryRepository:
         ]
         with self._conn as conn:
             cursor = conn.cursor()
-            cursor.executemany(_INSERT_TEST, rows)
+            cursor.executemany(_sql_insert_test(self._schema), rows)
             conn.commit()
 
     def fetch_history(self, limit: int = 20) -> list[dict[str, Any]]:
-        """Return the most recent run summaries from CM3INT.CM3_RUN_HISTORY.
+        """Return the most recent run summaries from the CM3_RUN_HISTORY table.
 
         Args:
             limit: Maximum number of rows to return (default 20).
@@ -146,7 +168,7 @@ class RunHistoryRepository:
         """
         with self._conn as conn:
             cursor = conn.cursor()
-            cursor.execute(_FETCH_HISTORY, {"limit": limit})
+            cursor.execute(_sql_fetch_history(self._schema), {"limit": limit})
             cols = [d[0].lower() for d in cursor.description]
             rows = cursor.fetchall()
 

--- a/src/pipeline/suite_config.py
+++ b/src/pipeline/suite_config.py
@@ -24,6 +24,32 @@ class StepDefinition(BaseModel):
     rules: Optional[str] = None
 
 
+class NotificationTarget(BaseModel):
+    """A single notification destination (email, Teams, or Slack).
+
+    Attributes:
+        type: Channel type — ``"email"``, ``"teams"``, or ``"slack"``.
+        to: List of recipient email addresses (used when type is ``"email"``).
+        url: Incoming webhook URL (used when type is ``"teams"`` or ``"slack"``).
+    """
+
+    type: Literal["email", "teams", "slack"]
+    to: Optional[List[str]] = None
+    url: Optional[str] = None
+
+
+class NotificationsConfig(BaseModel):
+    """Notification routing for suite results.
+
+    Attributes:
+        on_failure: Targets to notify when the suite fails.
+        on_success: Targets to notify when the suite passes.
+    """
+
+    on_failure: List[NotificationTarget] = Field(default_factory=list)
+    on_success: List[NotificationTarget] = Field(default_factory=list)
+
+
 class SuiteDefinition(BaseModel):
     """Top-level model for a named suite of validation steps.
 
@@ -38,9 +64,12 @@ class SuiteDefinition(BaseModel):
         steps: Ordered list of :class:`StepDefinition` objects to execute.
         thresholds: Optional dict of threshold values (e.g. ``{"max_errors": 5}``).
             Treated as raw metadata — enforcement is handled by the caller.
+        notifications: Optional notification configuration. When present,
+            the scheduler service sends notifications after suite completion.
     """
 
     name: str
     description: Optional[str] = None
     steps: List[StepDefinition] = Field(default_factory=list)
     thresholds: Optional[Dict] = None
+    notifications: Optional[NotificationsConfig] = None

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,5 +1,11 @@
 from .compare_service import run_compare_service
+from .notification_service import notify_suite_result
 from .parse_service import run_parse_service
 from .validate_service import run_validate_service
 
-__all__ = ["run_compare_service", "run_parse_service", "run_validate_service"]
+__all__ = [
+    "notify_suite_result",
+    "run_compare_service",
+    "run_parse_service",
+    "run_validate_service",
+]

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -1,0 +1,300 @@
+"""Notification service for suite test results (issue #35).
+
+Provides email (SMTP) and webhook (Teams/Slack) notification channels.
+All external calls handle errors gracefully — a notification failure never
+crashes the suite runner.
+
+Environment variables for email:
+
+* ``SMTP_HOST`` — SMTP server hostname (e.g. ``smtp.example.com``).
+* ``SMTP_PORT`` — SMTP server port (default ``587``).
+* ``SMTP_FROM`` — Sender email address.
+* ``SMTP_USER`` — SMTP authentication username (optional).
+* ``SMTP_PASSWORD`` — SMTP authentication password (optional).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import smtplib
+from datetime import datetime, timezone
+from email.mime.text import MIMEText
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from src.pipeline.suite_config import NotificationTarget, NotificationsConfig
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+
+def send_email(to: List[str], subject: str, body: str) -> bool:
+    """Send a plain-text email via SMTP using environment variable config.
+
+    Args:
+        to: List of recipient email addresses.
+        subject: Email subject line.
+        body: Plain-text email body.
+
+    Returns:
+        True if the email was sent successfully, False otherwise.
+    """
+    host = os.environ.get("SMTP_HOST", "")
+    port = int(os.environ.get("SMTP_PORT", "587"))
+    from_addr = os.environ.get("SMTP_FROM", "")
+    user = os.environ.get("SMTP_USER", "")
+    password = os.environ.get("SMTP_PASSWORD", "")
+
+    if not host or not from_addr:
+        logger.warning("SMTP_HOST or SMTP_FROM not configured — skipping email notification")
+        return False
+
+    msg = MIMEText(body, "plain", "utf-8")
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = ", ".join(to)
+
+    try:
+        with smtplib.SMTP(host, port, timeout=30) as server:
+            server.ehlo()
+            if port != 25:
+                server.starttls()
+                server.ehlo()
+            if user and password:
+                server.login(user, password)
+            server.sendmail(from_addr, to, msg.as_string())
+        logger.info("Email notification sent to %s", to)
+        return True
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to send email notification to %s", to, exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Webhooks
+# ---------------------------------------------------------------------------
+
+
+def send_teams_webhook(url: str, payload: Dict[str, Any]) -> bool:
+    """POST a message card to a Microsoft Teams incoming webhook.
+
+    Args:
+        url: The Teams incoming webhook URL.
+        payload: Dict conforming to the Teams MessageCard schema.
+
+    Returns:
+        True if the webhook accepted the payload, False otherwise.
+    """
+    try:
+        resp = requests.post(url, json=payload, timeout=15)
+        resp.raise_for_status()
+        logger.info("Teams webhook notification sent")
+        return True
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to send Teams webhook notification", exc_info=True)
+        return False
+
+
+def send_slack_webhook(url: str, payload: Dict[str, Any]) -> bool:
+    """POST a message payload to a Slack incoming webhook.
+
+    Args:
+        url: The Slack incoming webhook URL.
+        payload: Dict with at least a ``text`` key (Slack message format).
+
+    Returns:
+        True if the webhook accepted the payload, False otherwise.
+    """
+    try:
+        resp = requests.post(url, json=payload, timeout=15)
+        resp.raise_for_status()
+        logger.info("Slack webhook notification sent")
+        return True
+    except Exception:  # noqa: BLE001
+        logger.warning("Failed to send Slack webhook notification", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+
+def build_plain_text_body(suite_name: str, result: Dict[str, Any]) -> str:
+    """Build a plain-text summary of suite results for email notifications.
+
+    Args:
+        suite_name: Human-readable suite name.
+        result: Suite result dict as returned by
+            :func:`~src.services.scheduler_service.run_suite_by_name`.
+
+    Returns:
+        Formatted multi-line string summarising the run.
+    """
+    now_str = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    status = result.get("status", "unknown").upper()
+    run_id = result.get("run_id", "n/a")
+    step_results = result.get("step_results", [])
+
+    lines = [
+        f"Suite: {suite_name}",
+        f"Date:  {now_str}",
+        f"Run ID: {run_id}",
+        f"Status: {status}",
+        "",
+        "Step Results:",
+        "-" * 50,
+    ]
+
+    for step in step_results:
+        name = step.get("name", "?")
+        step_status = step.get("status", "unknown").upper()
+        errors = step.get("error_count", 0)
+        rows = step.get("total_rows", 0)
+        detail = step.get("detail", "")
+        line = f"  {step_status:<10} {name} — {rows} rows, {errors} error(s)"
+        if detail:
+            line += f" [{detail}]"
+        lines.append(line)
+
+    lines.append("-" * 50)
+    return "\n".join(lines)
+
+
+def build_teams_payload(suite_name: str, result: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a Teams MessageCard payload from suite results.
+
+    Args:
+        suite_name: Human-readable suite name.
+        result: Suite result dict.
+
+    Returns:
+        Dict conforming to the Teams MessageCard schema.
+    """
+    status = result.get("status", "unknown").upper()
+    color = "00cc00" if status == "PASSED" else "cc0000"
+    body = build_plain_text_body(suite_name, result)
+
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "themeColor": color,
+        "summary": f"Suite '{suite_name}' — {status}",
+        "sections": [
+            {
+                "activityTitle": f"CM3 Suite Result: {suite_name}",
+                "activitySubtitle": status,
+                "text": f"```\n{body}\n```",
+                "markdown": True,
+            }
+        ],
+    }
+
+
+def build_slack_payload(suite_name: str, result: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a Slack incoming-webhook payload from suite results.
+
+    Args:
+        suite_name: Human-readable suite name.
+        result: Suite result dict.
+
+    Returns:
+        Dict with ``text`` key suitable for Slack's incoming webhook API.
+    """
+    status = result.get("status", "unknown").upper()
+    emoji = ":white_check_mark:" if status == "PASSED" else ":x:"
+    body = build_plain_text_body(suite_name, result)
+
+    return {
+        "text": f"{emoji} *Suite '{suite_name}' — {status}*\n```\n{body}\n```",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def notify_suite_result(
+    suite_name: str,
+    result: Dict[str, Any],
+    notifications_config: Optional[NotificationsConfig],
+) -> None:
+    """Send notifications for a suite result based on the suite's config.
+
+    Determines whether the result warrants notification (``on_success`` or
+    ``on_failure``) and dispatches to the appropriate channels.  All errors
+    are caught and logged — this function never raises.
+
+    Args:
+        suite_name: Suite name used in notification messages.
+        result: Suite result dict (must contain a ``status`` key).
+        notifications_config: Optional notification configuration from the
+            suite definition.  When ``None``, no notifications are sent.
+    """
+    if notifications_config is None:
+        return
+
+    status = result.get("status", "unknown")
+    is_success = status == "passed"
+
+    targets: List[NotificationTarget] = []
+    if is_success and notifications_config.on_success:
+        targets = notifications_config.on_success
+    elif not is_success and notifications_config.on_failure:
+        targets = notifications_config.on_failure
+
+    for target in targets:
+        try:
+            _dispatch_target(suite_name, result, target)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Notification dispatch failed for target type='%s'",
+                target.type,
+                exc_info=True,
+            )
+
+
+def _dispatch_target(
+    suite_name: str,
+    result: Dict[str, Any],
+    target: NotificationTarget,
+) -> None:
+    """Route a single notification target to the correct sender.
+
+    Args:
+        suite_name: Suite name for the notification content.
+        result: Suite result dict.
+        target: The notification target describing type and destination.
+    """
+    if target.type == "email":
+        recipients = target.to if target.to else []
+        if not recipients:
+            logger.warning("Email notification target has no recipients — skipping")
+            return
+        subject = f"CM3 Suite '{suite_name}' — {result.get('status', 'unknown').upper()}"
+        body = build_plain_text_body(suite_name, result)
+        send_email(recipients, subject, body)
+
+    elif target.type == "teams":
+        if not target.url:
+            logger.warning("Teams notification target has no URL — skipping")
+            return
+        payload = build_teams_payload(suite_name, result)
+        send_teams_webhook(target.url, payload)
+
+    elif target.type == "slack":
+        if not target.url:
+            logger.warning("Slack notification target has no URL — skipping")
+            return
+        payload = build_slack_payload(suite_name, result)
+        send_slack_webhook(target.url, payload)
+
+    else:
+        logger.warning("Unknown notification target type: '%s'", target.type)

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -18,6 +18,7 @@ from typing import Any
 import yaml
 
 from src.pipeline.suite_config import SuiteDefinition, StepDefinition
+from src.services.notification_service import notify_suite_result
 from src.services.validate_service import run_validate_service
 
 logger = logging.getLogger(__name__)
@@ -160,13 +161,18 @@ def run_suite_by_name(
         if step_result["status"] in ("failed", "error"):
             overall_failed = True
 
-    return {
+    result = {
         "suite_name": suite_name,
         "run_id": run_id,
         "status": "failed" if overall_failed else "passed",
         "message": "",
         "step_results": step_results,
     }
+
+    # Send notifications if configured (errors are caught internally).
+    notify_suite_result(suite_name, result, matched.notifications)
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_db_config.py
+++ b/tests/unit/test_db_config.py
@@ -1,0 +1,226 @@
+"""Unit tests for src.config.db_config — database configuration module."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.config.db_config import DbConfig, get_db_config, get_connection
+
+
+# ---------------------------------------------------------------------------
+# get_db_config
+# ---------------------------------------------------------------------------
+
+
+class TestGetDbConfig:
+    """Tests for get_db_config()."""
+
+    def test_defaults_when_no_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When no ORACLE_* env vars are set, defaults are applied."""
+        monkeypatch.delenv("ORACLE_USER", raising=False)
+        monkeypatch.delenv("ORACLE_PASSWORD", raising=False)
+        monkeypatch.delenv("ORACLE_DSN", raising=False)
+        monkeypatch.delenv("ORACLE_SCHEMA", raising=False)
+
+        cfg = get_db_config()
+
+        assert cfg.user == "CM3INT"
+        assert cfg.password == ""
+        assert cfg.dsn == "localhost:1521/FREEPDB1"
+        # schema defaults to user
+        assert cfg.schema == "CM3INT"
+
+    def test_custom_values_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Env vars override every default."""
+        monkeypatch.setenv("ORACLE_USER", "TESTUSER")
+        monkeypatch.setenv("ORACLE_PASSWORD", "s3cret")
+        monkeypatch.setenv("ORACLE_DSN", "dbhost:1522/TESTPDB")
+        monkeypatch.setenv("ORACLE_SCHEMA", "TESTSCHEMA")
+
+        cfg = get_db_config()
+
+        assert cfg.user == "TESTUSER"
+        assert cfg.password == "s3cret"
+        assert cfg.dsn == "dbhost:1522/TESTPDB"
+        assert cfg.schema == "TESTSCHEMA"
+
+    def test_schema_defaults_to_user(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ORACLE_SCHEMA is not set, it falls back to ORACLE_USER."""
+        monkeypatch.setenv("ORACLE_USER", "MYUSER")
+        monkeypatch.delenv("ORACLE_SCHEMA", raising=False)
+
+        cfg = get_db_config()
+
+        assert cfg.schema == "MYUSER"
+
+    def test_config_is_immutable(self) -> None:
+        """DbConfig instances are frozen dataclasses."""
+        cfg = DbConfig(user="u", password="p", dsn="d", schema="s")
+        with pytest.raises(AttributeError):
+            cfg.user = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# get_connection
+# ---------------------------------------------------------------------------
+
+
+class TestGetConnection:
+    """Tests for get_connection()."""
+
+    def test_fails_fast_without_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Attempting to connect with an empty password raises RuntimeError."""
+        monkeypatch.delenv("ORACLE_PASSWORD", raising=False)
+
+        with pytest.raises(RuntimeError, match="ORACLE_PASSWORD is not set"):
+            get_connection()
+
+    def test_fails_fast_with_explicit_empty_password(self) -> None:
+        """An explicit empty password in config also triggers fail-fast."""
+        cfg = DbConfig(user="u", password="", dsn="d", schema="s")
+        with pytest.raises(RuntimeError, match="ORACLE_PASSWORD is not set"):
+            get_connection(config=cfg)
+
+    @patch("src.config.db_config.oracledb")
+    def test_creates_connection_with_config(self, mock_oracledb: MagicMock) -> None:
+        """When password is present, oracledb.connect is called correctly."""
+        mock_conn = MagicMock()
+        mock_oracledb.connect.return_value = mock_conn
+
+        cfg = DbConfig(user="TESTUSER", password="pass", dsn="host:1521/DB", schema="S")
+        result = get_connection(config=cfg)
+
+        mock_oracledb.connect.assert_called_once_with(
+            user="TESTUSER",
+            password="pass",
+            dsn="host:1521/DB",
+        )
+        assert result is mock_conn
+
+    @patch("src.config.db_config.oracledb")
+    def test_wraps_oracledb_error_in_connection_error(self, mock_oracledb: MagicMock) -> None:
+        """oracledb.Error is wrapped in ConnectionError with context."""
+        import oracledb as real_oracledb
+
+        mock_oracledb.connect.side_effect = real_oracledb.Error("ORA-12541")
+        mock_oracledb.Error = real_oracledb.Error
+
+        cfg = DbConfig(user="u", password="p", dsn="bad:1521/X", schema="s")
+        with pytest.raises(ConnectionError, match="Failed to connect"):
+            get_connection(config=cfg)
+
+    @patch("src.config.db_config.oracledb")
+    def test_reads_env_when_no_config_passed(
+        self, mock_oracledb: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When config=None, get_connection reads from env via get_db_config."""
+        monkeypatch.setenv("ORACLE_USER", "ENVUSER")
+        monkeypatch.setenv("ORACLE_PASSWORD", "envpass")
+        monkeypatch.setenv("ORACLE_DSN", "envhost:1521/ENVDB")
+
+        mock_conn = MagicMock()
+        mock_oracledb.connect.return_value = mock_conn
+
+        result = get_connection()
+
+        mock_oracledb.connect.assert_called_once_with(
+            user="ENVUSER",
+            password="envpass",
+            dsn="envhost:1521/ENVDB",
+        )
+        assert result is mock_conn
+
+
+# ---------------------------------------------------------------------------
+# OracleConnection.from_env integration
+# ---------------------------------------------------------------------------
+
+
+class TestOracleConnectionFromEnv:
+    """Verify OracleConnection.from_env uses centralised config."""
+
+    def test_from_env_uses_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """from_env should pick up default user and DSN from db_config."""
+        monkeypatch.delenv("ORACLE_USER", raising=False)
+        monkeypatch.delenv("ORACLE_PASSWORD", raising=False)
+        monkeypatch.delenv("ORACLE_DSN", raising=False)
+
+        from src.database.connection import OracleConnection
+
+        conn = OracleConnection.from_env()
+
+        assert conn.username == "CM3INT"
+        assert conn.dsn == "localhost:1521/FREEPDB1"
+        assert conn.password == ""
+
+    def test_from_env_reads_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """from_env should honour ORACLE_* env vars."""
+        monkeypatch.setenv("ORACLE_USER", "CUSTOM")
+        monkeypatch.setenv("ORACLE_PASSWORD", "pw")
+        monkeypatch.setenv("ORACLE_DSN", "remote:1521/SVC")
+
+        from src.database.connection import OracleConnection
+
+        conn = OracleConnection.from_env()
+
+        assert conn.username == "CUSTOM"
+        assert conn.password == "pw"
+        assert conn.dsn == "remote:1521/SVC"
+
+    def test_connect_fails_fast_without_password(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OracleConnection.connect() should fail fast when password is empty."""
+        monkeypatch.delenv("ORACLE_PASSWORD", raising=False)
+
+        from src.database.connection import OracleConnection
+
+        conn = OracleConnection.from_env()
+        with pytest.raises(RuntimeError, match="ORACLE_PASSWORD is not set"):
+            conn.connect()
+
+
+# ---------------------------------------------------------------------------
+# RunHistoryRepository schema configuration
+# ---------------------------------------------------------------------------
+
+
+class TestRunHistorySchema:
+    """Verify run_history SQL uses configurable schema."""
+
+    def test_sql_uses_configured_schema(self) -> None:
+        """SQL helpers should interpolate the schema parameter."""
+        from src.database.run_history import (
+            _sql_insert_run,
+            _sql_insert_test,
+            _sql_fetch_history,
+        )
+
+        assert "MYSCHEMA.CM3_RUN_HISTORY" in _sql_insert_run("MYSCHEMA")
+        assert "MYSCHEMA.CM3_RUN_TESTS" in _sql_insert_test("MYSCHEMA")
+        assert "MYSCHEMA.CM3_RUN_HISTORY" in _sql_fetch_history("MYSCHEMA")
+
+    def test_repository_uses_env_schema(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RunHistoryRepository picks up ORACLE_SCHEMA from env."""
+        monkeypatch.setenv("ORACLE_SCHEMA", "PRODSCHEMA")
+
+        from src.database.run_history import RunHistoryRepository
+        from src.database.connection import OracleConnection
+
+        conn = OracleConnection(username="u", password="p", dsn="d")
+        repo = RunHistoryRepository(conn=conn)
+
+        assert repo._schema == "PRODSCHEMA"
+
+    def test_repository_schema_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit schema kwarg overrides env var."""
+        monkeypatch.setenv("ORACLE_SCHEMA", "ENVSCHEMA")
+
+        from src.database.run_history import RunHistoryRepository
+        from src.database.connection import OracleConnection
+
+        conn = OracleConnection(username="u", password="p", dsn="d")
+        repo = RunHistoryRepository(conn=conn, schema="OVERRIDE")
+
+        assert repo._schema == "OVERRIDE"

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -1,0 +1,369 @@
+"""Unit tests for the notification service (issue #35).
+
+Covers:
+- Email formatting and SMTP dispatch
+- Teams/Slack webhook payload generation and dispatch
+- Graceful error handling (failures logged, not raised)
+- notify_suite_result routing to correct channels
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, ANY
+
+import pytest
+
+from src.pipeline.suite_config import NotificationTarget, NotificationsConfig
+from src.services.notification_service import (
+    build_plain_text_body,
+    build_slack_payload,
+    build_teams_payload,
+    notify_suite_result,
+    send_email,
+    send_slack_webhook,
+    send_teams_webhook,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_PASSED_RESULT = {
+    "suite_name": "daily-validation",
+    "run_id": "abc-123",
+    "status": "passed",
+    "message": "",
+    "step_results": [
+        {
+            "name": "Validate customer file",
+            "type": "validate",
+            "status": "passed",
+            "error_count": 0,
+            "total_rows": 100,
+            "detail": "",
+        },
+    ],
+}
+
+_FAILED_RESULT = {
+    "suite_name": "daily-validation",
+    "run_id": "def-456",
+    "status": "failed",
+    "message": "",
+    "step_results": [
+        {
+            "name": "Validate customer file",
+            "type": "validate",
+            "status": "passed",
+            "error_count": 0,
+            "total_rows": 100,
+            "detail": "",
+        },
+        {
+            "name": "Validate transaction file",
+            "type": "validate",
+            "status": "failed",
+            "error_count": 3,
+            "total_rows": 200,
+            "detail": "3 validation error(s)",
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Plain text body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPlainTextBody:
+    """Tests for the plain-text email body builder."""
+
+    def test_contains_suite_name(self):
+        body = build_plain_text_body("daily-validation", _PASSED_RESULT)
+        assert "daily-validation" in body
+
+    def test_contains_status_passed(self):
+        body = build_plain_text_body("daily-validation", _PASSED_RESULT)
+        assert "PASSED" in body
+
+    def test_contains_status_failed(self):
+        body = build_plain_text_body("daily-validation", _FAILED_RESULT)
+        assert "FAILED" in body
+
+    def test_contains_run_id(self):
+        body = build_plain_text_body("daily-validation", _PASSED_RESULT)
+        assert "abc-123" in body
+
+    def test_contains_step_details(self):
+        body = build_plain_text_body("daily-validation", _FAILED_RESULT)
+        assert "Validate customer file" in body
+        assert "Validate transaction file" in body
+        assert "3 validation error(s)" in body
+
+    def test_step_rows_and_errors(self):
+        body = build_plain_text_body("daily-validation", _FAILED_RESULT)
+        assert "200 rows" in body
+        assert "3 error(s)" in body
+
+
+# ---------------------------------------------------------------------------
+# Teams payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTeamsPayload:
+    """Tests for the Teams MessageCard payload builder."""
+
+    def test_message_card_schema(self):
+        payload = build_teams_payload("my-suite", _PASSED_RESULT)
+        assert payload["@type"] == "MessageCard"
+        assert "@context" in payload
+
+    def test_passed_colour_green(self):
+        payload = build_teams_payload("my-suite", _PASSED_RESULT)
+        assert payload["themeColor"] == "00cc00"
+
+    def test_failed_colour_red(self):
+        payload = build_teams_payload("my-suite", _FAILED_RESULT)
+        assert payload["themeColor"] == "cc0000"
+
+    def test_summary_contains_suite_name(self):
+        payload = build_teams_payload("my-suite", _PASSED_RESULT)
+        assert "my-suite" in payload["summary"]
+
+    def test_section_body_present(self):
+        payload = build_teams_payload("my-suite", _PASSED_RESULT)
+        sections = payload.get("sections", [])
+        assert len(sections) == 1
+        assert "my-suite" in sections[0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Slack payload
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSlackPayload:
+    """Tests for the Slack webhook payload builder."""
+
+    def test_text_key_present(self):
+        payload = build_slack_payload("my-suite", _PASSED_RESULT)
+        assert "text" in payload
+
+    def test_passed_has_checkmark(self):
+        payload = build_slack_payload("my-suite", _PASSED_RESULT)
+        assert ":white_check_mark:" in payload["text"]
+
+    def test_failed_has_x(self):
+        payload = build_slack_payload("my-suite", _FAILED_RESULT)
+        assert ":x:" in payload["text"]
+
+    def test_contains_suite_name(self):
+        payload = build_slack_payload("my-suite", _PASSED_RESULT)
+        assert "my-suite" in payload["text"]
+
+
+# ---------------------------------------------------------------------------
+# send_email
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmail:
+    """Tests for SMTP email sending."""
+
+    @patch.dict("os.environ", {
+        "SMTP_HOST": "smtp.test.com",
+        "SMTP_PORT": "587",
+        "SMTP_FROM": "ci@example.com",
+        "SMTP_USER": "user",
+        "SMTP_PASSWORD": "pass",
+    })
+    @patch("src.services.notification_service.smtplib.SMTP")
+    def test_sends_email_successfully(self, mock_smtp_cls):
+        mock_server = MagicMock()
+        mock_smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = send_email(["dev@test.com"], "Test Subject", "Test body")
+
+        assert result is True
+        mock_smtp_cls.assert_called_once_with("smtp.test.com", 587, timeout=30)
+
+    @patch.dict("os.environ", {"SMTP_HOST": "", "SMTP_FROM": ""}, clear=False)
+    def test_returns_false_when_not_configured(self):
+        result = send_email(["dev@test.com"], "Subject", "Body")
+        assert result is False
+
+    @patch.dict("os.environ", {
+        "SMTP_HOST": "smtp.test.com",
+        "SMTP_PORT": "587",
+        "SMTP_FROM": "ci@example.com",
+    })
+    @patch("src.services.notification_service.smtplib.SMTP")
+    def test_catches_smtp_error_gracefully(self, mock_smtp_cls):
+        mock_smtp_cls.side_effect = Exception("Connection refused")
+
+        result = send_email(["dev@test.com"], "Subject", "Body")
+
+        assert result is False  # no exception raised
+
+
+# ---------------------------------------------------------------------------
+# send_teams_webhook
+# ---------------------------------------------------------------------------
+
+
+class TestSendTeamsWebhook:
+    """Tests for Teams webhook sending."""
+
+    @patch("src.services.notification_service.requests.post")
+    def test_sends_successfully(self, mock_post):
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        result = send_teams_webhook("https://teams.hook/123", {"key": "value"})
+
+        assert result is True
+        mock_post.assert_called_once_with(
+            "https://teams.hook/123", json={"key": "value"}, timeout=15
+        )
+
+    @patch("src.services.notification_service.requests.post")
+    def test_catches_error_gracefully(self, mock_post):
+        mock_post.side_effect = Exception("Timeout")
+
+        result = send_teams_webhook("https://teams.hook/123", {})
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# send_slack_webhook
+# ---------------------------------------------------------------------------
+
+
+class TestSendSlackWebhook:
+    """Tests for Slack webhook sending."""
+
+    @patch("src.services.notification_service.requests.post")
+    def test_sends_successfully(self, mock_post):
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        result = send_slack_webhook("https://hooks.slack.com/xxx", {"text": "hi"})
+
+        assert result is True
+
+    @patch("src.services.notification_service.requests.post")
+    def test_catches_error_gracefully(self, mock_post):
+        mock_post.side_effect = Exception("Timeout")
+
+        result = send_slack_webhook("https://hooks.slack.com/xxx", {"text": "hi"})
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# notify_suite_result — routing
+# ---------------------------------------------------------------------------
+
+
+class TestNotifySuiteResult:
+    """Tests for the orchestration function."""
+
+    def test_noop_when_config_is_none(self):
+        # Should not raise.
+        notify_suite_result("suite", _PASSED_RESULT, None)
+
+    @patch("src.services.notification_service.send_email")
+    def test_routes_email_on_failure(self, mock_email):
+        mock_email.return_value = True
+        config = NotificationsConfig(
+            on_failure=[NotificationTarget(type="email", to=["dev@test.com"])],
+            on_success=[],
+        )
+
+        notify_suite_result("suite", _FAILED_RESULT, config)
+
+        mock_email.assert_called_once()
+        args = mock_email.call_args
+        assert args[0][0] == ["dev@test.com"]
+        assert "FAILED" in args[0][1]  # subject
+
+    @patch("src.services.notification_service.send_email")
+    def test_does_not_email_on_success_when_only_on_failure(self, mock_email):
+        config = NotificationsConfig(
+            on_failure=[NotificationTarget(type="email", to=["dev@test.com"])],
+            on_success=[],
+        )
+
+        notify_suite_result("suite", _PASSED_RESULT, config)
+
+        mock_email.assert_not_called()
+
+    @patch("src.services.notification_service.send_email")
+    def test_routes_email_on_success(self, mock_email):
+        mock_email.return_value = True
+        config = NotificationsConfig(
+            on_failure=[],
+            on_success=[NotificationTarget(type="email", to=["qa@test.com"])],
+        )
+
+        notify_suite_result("suite", _PASSED_RESULT, config)
+
+        mock_email.assert_called_once()
+
+    @patch("src.services.notification_service.send_teams_webhook")
+    def test_routes_teams_on_failure(self, mock_teams):
+        mock_teams.return_value = True
+        config = NotificationsConfig(
+            on_failure=[NotificationTarget(type="teams", url="https://teams.hook/1")],
+        )
+
+        notify_suite_result("suite", _FAILED_RESULT, config)
+
+        mock_teams.assert_called_once()
+        call_url = mock_teams.call_args[0][0]
+        assert call_url == "https://teams.hook/1"
+
+    @patch("src.services.notification_service.send_slack_webhook")
+    def test_routes_slack_on_failure(self, mock_slack):
+        mock_slack.return_value = True
+        config = NotificationsConfig(
+            on_failure=[NotificationTarget(type="slack", url="https://hooks.slack.com/x")],
+        )
+
+        notify_suite_result("suite", _FAILED_RESULT, config)
+
+        mock_slack.assert_called_once()
+
+    @patch("src.services.notification_service.send_email")
+    @patch("src.services.notification_service.send_teams_webhook")
+    def test_multiple_targets_on_failure(self, mock_teams, mock_email):
+        mock_email.return_value = True
+        mock_teams.return_value = True
+        config = NotificationsConfig(
+            on_failure=[
+                NotificationTarget(type="email", to=["dev@test.com"]),
+                NotificationTarget(type="teams", url="https://teams.hook/1"),
+            ],
+        )
+
+        notify_suite_result("suite", _FAILED_RESULT, config)
+
+        mock_email.assert_called_once()
+        mock_teams.assert_called_once()
+
+    @patch("src.services.notification_service.send_email")
+    def test_dispatch_error_does_not_raise(self, mock_email):
+        mock_email.side_effect = RuntimeError("unexpected")
+        config = NotificationsConfig(
+            on_failure=[NotificationTarget(type="email", to=["dev@test.com"])],
+        )
+
+        # Must not raise.
+        notify_suite_result("suite", _FAILED_RESULT, config)
+
+    def test_empty_targets_is_noop(self):
+        config = NotificationsConfig(on_failure=[], on_success=[])
+        # Should not raise.
+        notify_suite_result("suite", _FAILED_RESULT, config)
+        notify_suite_result("suite", _PASSED_RESULT, config)


### PR DESCRIPTION
## Summary
- **#35**: Notification service — email (SMTP), Teams webhook, Slack webhook after suite runs. Configurable per-suite YAML with `on_failure`/`on_success` routing. Graceful error handling.
- **#48**: Configurable Oracle DSN — `ORACLE_USER`, `ORACLE_PASSWORD`, `ORACLE_DSN`, `ORACLE_SCHEMA` env vars with defaults. Fail-fast on missing password. Removed hardcoded `CM3INT` schema.

## Test plan
- [x] `pytest tests/unit/` — 726 passed, 84.56% coverage
- [x] 31 notification tests (email format, webhook payloads, error handling)
- [x] 15 DB config tests (defaults, custom env, fail-fast, connection mock)

## Issues closed
Closes #35 #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)