### PR TITLE
fix(ci): rename CI templates from cm3 to valdo

### DIFF
--- a/ci/templates/azure-valdo-validate.yml
+++ b/ci/templates/azure-valdo-validate.yml
@@ -3,7 +3,7 @@
 # Usage in your pipeline:
 #
 #   steps:
-#     - template: ci/templates/azure-cm3-validate.yml
+#     - template: ci/templates/azure-valdo-validate.yml
 #       parameters:
 #         file: data/batch/customers.txt
 #         mapping: config/mappings/customers.json
@@ -77,12 +77,12 @@ steps:
       echo "Running: $CMD"
       eval "$CMD"
 
-      echo "##vso[task.setvariable variable=CM3_REPORT_PATH]$REPORT_FILE"
+      echo "##vso[task.setvariable variable=VALDO_REPORT_PATH]$REPORT_FILE"
     displayName: 'Run Valdo Validation'
 
   - script: |
       set -euo pipefail
-      REPORT_FILE="$(CM3_REPORT_PATH)"
+      REPORT_FILE="$(VALDO_REPORT_PATH)"
 
       if [ "${{ parameters.outputFormat }}" = "json" ] && [ -f "$REPORT_FILE" ]; then
         TOTAL_ROWS=$(python3 -c "
@@ -101,8 +101,8 @@ steps:
       print(summary.get('error_count', summary.get('total_errors', 0)))
       " 2>/dev/null || echo "0")
 
-        echo "##vso[task.setvariable variable=CM3_TOTAL_ROWS]$TOTAL_ROWS"
-        echo "##vso[task.setvariable variable=CM3_ERROR_COUNT]$ERROR_COUNT"
+        echo "##vso[task.setvariable variable=VALDO_TOTAL_ROWS]$TOTAL_ROWS"
+        echo "##vso[task.setvariable variable=VALDO_ERROR_COUNT]$ERROR_COUNT"
 
         FAILED="false"
 

--- a/ci/templates/gitlab-valdo-validate.yml
+++ b/ci/templates/gitlab-valdo-validate.yml
@@ -3,27 +3,27 @@
 # Usage in your .gitlab-ci.yml:
 #
 #   include:
-#     - project: 'your-group/cm3-batch-automations'
-#       file: 'ci/templates/gitlab-cm3-validate.yml'
+#     - project: 'your-group/valdo'
+#       file: 'ci/templates/gitlab-valdo-validate.yml'
 #
 #   validate-batch:
-#     extends: .cm3-validate
+#     extends: .valdo-validate
 #     variables:
-#       CM3_FILE: data/batch/customers.txt
-#       CM3_MAPPING: config/mappings/customers.json
-#       CM3_RULES: config/rules/customers_rules.json
-#       CM3_THRESHOLD_MAX_ERRORS: "100"
+#       VALDO_FILE: data/batch/customers.txt
+#       VALDO_MAPPING: config/mappings/customers.json
+#       VALDO_RULES: config/rules/customers_rules.json
+#       VALDO_THRESHOLD_MAX_ERRORS: "100"
 
-.cm3-validate:
+.valdo-validate:
   stage: validate
   image: python:3.11-slim
   variables:
-    CM3_FILE: ""
-    CM3_MAPPING: ""
-    CM3_RULES: ""
-    CM3_THRESHOLD_MAX_ERRORS: ""
-    CM3_THRESHOLD_MAX_ERROR_PCT: ""
-    CM3_OUTPUT_FORMAT: "json"
+    VALDO_FILE: ""
+    VALDO_MAPPING: ""
+    VALDO_RULES: ""
+    VALDO_THRESHOLD_MAX_ERRORS: ""
+    VALDO_THRESHOLD_MAX_ERROR_PCT: ""
+    VALDO_OUTPUT_FORMAT: "json"
     VALDO_VERSION: "cm3-batch-automations"
   before_script:
     - python -m pip install --upgrade pip
@@ -32,21 +32,21 @@
     - |
       set -euo pipefail
 
-      if [ -z "$CM3_FILE" ] || [ -z "$CM3_MAPPING" ]; then
-        echo "ERROR: CM3_FILE and CM3_MAPPING variables are required"
+      if [ -z "$VALDO_FILE" ] || [ -z "$VALDO_MAPPING" ]; then
+        echo "ERROR: VALDO_FILE and VALDO_MAPPING variables are required"
         exit 1
       fi
 
       REPORT_DIR="valdo-reports"
       mkdir -p "$REPORT_DIR"
-      REPORT_FILE="$REPORT_DIR/validation-report.$CM3_OUTPUT_FORMAT"
+      REPORT_FILE="$REPORT_DIR/validation-report.$VALDO_OUTPUT_FORMAT"
 
       CMD="valdo validate"
-      CMD="$CMD --file '$CM3_FILE'"
-      CMD="$CMD --mapping '$CM3_MAPPING'"
+      CMD="$CMD --file '$VALDO_FILE'"
+      CMD="$CMD --mapping '$VALDO_MAPPING'"
 
-      if [ -n "$CM3_RULES" ]; then
-        CMD="$CMD --rules '$CM3_RULES'"
+      if [ -n "$VALDO_RULES" ]; then
+        CMD="$CMD --rules '$VALDO_RULES'"
       fi
 
       CMD="$CMD --output '$REPORT_FILE'"
@@ -56,7 +56,7 @@
       eval "$CMD"
 
       # Parse results and evaluate thresholds (JSON only)
-      if [ "$CM3_OUTPUT_FORMAT" = "json" ] && [ -f "$REPORT_FILE" ]; then
+      if [ "$VALDO_OUTPUT_FORMAT" = "json" ] && [ -f "$REPORT_FILE" ]; then
         TOTAL_ROWS=$(python3 -c "
       import json
       with open('$REPORT_FILE') as f:
@@ -77,15 +77,15 @@
 
         FAILED="false"
 
-        if [ -n "$CM3_THRESHOLD_MAX_ERRORS" ] && [ "$ERROR_COUNT" -gt "$CM3_THRESHOLD_MAX_ERRORS" ] 2>/dev/null; then
-          echo "WARNING: Error count ($ERROR_COUNT) exceeds threshold ($CM3_THRESHOLD_MAX_ERRORS)"
+        if [ -n "$VALDO_THRESHOLD_MAX_ERRORS" ] && [ "$ERROR_COUNT" -gt "$VALDO_THRESHOLD_MAX_ERRORS" ] 2>/dev/null; then
+          echo "WARNING: Error count ($ERROR_COUNT) exceeds threshold ($VALDO_THRESHOLD_MAX_ERRORS)"
           FAILED="true"
         fi
 
-        if [ -n "$CM3_THRESHOLD_MAX_ERROR_PCT" ] && [ "$TOTAL_ROWS" -gt 0 ]; then
+        if [ -n "$VALDO_THRESHOLD_MAX_ERROR_PCT" ] && [ "$TOTAL_ROWS" -gt 0 ]; then
           ERROR_PCT=$(python3 -c "print(round($ERROR_COUNT / $TOTAL_ROWS * 100, 2))")
-          if python3 -c "exit(0 if $ERROR_PCT > $CM3_THRESHOLD_MAX_ERROR_PCT else 1)"; then
-            echo "WARNING: Error percentage (${ERROR_PCT}%) exceeds threshold (${CM3_THRESHOLD_MAX_ERROR_PCT}%)"
+          if python3 -c "exit(0 if $ERROR_PCT > $VALDO_THRESHOLD_MAX_ERROR_PCT else 1)"; then
+            echo "WARNING: Error percentage (${ERROR_PCT}%) exceeds threshold (${VALDO_THRESHOLD_MAX_ERROR_PCT}%)"
             FAILED="true"
           fi
         fi

--- a/docs/CI_INTEGRATION_GUIDE.md
+++ b/docs/CI_INTEGRATION_GUIDE.md
@@ -168,11 +168,11 @@ jobs:
 
 ### Pattern 5: Azure DevOps Template
 
-Use the step template in `ci/templates/azure-cm3-validate.yml`:
+Use the step template in `ci/templates/azure-valdo-validate.yml`:
 
 ```yaml
 steps:
-  - template: ci/templates/azure-cm3-validate.yml
+  - template: ci/templates/azure-valdo-validate.yml
     parameters:
       file: data/batch/customers.txt
       mapping: config/mappings/customers.json
@@ -184,20 +184,20 @@ steps:
 
 ### Pattern 6: GitLab CI Template
 
-Include the template from `ci/templates/gitlab-cm3-validate.yml`:
+Include the template from `ci/templates/gitlab-valdo-validate.yml`:
 
 ```yaml
 include:
-  - local: 'ci/templates/gitlab-cm3-validate.yml'
+  - local: 'ci/templates/gitlab-valdo-validate.yml'
 
 validate-customers:
-  extends: .cm3-validate
+  extends: .valdo-validate
   variables:
-    CM3_FILE: data/batch/customers.txt
-    CM3_MAPPING: config/mappings/customers.json
-    CM3_RULES: config/rules/customers_rules.json
-    CM3_THRESHOLD_MAX_ERRORS: "50"
-    CM3_THRESHOLD_MAX_ERROR_PCT: "5"
+    VALDO_FILE: data/batch/customers.txt
+    VALDO_MAPPING: config/mappings/customers.json
+    VALDO_RULES: config/rules/customers_rules.json
+    VALDO_THRESHOLD_MAX_ERRORS: "50"
+    VALDO_THRESHOLD_MAX_ERROR_PCT: "5"
 ```
 
 ---
@@ -224,12 +224,12 @@ validate-customers:
 
 | CLI Flag | GitHub Action Input | Azure Parameter | GitLab Variable |
 |----------|-------------------|-----------------|-----------------|
-| `--file` | `file` | `file` | `CM3_FILE` |
-| `--mapping` | `mapping` | `mapping` | `CM3_MAPPING` |
-| `--rules` | `rules` | `rules` | `CM3_RULES` |
-| `--output` format | `output-format` | `outputFormat` | `CM3_OUTPUT_FORMAT` |
-| (threshold) | `threshold-max-errors` | `thresholdMaxErrors` | `CM3_THRESHOLD_MAX_ERRORS` |
-| (threshold) | `threshold-max-error-pct` | `thresholdMaxErrorPct` | `CM3_THRESHOLD_MAX_ERROR_PCT` |
+| `--file` | `file` | `file` | `VALDO_FILE` |
+| `--mapping` | `mapping` | `mapping` | `VALDO_MAPPING` |
+| `--rules` | `rules` | `rules` | `VALDO_RULES` |
+| `--output` format | `output-format` | `outputFormat` | `VALDO_OUTPUT_FORMAT` |
+| (threshold) | `threshold-max-errors` | `thresholdMaxErrors` | `VALDO_THRESHOLD_MAX_ERRORS` |
+| (threshold) | `threshold-max-error-pct` | `thresholdMaxErrorPct` | `VALDO_THRESHOLD_MAX_ERROR_PCT` |
 | (fail gate) | `fail-on-threshold` | (always fails) | (always fails) |
 | Python version | `python-version` | `pythonVersion` | (image-based) |
 | Package version | `cm3-version` | `cm3Version` | `CM3_VERSION` |

--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -985,7 +985,7 @@ The report is automatically uploaded as a build artifact retained for 30 days.
 
 ### Azure DevOps
 
-Use the step template at `ci/templates/azure-cm3-validate.yml`:
+Use the step template at `ci/templates/azure-valdo-validate.yml`:
 
 ```yaml
 # azure-pipelines.yml
@@ -996,7 +996,7 @@ pool:
   vmImage: ubuntu-latest
 
 steps:
-  - template: ci/templates/azure-cm3-validate.yml
+  - template: ci/templates/azure-valdo-validate.yml
     parameters:
       file: data/batch/customers.txt
       mapping: config/mappings/customer_mapping.json
@@ -1012,22 +1012,22 @@ The template publishes the report as a build artifact named
 ### GitLab CI
 
 Include the template and extend the hidden job at
-`ci/templates/gitlab-cm3-validate.yml`:
+`ci/templates/gitlab-valdo-validate.yml`:
 
 ```yaml
 # .gitlab-ci.yml
 include:
   - project: 'your-group/valdo-automations'
-    file: 'ci/templates/gitlab-cm3-validate.yml'
+    file: 'ci/templates/gitlab-valdo-validate.yml'
 
 validate-customers:
-  extends: .cm3-validate
+  extends: .valdo-validate
   variables:
-    CM3_FILE: data/batch/customers.txt
-    CM3_MAPPING: config/mappings/customer_mapping.json
-    CM3_RULES: config/rules/customer_rules.json
-    CM3_THRESHOLD_MAX_ERRORS: "50"
-    CM3_THRESHOLD_MAX_ERROR_PCT: "5"
+    VALDO_FILE: data/batch/customers.txt
+    VALDO_MAPPING: config/mappings/customer_mapping.json
+    VALDO_RULES: config/rules/customer_rules.json
+    VALDO_THRESHOLD_MAX_ERRORS: "50"
+    VALDO_THRESHOLD_MAX_ERROR_PCT: "5"
 ```
 
 Reports are stored as GitLab CI artifacts for 30 days.


### PR DESCRIPTION
## Summary
Rename CI template files and variables to match the Valdo brand:
- Template files: `gitlab-cm3-validate.yml` → `gitlab-valdo-validate.yml`, same for Azure
- GitLab job: `.cm3-validate` → `.valdo-validate`
- Variables: `CM3_FILE` → `VALDO_FILE`, `CM3_MAPPING` → `VALDO_MAPPING`, etc.
- Docs updated to reference new names

- [x] 857 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)