### PR TITLE
feat(ui): add downloadable sample mapping and rules templates

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -127,6 +127,10 @@ _REPORTS_DIR = Path(__file__).parent.parent.parent / "reports"
 _REPORTS_DIR.mkdir(parents=True, exist_ok=True)
 app.mount("/reports", StaticFiles(directory=str(_REPORTS_DIR)), name="reports")
 
+_TEMPLATES_DIR = Path(__file__).parent.parent / "reports" / "static" / "templates"
+_TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+app.mount("/static/templates", StaticFiles(directory=str(_TEMPLATES_DIR)), name="templates")
+
 _DOCS_DIR = Path(__file__).parent.parent.parent / "docs"
 
 

--- a/src/reports/static/templates/mapping_template.csv
+++ b/src/reports/static/templates/mapping_template.csv
@@ -1,0 +1,8 @@
+field_name,data_type,position,length,target_name,required,description
+ACCOUNT_NUM,String,1,18,account_number,Yes,Customer account number
+FIRST_NAME,String,19,30,first_name,Yes,Customer first name
+LAST_NAME,String,49,30,last_name,Yes,Customer last name
+SSN,String,79,9,ssn,No,Social security number
+BALANCE,Numeric,88,12,balance,Yes,Account balance
+OPEN_DATE,Date,100,8,open_date,Yes,Account open date (CCYYMMDD)
+STATUS,String,108,1,status,Yes,Account status (A/I/C)

--- a/src/reports/static/templates/rules_template.csv
+++ b/src/reports/static/templates/rules_template.csv
@@ -1,0 +1,6 @@
+Rule ID,Rule Name,Field,Type,Severity,Enabled,Message,Value
+R001,account_not_empty,ACCOUNT_NUM,not_empty,error,Yes,Account number must not be empty,
+R002,balance_positive,BALANCE,min_value,warning,Yes,Balance should be positive,0
+R003,status_valid,STATUS,valid_values,error,Yes,Status must be A I or C,A|I|C
+R004,date_format,OPEN_DATE,date_format,error,Yes,Date must be CCYYMMDD,CCYYMMDD
+R005,name_not_empty,FIRST_NAME,not_empty,error,Yes,First name must not be empty,

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -1570,6 +1570,21 @@
   <div id="panel-mapping" class="panel panel-hidden" role="tabpanel" aria-labelledby="tab-mapping">
     <h2>Mapping Generator</h2>
 
+    <!-- Download Templates -->
+    <div style="margin-bottom:18px;padding:12px 16px;border:1px solid var(--border);border-radius:10px;background:var(--surface)">
+      <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+        <a href="/static/templates/mapping_template.csv" download class="btn btn-secondary" style="font-size:12px;padding:6px 14px;text-decoration:none;display:inline-flex;align-items:center;gap:5px">
+          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m0 0l-4-4m4 4l4-4M4 19h16"/></svg>
+          Mapping Template (.csv)
+        </a>
+        <a href="/static/templates/rules_template.csv" download class="btn btn-secondary" style="font-size:12px;padding:6px 14px;text-decoration:none;display:inline-flex;align-items:center;gap:5px">
+          <svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M12 5v14m0 0l-4-4m4 4l4-4M4 19h16"/></svg>
+          Rules Template (.csv)
+        </a>
+      </div>
+      <div style="margin-top:8px;font-size:12px;color:var(--muted)">Download a template, fill it in with your field definitions, then upload it above to generate a mapping.</div>
+    </div>
+
     <!-- Step indicators -->
     <div class="step-indicators">
       <div class="step active" id="mapStep1">


### PR DESCRIPTION
## Summary
- Sample CSV templates for field mappings and business rules
- Download buttons in the Mapping Generator tab
- Templates served via `/static/templates/` endpoint

- [x] 857 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)