### PR TITLE
feat(rules): add cross-row validation engine (#149)

### DIFF
--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -1224,6 +1224,134 @@ validation.
 }
 ```
 
+### Cross-Row Validation
+
+Cross-row rules validate properties that span multiple rows rather than
+individual field values.  Set `"type": "cross_row"` and add a `"check"`
+key that names one of the six supported check types.
+
+The optional `when` condition is applied first (as for all rule types), so
+cross-row checks operate only on the filtered subset of rows.
+
+#### check: unique
+
+No duplicate values in a single field.
+
+```json
+{
+  "id": "CR001",
+  "name": "Account number must be unique",
+  "type": "cross_row",
+  "check": "unique",
+  "field": "LN-NUM-ERT",
+  "severity": "error",
+  "enabled": true
+}
+```
+
+#### check: unique_composite
+
+No duplicate combinations across a list of fields.
+
+```json
+{
+  "id": "CR002",
+  "name": "Account + batch item must be unique",
+  "type": "cross_row",
+  "check": "unique_composite",
+  "fields": ["LN-NUM-ERT", "BAT-ITM-NUM-ERT"],
+  "severity": "error",
+  "enabled": true
+}
+```
+
+#### check: consistent
+
+All rows that share the same value in `key_field` must have the same value in
+`target_field`.
+
+```json
+{
+  "id": "CR003",
+  "name": "Bank number must match for same account",
+  "type": "cross_row",
+  "check": "consistent",
+  "key_field": "LN-NUM-ERT",
+  "target_field": "BK-NUM-ERT",
+  "severity": "error",
+  "enabled": true
+}
+```
+
+#### check: sequential
+
+The `sequence_field` values within each `key_field` group must form a complete
+sequence `1, 2, 3, …, N` (where `N` is the number of rows in the group).
+Row order in the file does not matter — only the set of values is checked.
+
+```json
+{
+  "id": "CR004",
+  "name": "Batch items must be sequential per account",
+  "type": "cross_row",
+  "check": "sequential",
+  "key_field": "LN-NUM-ERT",
+  "sequence_field": "BAT-ITM-NUM-ERT",
+  "severity": "error",
+  "enabled": true
+}
+```
+
+#### check: group_count
+
+The actual number of rows per `key_field` group must equal the value declared
+in `count_field`.  All rows in a mismatched group are flagged.
+
+```json
+{
+  "id": "CR005",
+  "name": "Transaction count must match actual records",
+  "type": "cross_row",
+  "check": "group_count",
+  "key_field": "LN-NUM-ERT",
+  "count_field": "TRN-CNT-ERT",
+  "severity": "error",
+  "enabled": true
+}
+```
+
+#### check: group_sum
+
+The sum of `sum_field` across a `key_field` group must fall within
+`[min_value, max_value]`.  Either bound is optional.
+
+```json
+{
+  "id": "CR006",
+  "name": "Total payments per account must not exceed limit",
+  "type": "cross_row",
+  "check": "group_sum",
+  "key_field": "LN-NUM-ERT",
+  "sum_field": "OGL-PMT-AMT-LTD-ORI",
+  "max_value": 999999999,
+  "severity": "warning",
+  "enabled": true
+}
+```
+
+| Check | Required keys | Optional keys |
+|---|---|---|
+| `unique` | `field` | `when` |
+| `unique_composite` | `fields` (list) | `when` |
+| `consistent` | `key_field`, `target_field` | `when` |
+| `sequential` | `key_field`, `sequence_field` | `when` |
+| `group_count` | `key_field`, `count_field` | `when` |
+| `group_sum` | `key_field`, `sum_field` | `min_value`, `max_value`, `when` |
+
+Missing columns are silently skipped (a warning is emitted to the log) so that
+a rules file remains forward-compatible with files that may not yet have all
+fields present.
+
 ### Suite YAML Format
 
 Suite files define multi-step validation or comparison workflows.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -339,6 +339,67 @@ valdo convert-rules \
 
 > All exported CSV files include a `source_row` column identifying the original line number in the source file. This column is also shown in HTML error and difference tables for easy trace-back.
 
+### 5a. Cross-Row Rules
+
+Cross-row rules validate properties that span multiple rows rather than
+individual cells.  Use `"type": "cross_row"` in your rules JSON with one of
+six `"check"` values:
+
+| Check | What it validates |
+|---|---|
+| `unique` | No duplicate values in a single field |
+| `unique_composite` | No duplicate combinations across a list of fields |
+| `consistent` | All rows sharing a key have the same value in a target field |
+| `sequential` | Sequence field is 1, 2, 3, ... within each key group |
+| `group_count` | Actual row count per key equals the value in a declared count field |
+| `group_sum` | Sum of a field per key falls within optional min/max bounds |
+
+**Example rules JSON:**
+
+```json
+{
+  "rules": [
+    {
+      "id": "CR001",
+      "name": "Account number must be unique",
+      "type": "cross_row",
+      "check": "unique",
+      "field": "LN-NUM-ERT",
+      "severity": "error",
+      "enabled": true
+    },
+    {
+      "id": "CR003",
+      "name": "Bank number consistent per account",
+      "type": "cross_row",
+      "check": "consistent",
+      "key_field": "LN-NUM-ERT",
+      "target_field": "BK-NUM-ERT",
+      "severity": "error",
+      "enabled": true
+    },
+    {
+      "id": "CR006",
+      "name": "Total payments must not exceed limit",
+      "type": "cross_row",
+      "check": "group_sum",
+      "key_field": "LN-NUM-ERT",
+      "sum_field": "OGL-PMT-AMT-LTD-ORI",
+      "max_value": 999999999,
+      "severity": "warning",
+      "enabled": true
+    }
+  ]
+}
+```
+
+The `when` condition works the same as for field-level rules: rows are filtered
+first, then the cross-row check runs on the surviving subset.
+
+For full documentation of every check type and all supported keys, see the
+[Cross-Row Validation](USAGE_AND_OPERATIONS_GUIDE.md#cross-row-validation)
+section of the Operations Guide.
+
 ### 6. Validation
 
 Validate a file against mapping rules and generate comprehensive HTML reports:

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -136,6 +136,10 @@ Configuration & Validators
    :members:
    :undoc-members:
 
+.. automodule:: src.validators.cross_row_validator
+   :members:
+   :undoc-members:
+
 .. automodule:: src.validators.rule_engine
    :members:
    :undoc-members:

--- a/src/reports/static/templates/rules_template.csv
+++ b/src/reports/static/templates/rules_template.csv
@@ -14,3 +14,9 @@ R012,name_min_length,FIRST_NAME,min_length,error,Yes,First name must be at least
 R013,ssn_format,SSN,regex,error,Yes,SSN must be 9 digits (no dashes),^\d{9}$
 R014,ssn_not_all_zeros,SSN,regex,error,Yes,SSN must not be all zeros,^(?!000000000)\d{9}$
 R015,cross_field_active_balance,STATUS|BALANCE,cross_field,warning,Yes,Active accounts should have a positive balance,STATUS=A AND BALANCE>0
+CR001,unique_account,LN-NUM-ERT,cross_row:unique,error,Yes,Account number must be unique,
+CR002,unique_combo,LN-NUM-ERT|BAT-ITM-NUM-ERT,cross_row:unique_composite,error,Yes,Account + batch item must be unique,
+CR003,consistent_bank,LN-NUM-ERT>BK-NUM-ERT,cross_row:consistent,error,Yes,Bank number must match for same account,
+CR004,sequential_items,LN-NUM-ERT>BAT-ITM-NUM-ERT,cross_row:sequential,error,Yes,Batch items must be sequential per account,1
+CR005,txn_count_match,LN-NUM-ERT>TRN-CNT-ERT,cross_row:group_count,error,Yes,Transaction count must match actual records,
+CR006,payment_limit,LN-NUM-ERT>OGL-PMT-AMT-LTD-ORI,cross_row:group_sum,warning,Yes,Total payments per account must not exceed limit,999999999

--- a/src/validators/cross_row_validator.py
+++ b/src/validators/cross_row_validator.py
@@ -1,0 +1,406 @@
+"""Cross-row validation engine — issue #149.
+
+Validates rules that span multiple rows grouped by a key column.
+Supported check types:
+
+- ``unique``            -- no duplicate values in a single field
+- ``unique_composite``  -- no duplicate combinations across a list of fields
+- ``consistent``        -- all rows sharing a key must have the same target value
+- ``sequential``        -- sequence_field must be 1,2,3,... within each key group
+- ``group_count``       -- actual row count per key must match a declared count field
+- ``group_sum``         -- sum of a numeric field per key must fall within bounds
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import List
+
+import pandas as pd
+
+from src.validators.rule_engine import RuleViolation
+
+_logger = logging.getLogger(__name__)
+
+
+class CrossRowValidator:
+    """Validate rules that span multiple rows grouped by key columns.
+
+    Each public ``_check_*`` method accepts a rule dict and a (possibly
+    pre-filtered) DataFrame and returns a list of :class:`~src.validators.rule_engine.RuleViolation`
+    objects — one per offending row.
+
+    The entry point is :meth:`validate`, which dispatches to the correct
+    check method based on ``rule['check']``.
+    """
+
+    # Map check-type strings to handler method names.
+    _DISPATCH: dict[str, str] = {
+        "unique":            "_check_unique",
+        "unique_composite":  "_check_unique_composite",
+        "consistent":        "_check_consistent",
+        "sequential":        "_check_sequential",
+        "group_count":       "_check_group_count",
+        "group_sum":         "_check_group_sum",
+    }
+
+    def validate(self, rule: dict, df: pd.DataFrame) -> List[RuleViolation]:
+        """Route to the correct check method based on ``rule['check']``.
+
+        Args:
+            rule: Rule configuration dict.  Must contain at least ``id``,
+                ``name``, ``severity``, and ``check`` keys.
+            df: DataFrame to validate (already filtered by any ``when``
+                condition applied by :class:`~src.validators.rule_engine.RuleEngine`).
+
+        Returns:
+            List of :class:`~src.validators.rule_engine.RuleViolation` objects.
+            Empty list when the DataFrame is empty or all rows pass.
+
+        Raises:
+            ValueError: When ``rule['check']`` is not a recognised check type.
+        """
+        if df.empty:
+            return []
+
+        check = rule.get("check", "")
+        method_name = self._DISPATCH.get(check)
+        if method_name is None:
+            raise ValueError(
+                f"Unknown cross_row check type: '{check}'. "
+                f"Supported types: {sorted(self._DISPATCH)}"
+            )
+        return getattr(self, method_name)(rule, df)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _make_violation(
+        self,
+        rule: dict,
+        idx: int,
+        field: str,
+        value: object,
+        message: str,
+    ) -> RuleViolation:
+        """Build a :class:`~src.validators.rule_engine.RuleViolation` for *idx*.
+
+        Args:
+            rule: Rule configuration dict.
+            idx: DataFrame index label for the offending row.
+            field: Field name(s) for display.
+            value: Observed value(s) for display.
+            message: Human-readable violation message.
+
+        Returns:
+            Populated :class:`~src.validators.rule_engine.RuleViolation`.
+        """
+        rid = str(rule.get("id", "UNKNOWN")).upper().replace(" ", "_")
+        issue_code = f"BR_{rid}_CROSS"
+        return RuleViolation(
+            rule_id=rule["id"],
+            rule_name=rule["name"],
+            severity=rule.get("severity", "error"),
+            row_number=int(idx) + 1,  # 1-indexed for user display
+            field=field,
+            value=value,
+            message=message,
+            issue_code=issue_code,
+        )
+
+    def _warn_missing(self, rule: dict, *columns: str) -> None:
+        """Emit a warning when expected columns are absent from the DataFrame.
+
+        Args:
+            rule: Rule configuration dict (used for context in the message).
+            *columns: Column names that are missing.
+        """
+        for col in columns:
+            warnings.warn(
+                f"cross_row rule '{rule.get('id')}' (check={rule.get('check')}): "
+                f"column '{col}' not found in DataFrame — rule skipped.",
+                stacklevel=3,
+            )
+
+    # ------------------------------------------------------------------
+    # Check implementations
+    # ------------------------------------------------------------------
+
+    def _check_unique(self, rule: dict, df: pd.DataFrame) -> List[RuleViolation]:
+        """Return violations for duplicate values in ``rule['field']``.
+
+        NaN values are excluded from duplicate detection (a NaN is not
+        considered a duplicate of another NaN).
+
+        Args:
+            rule: Must contain ``field`` (str).
+            df: DataFrame to inspect.
+
+        Returns:
+            One violation per row that participates in a duplicate group.
+        """
+        field = rule.get("field", "")
+        if field not in df.columns:
+            self._warn_missing(rule, field)
+            return []
+
+        series = df[field]
+        # keep_False marks ALL occurrences of duplicated values
+        dup_mask = series.duplicated(keep=False) & series.notna()
+        violations: List[RuleViolation] = []
+        description = rule.get("description", rule.get("name", ""))
+
+        for idx in df[dup_mask].index:
+            val = df.loc[idx, field]
+            violations.append(
+                self._make_violation(
+                    rule,
+                    idx,
+                    field,
+                    val,
+                    f"{description}: duplicate value '{val}' in field '{field}'",
+                )
+            )
+        return violations
+
+    def _check_unique_composite(
+        self, rule: dict, df: pd.DataFrame
+    ) -> List[RuleViolation]:
+        """Return violations for duplicate row combinations across ``rule['fields']``.
+
+        Args:
+            rule: Must contain ``fields`` (list of str).
+            df: DataFrame to inspect.
+
+        Returns:
+            One violation per row that participates in a duplicate combination.
+        """
+        fields: list[str] = rule.get("fields", [])
+        missing = [f for f in fields if f not in df.columns]
+        if missing:
+            self._warn_missing(rule, *missing)
+            return []
+
+        dup_mask = df.duplicated(subset=fields, keep=False)
+        violations: List[RuleViolation] = []
+        field_label = ", ".join(fields)
+        description = rule.get("description", rule.get("name", ""))
+
+        for idx in df[dup_mask].index:
+            combo = tuple(df.loc[idx, f] for f in fields)
+            violations.append(
+                self._make_violation(
+                    rule,
+                    idx,
+                    field_label,
+                    str(combo),
+                    f"{description}: duplicate combination {dict(zip(fields, combo))}",
+                )
+            )
+        return violations
+
+    def _check_consistent(self, rule: dict, df: pd.DataFrame) -> List[RuleViolation]:
+        """Return violations where rows sharing a key have different target values.
+
+        Groups by ``rule['key_field']`` and checks that ``rule['target_field']``
+        has exactly one distinct non-null value within each group.
+
+        Args:
+            rule: Must contain ``key_field`` and ``target_field`` (str).
+            df: DataFrame to inspect.
+
+        Returns:
+            One violation per row in any inconsistent group.
+        """
+        key_field = rule.get("key_field", "")
+        target_field = rule.get("target_field", "")
+        missing = [c for c in (key_field, target_field) if c not in df.columns]
+        if missing:
+            self._warn_missing(rule, *missing)
+            return []
+
+        description = rule.get("description", rule.get("name", ""))
+        violations: List[RuleViolation] = []
+
+        # Identify keys where the target_field has more than one distinct value.
+        inconsistent_keys = (
+            df.dropna(subset=[target_field])
+            .groupby(key_field)[target_field]
+            .nunique()
+        )
+        bad_keys = inconsistent_keys[inconsistent_keys > 1].index
+
+        if len(bad_keys) == 0:
+            return []
+
+        bad_rows = df[df[key_field].isin(bad_keys)]
+        for idx in bad_rows.index:
+            key_val = df.loc[idx, key_field]
+            target_val = df.loc[idx, target_field]
+            violations.append(
+                self._make_violation(
+                    rule,
+                    idx,
+                    target_field,
+                    target_val,
+                    f"{description}: '{target_field}' is inconsistent within "
+                    f"'{key_field}'='{key_val}' group",
+                )
+            )
+        return violations
+
+    def _check_sequential(
+        self, rule: dict, df: pd.DataFrame
+    ) -> List[RuleViolation]:
+        """Return violations where sequence_field is not 1,2,3,… within key groups.
+
+        The check is order-independent: it verifies that the *set* of integer
+        values for the key group equals ``{1, 2, …, N}`` where ``N`` is the
+        number of rows in the group.
+
+        Args:
+            rule: Must contain ``key_field`` and ``sequence_field`` (str).
+            df: DataFrame to inspect.
+
+        Returns:
+            One violation per row in any non-sequential group.
+        """
+        key_field = rule.get("key_field", "")
+        seq_field = rule.get("sequence_field", "")
+        missing = [c for c in (key_field, seq_field) if c not in df.columns]
+        if missing:
+            self._warn_missing(rule, *missing)
+            return []
+
+        description = rule.get("description", rule.get("name", ""))
+        violations: List[RuleViolation] = []
+
+        # Work with a numeric copy of the sequence field.
+        numeric_seq = pd.to_numeric(df[seq_field], errors="coerce")
+        bad_index_labels: set[int] = set()
+
+        for key_val, group in df.groupby(key_field):
+            n = len(group)
+            seq_vals = numeric_seq.loc[group.index]
+            expected = set(range(1, n + 1))
+            actual = set(seq_vals.dropna().astype(int))
+            if actual != expected:
+                bad_index_labels.update(group.index)
+
+        for idx in bad_index_labels:
+            seq_val = df.loc[idx, seq_field]
+            key_val = df.loc[idx, key_field]
+            violations.append(
+                self._make_violation(
+                    rule,
+                    idx,
+                    seq_field,
+                    seq_val,
+                    f"{description}: '{seq_field}' is not sequential "
+                    f"within '{key_field}'='{key_val}' group",
+                )
+            )
+        return violations
+
+    def _check_group_count(
+        self, rule: dict, df: pd.DataFrame
+    ) -> List[RuleViolation]:
+        """Return violations where actual row count per key mismatches declared count.
+
+        Each row in a mismatched group is reported as a violation because any
+        row in the group carries the incorrect header count.
+
+        Args:
+            rule: Must contain ``key_field`` and ``count_field`` (str).
+                ``count_field`` holds the declared expected row count.
+            df: DataFrame to inspect.
+
+        Returns:
+            One violation per row in any mismatched group.
+        """
+        key_field = rule.get("key_field", "")
+        count_field = rule.get("count_field", "")
+        missing = [c for c in (key_field, count_field) if c not in df.columns]
+        if missing:
+            self._warn_missing(rule, *missing)
+            return []
+
+        description = rule.get("description", rule.get("name", ""))
+        violations: List[RuleViolation] = []
+
+        for key_val, group in df.groupby(key_field):
+            actual_count = len(group)
+            declared_counts = pd.to_numeric(
+                group[count_field], errors="coerce"
+            ).dropna()
+            if declared_counts.empty:
+                continue
+            # Use the first non-null declared count in the group.
+            declared = int(declared_counts.iloc[0])
+            if actual_count != declared:
+                for idx in group.index:
+                    violations.append(
+                        self._make_violation(
+                            rule,
+                            idx,
+                            count_field,
+                            df.loc[idx, count_field],
+                            f"{description}: expected {declared} rows for "
+                            f"'{key_field}'='{key_val}' but found {actual_count}",
+                        )
+                    )
+        return violations
+
+    def _check_group_sum(
+        self, rule: dict, df: pd.DataFrame
+    ) -> List[RuleViolation]:
+        """Return violations where the sum of sum_field per key is out of bounds.
+
+        Both ``min_value`` and ``max_value`` are optional.  If absent the
+        corresponding bound is not enforced.
+
+        Args:
+            rule: Must contain ``key_field`` and ``sum_field`` (str).
+                Optional: ``min_value`` (numeric), ``max_value`` (numeric).
+            df: DataFrame to inspect.
+
+        Returns:
+            One violation per row in any out-of-bounds group.
+        """
+        key_field = rule.get("key_field", "")
+        sum_field = rule.get("sum_field", "")
+        missing = [c for c in (key_field, sum_field) if c not in df.columns]
+        if missing:
+            self._warn_missing(rule, *missing)
+            return []
+
+        min_value = rule.get("min_value")
+        max_value = rule.get("max_value")
+        description = rule.get("description", rule.get("name", ""))
+        violations: List[RuleViolation] = []
+
+        numeric_sum = pd.to_numeric(df[sum_field], errors="coerce")
+
+        for key_val, group in df.groupby(key_field):
+            group_sum = numeric_sum.loc[group.index].sum()
+            out_of_bounds = False
+            if min_value is not None and group_sum < min_value:
+                out_of_bounds = True
+            if max_value is not None and group_sum > max_value:
+                out_of_bounds = True
+            if out_of_bounds:
+                for idx in group.index:
+                    violations.append(
+                        self._make_violation(
+                            rule,
+                            idx,
+                            sum_field,
+                            numeric_sum.loc[idx],
+                            f"{description}: sum of '{sum_field}' for "
+                            f"'{key_field}'='{key_val}' is {group_sum} "
+                            f"(allowed: {min_value} to {max_value})",
+                        )
+                    )
+        return violations

--- a/src/validators/rule_engine.py
+++ b/src/validators/rule_engine.py
@@ -154,6 +154,8 @@ class RuleEngine:
             return self._validate_field(rule, scoped_df)
         elif rule_type == 'cross_field':
             return self._validate_cross_field(rule, scoped_df)
+        elif rule_type == 'cross_row':
+            return self._validate_cross_row(rule, scoped_df)
         else:
             raise ValueError(f"Unknown rule type: {rule_type}")
     
@@ -225,6 +227,22 @@ class RuleEngine:
         
         return violations
     
+    def _validate_cross_row(self, rule: Dict, df: pd.DataFrame) -> List[RuleViolation]:
+        """Delegate cross-row validation to CrossRowValidator.
+
+        Args:
+            rule: Rule configuration dict.  Must include a ``check`` key that
+                names one of the supported cross-row check types.
+            df: DataFrame filtered by any ``when`` condition.
+
+        Returns:
+            List of :class:`RuleViolation` objects produced by
+            :class:`~src.validators.cross_row_validator.CrossRowValidator`.
+        """
+        from src.validators.cross_row_validator import CrossRowValidator
+        validator = CrossRowValidator()
+        return validator.validate(rule, df)
+
     def _validate_cross_field(self, rule: Dict, df: pd.DataFrame) -> List[RuleViolation]:
         """
         Validate relationships between fields.

--- a/tests/unit/test_cross_row_validator.py
+++ b/tests/unit/test_cross_row_validator.py
@@ -1,0 +1,554 @@
+"""Tests for CrossRowValidator — issue #149.
+
+Covers all 6 cross-row check types:
+  - unique
+  - unique_composite
+  - consistent
+  - sequential
+  - group_count
+  - group_sum
+
+Plus edge cases: empty DataFrame, single-row groups, missing columns, NaN values.
+"""
+
+import pandas as pd
+import pytest
+
+from src.validators.cross_row_validator import CrossRowValidator
+from src.validators.rule_engine import RuleViolation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_rule(check: str, **kwargs) -> dict:
+    """Return a minimal cross_row rule dict for the given check type."""
+    return {
+        "id": "CR_TEST",
+        "name": f"test_{check}",
+        "type": "cross_row",
+        "check": check,
+        "severity": "error",
+        **kwargs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# unique
+# ---------------------------------------------------------------------------
+
+class TestCheckUnique:
+    """Tests for the 'unique' cross-row check."""
+
+    def test_unique_passes_with_distinct_values(self):
+        """No violations when all values in the field are distinct."""
+        df = pd.DataFrame({"ACCOUNT": ["A001", "A002", "A003"]})
+        rule = _make_rule("unique", field="ACCOUNT")
+        validator = CrossRowValidator()
+        violations = validator.validate(rule, df)
+        assert violations == []
+
+    def test_unique_fails_with_duplicate_values(self):
+        """Each duplicated row produces a violation."""
+        df = pd.DataFrame({"ACCOUNT": ["A001", "A002", "A001", "A003", "A002"]})
+        rule = _make_rule("unique", field="ACCOUNT")
+        validator = CrossRowValidator()
+        violations = validator.validate(rule, df)
+        # Rows 0, 2 share "A001"; rows 1, 4 share "A002" — all 4 are violations
+        assert len(violations) == 4
+        assert all(isinstance(v, RuleViolation) for v in violations)
+
+    def test_unique_reports_correct_1indexed_row_numbers(self):
+        """row_number in violations is 1-indexed (user-facing)."""
+        df = pd.DataFrame({"ACCOUNT": ["A001", "A001"]})
+        rule = _make_rule("unique", field="ACCOUNT")
+        violations = CrossRowValidator().validate(rule, df)
+        row_numbers = {v.row_number for v in violations}
+        assert row_numbers == {1, 2}
+
+    def test_unique_missing_column_returns_empty(self):
+        """Gracefully returns no violations when field is absent."""
+        df = pd.DataFrame({"OTHER": [1, 2, 3]})
+        rule = _make_rule("unique", field="ACCOUNT")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_unique_empty_dataframe_returns_empty(self):
+        """No violations on an empty DataFrame."""
+        df = pd.DataFrame({"ACCOUNT": pd.Series([], dtype=str)})
+        rule = _make_rule("unique", field="ACCOUNT")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_unique_nan_values_not_flagged_as_duplicates(self):
+        """NaN values are not treated as duplicates of each other."""
+        df = pd.DataFrame({"ACCOUNT": ["A001", None, None]})
+        rule = _make_rule("unique", field="ACCOUNT")
+        violations = CrossRowValidator().validate(rule, df)
+        # Only "A001" is distinct; NaN rows should not be flagged
+        assert len(violations) == 0
+
+
+# ---------------------------------------------------------------------------
+# unique_composite
+# ---------------------------------------------------------------------------
+
+class TestCheckUniqueComposite:
+    """Tests for the 'unique_composite' cross-row check."""
+
+    def test_unique_composite_passes_with_distinct_combinations(self):
+        """No violations when every row has a unique column combination."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002"],
+            "ITEM":    ["1",    "2",    "1"],
+        })
+        rule = _make_rule("unique_composite", fields=["ACCOUNT", "ITEM"])
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_unique_composite_fails_with_duplicate_combination(self):
+        """Duplicate row-combinations each produce a violation."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A001"],
+            "ITEM":    ["1",    "1",    "2"],
+        })
+        rule = _make_rule("unique_composite", fields=["ACCOUNT", "ITEM"])
+        violations = CrossRowValidator().validate(rule, df)
+        # rows 0 and 1 share (A001, 1)
+        assert len(violations) == 2
+
+    def test_unique_composite_missing_column_returns_empty(self):
+        """Returns no violations when any composite field is absent."""
+        df = pd.DataFrame({"ACCOUNT": ["A001", "A001"]})
+        rule = _make_rule("unique_composite", fields=["ACCOUNT", "MISSING"])
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_unique_composite_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": pd.Series([], dtype=str),
+                           "ITEM": pd.Series([], dtype=str)})
+        rule = _make_rule("unique_composite", fields=["ACCOUNT", "ITEM"])
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# consistent
+# ---------------------------------------------------------------------------
+
+class TestCheckConsistent:
+    """Tests for the 'consistent' cross-row check."""
+
+    def test_consistent_passes_when_target_uniform_per_key(self):
+        """No violations when target_field has the same value within each key group."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002", "A002"],
+            "BANK":    ["BK1",  "BK1",  "BK2",  "BK2"],
+        })
+        rule = _make_rule("consistent", key_field="ACCOUNT", target_field="BANK")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_consistent_fails_when_target_differs_within_key(self):
+        """Rows in a key group with conflicting target values produce violations."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002"],
+            "BANK":    ["BK1",  "BK2",  "BK3"],
+        })
+        rule = _make_rule("consistent", key_field="ACCOUNT", target_field="BANK")
+        violations = CrossRowValidator().validate(rule, df)
+        # Both rows 0 and 1 belong to A001 which is inconsistent
+        assert len(violations) == 2
+
+    def test_consistent_single_row_groups_always_pass(self):
+        """Single-row groups are trivially consistent."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A002", "A003"],
+            "BANK":    ["BK1",  "BK2",  "BK3"],
+        })
+        rule = _make_rule("consistent", key_field="ACCOUNT", target_field="BANK")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_consistent_missing_key_column_returns_empty(self):
+        df = pd.DataFrame({"BANK": ["BK1", "BK2"]})
+        rule = _make_rule("consistent", key_field="ACCOUNT", target_field="BANK")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_consistent_missing_target_column_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": ["A001", "A001"]})
+        rule = _make_rule("consistent", key_field="ACCOUNT", target_field="BANK")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_consistent_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": pd.Series([], dtype=str),
+                           "BANK": pd.Series([], dtype=str)})
+        rule = _make_rule("consistent", key_field="ACCOUNT", target_field="BANK")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# sequential
+# ---------------------------------------------------------------------------
+
+class TestCheckSequential:
+    """Tests for the 'sequential' cross-row check."""
+
+    def test_sequential_passes_with_correct_sequence(self):
+        """No violations when sequence_field is 1,2,3,... within each key group."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A001", "A002", "A002"],
+            "ITEM":    [1,      2,      3,      1,      2],
+        })
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_sequential_fails_with_gap_in_sequence(self):
+        """Gap in sequence (1, 3 — missing 2) with 3 rows produces violations."""
+        # 3 rows in the group but values are {1, 3, 4} — missing 2, not 1..3
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A001"],
+            "ITEM":    [1,      3,      4],
+        })
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert len(violations) > 0
+
+    def test_sequential_fails_when_sequence_does_not_start_at_one(self):
+        """Sequence starting at 2 instead of 1 produces violations."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001"],
+            "ITEM":    [2,      3],
+        })
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert len(violations) > 0
+
+    def test_sequential_passes_with_out_of_order_rows(self):
+        """Rows need not be sorted; only the set of values matters (1..N)."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A001"],
+            "ITEM":    [3,      1,      2],
+        })
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_sequential_single_row_group_passes(self):
+        """A group with a single row should have sequence value of 1."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001"],
+            "ITEM":    [1],
+        })
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_sequential_missing_key_column_returns_empty(self):
+        df = pd.DataFrame({"ITEM": [1, 2, 3]})
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_sequential_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": pd.Series([], dtype=str),
+                           "ITEM": pd.Series([], dtype=int)})
+        rule = _make_rule("sequential", key_field="ACCOUNT", sequence_field="ITEM")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# group_count
+# ---------------------------------------------------------------------------
+
+class TestCheckGroupCount:
+    """Tests for the 'group_count' cross-row check."""
+
+    def test_group_count_passes_when_count_matches(self):
+        """No violations when actual row count equals the declared count field."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A001"],
+            "TXN_CNT": [3,      3,      3],
+        })
+        rule = _make_rule("group_count", key_field="ACCOUNT", count_field="TXN_CNT")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_group_count_fails_when_count_mismatches(self):
+        """Violation produced when declared count differs from actual row count."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A001"],
+            "TXN_CNT": [5,      5,      5],
+        })
+        rule = _make_rule("group_count", key_field="ACCOUNT", count_field="TXN_CNT")
+        violations = CrossRowValidator().validate(rule, df)
+        assert len(violations) > 0
+
+    def test_group_count_multiple_groups_partial_mismatch(self):
+        """Only the mismatched group generates violations."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002", "A002"],
+            "TXN_CNT": [2,      2,      3,      3],
+        })
+        rule = _make_rule("group_count", key_field="ACCOUNT", count_field="TXN_CNT")
+        violations = CrossRowValidator().validate(rule, df)
+        # A001 has count=2 actual=2 (pass); A002 has count=3 actual=2 (fail)
+        assert len(violations) == 2
+
+    def test_group_count_missing_key_column_returns_empty(self):
+        df = pd.DataFrame({"TXN_CNT": [2, 2]})
+        rule = _make_rule("group_count", key_field="ACCOUNT", count_field="TXN_CNT")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_group_count_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": pd.Series([], dtype=str),
+                           "TXN_CNT": pd.Series([], dtype=int)})
+        rule = _make_rule("group_count", key_field="ACCOUNT", count_field="TXN_CNT")
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# group_sum
+# ---------------------------------------------------------------------------
+
+class TestCheckGroupSum:
+    """Tests for the 'group_sum' cross-row check."""
+
+    def test_group_sum_passes_within_bounds(self):
+        """No violations when group sum is within [min_value, max_value]."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002"],
+            "AMOUNT":  [100.0,  200.0,  50.0],
+        })
+        rule = _make_rule(
+            "group_sum",
+            key_field="ACCOUNT",
+            sum_field="AMOUNT",
+            min_value=0,
+            max_value=500,
+        )
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_group_sum_fails_when_sum_exceeds_max(self):
+        """Violations produced for groups whose sum exceeds max_value."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002"],
+            "AMOUNT":  [400.0,  400.0,  50.0],  # A001 sum = 800 > 500
+        })
+        rule = _make_rule(
+            "group_sum",
+            key_field="ACCOUNT",
+            sum_field="AMOUNT",
+            min_value=0,
+            max_value=500,
+        )
+        violations = CrossRowValidator().validate(rule, df)
+        # Both A001 rows flagged; A002 is fine
+        assert len(violations) == 2
+
+    def test_group_sum_fails_when_sum_below_min(self):
+        """Violations produced for groups whose sum is below min_value."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001"],
+            "AMOUNT":  [10.0,   5.0],   # sum = 15 < 100
+        })
+        rule = _make_rule(
+            "group_sum",
+            key_field="ACCOUNT",
+            sum_field="AMOUNT",
+            min_value=100,
+            max_value=9999,
+        )
+        violations = CrossRowValidator().validate(rule, df)
+        assert len(violations) == 2
+
+    def test_group_sum_no_max_value_only_min(self):
+        """When max_value is absent, only min_value is enforced."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001"],
+            "AMOUNT":  [50.0],   # sum = 50 >= 10 (ok)
+        })
+        rule = _make_rule(
+            "group_sum",
+            key_field="ACCOUNT",
+            sum_field="AMOUNT",
+            min_value=10,
+        )
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_group_sum_missing_sum_column_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": ["A001", "A001"]})
+        rule = _make_rule(
+            "group_sum",
+            key_field="ACCOUNT",
+            sum_field="AMOUNT",
+            min_value=0,
+            max_value=999,
+        )
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+    def test_group_sum_empty_dataframe_returns_empty(self):
+        df = pd.DataFrame({"ACCOUNT": pd.Series([], dtype=str),
+                           "AMOUNT": pd.Series([], dtype=float)})
+        rule = _make_rule(
+            "group_sum",
+            key_field="ACCOUNT",
+            sum_field="AMOUNT",
+            min_value=0,
+            max_value=999,
+        )
+        violations = CrossRowValidator().validate(rule, df)
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Unknown check type
+# ---------------------------------------------------------------------------
+
+class TestUnknownCheckType:
+    """validate() must raise ValueError for an unrecognised check type."""
+
+    def test_unknown_check_raises_value_error(self):
+        df = pd.DataFrame({"X": [1, 2]})
+        rule = _make_rule("bogus_check", field="X")
+        with pytest.raises(ValueError, match="Unknown cross_row check"):
+            CrossRowValidator().validate(rule, df)
+
+
+# ---------------------------------------------------------------------------
+# RuleEngine integration — cross_row dispatch
+# ---------------------------------------------------------------------------
+
+class TestRuleEngineDispatchesCrossRow:
+    """RuleEngine must route cross_row rules to CrossRowValidator."""
+
+    def test_rule_engine_unique_via_cross_row_type(self):
+        """A cross_row rule with check=unique is dispatched and produces violations."""
+        df = pd.DataFrame({"ACCT": ["A001", "A001", "A002"]})
+        config = {
+            "rules": [
+                {
+                    "id": "CR1",
+                    "name": "Account must be unique",
+                    "type": "cross_row",
+                    "check": "unique",
+                    "field": "ACCT",
+                    "severity": "error",
+                    "enabled": True,
+                }
+            ]
+        }
+        from src.validators.rule_engine import RuleEngine
+        engine = RuleEngine(config)
+        violations = engine.validate(df)
+        assert len(violations) == 2  # rows 0 and 1 share A001
+
+    def test_rule_engine_cross_row_consistent_no_violations(self):
+        """cross_row consistent rule produces zero violations on clean data."""
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A002"],
+            "BANK":    ["BK1",  "BK1",  "BK2"],
+        })
+        config = {
+            "rules": [
+                {
+                    "id": "CR2",
+                    "name": "Bank consistent per account",
+                    "type": "cross_row",
+                    "check": "consistent",
+                    "key_field": "ACCOUNT",
+                    "target_field": "BANK",
+                    "severity": "error",
+                    "enabled": True,
+                }
+            ]
+        }
+        from src.validators.rule_engine import RuleEngine
+        engine = RuleEngine(config)
+        violations = engine.validate(df)
+        assert violations == []
+
+    def test_rule_engine_when_condition_applied_before_cross_row(self):
+        """The `when` filter is applied before passing rows to CrossRowValidator."""
+        # Only rows with STATUS=ACTIVE go to the unique check.
+        # A001 appears twice with STATUS=ACTIVE → violation.
+        # A003 appears twice with STATUS=INACTIVE → filtered out, no violation.
+        df = pd.DataFrame({
+            "ACCOUNT": ["A001", "A001", "A003", "A003"],
+            "STATUS":  ["ACTIVE", "ACTIVE", "INACTIVE", "INACTIVE"],
+        })
+        config = {
+            "rules": [
+                {
+                    "id": "CR3",
+                    "name": "Active accounts must be unique",
+                    "type": "cross_row",
+                    "check": "unique",
+                    "field": "ACCOUNT",
+                    "when": "STATUS = ACTIVE",
+                    "severity": "error",
+                    "enabled": True,
+                }
+            ]
+        }
+        from src.validators.rule_engine import RuleEngine
+        engine = RuleEngine(config)
+        violations = engine.validate(df)
+        assert len(violations) == 2
+        # All violations must reference ACTIVE rows (1-indexed rows 1 and 2)
+        row_numbers = {v.row_number for v in violations}
+        assert row_numbers == {1, 2}
+
+    def test_rule_engine_existing_field_validation_unchanged(self):
+        """Adding cross_row support must not break existing field_validation rules."""
+        df = pd.DataFrame({"STATUS": ["ACTIVE", "INVALID"]})
+        config = {
+            "rules": [
+                {
+                    "id": "R1",
+                    "name": "Status must be ACTIVE",
+                    "type": "field_validation",
+                    "field": "STATUS",
+                    "operator": "in",
+                    "values": ["ACTIVE"],
+                    "severity": "error",
+                    "enabled": True,
+                }
+            ]
+        }
+        from src.validators.rule_engine import RuleEngine
+        engine = RuleEngine(config)
+        violations = engine.validate(df)
+        assert len(violations) == 1
+        assert violations[0].row_number == 2
+
+    def test_rule_engine_issue_code_uses_cross_suffix(self):
+        """cross_row violations carry an issue_code ending in _CROSS."""
+        df = pd.DataFrame({"ACCT": ["DUP", "DUP"]})
+        config = {
+            "rules": [
+                {
+                    "id": "CR99",
+                    "name": "Unique account",
+                    "type": "cross_row",
+                    "check": "unique",
+                    "field": "ACCT",
+                    "severity": "error",
+                    "enabled": True,
+                }
+            ]
+        }
+        from src.validators.rule_engine import RuleEngine
+        violations = RuleEngine(config).validate(df)
+        assert all(v.issue_code.endswith("_CROSS") for v in violations)


### PR DESCRIPTION
## Summary
6 generic cross-row validation check types for the rules engine:
- `unique` / `unique_composite` — duplicate detection
- `consistent` — key-grouped value consistency
- `sequential` — ordered sequence within groups
- `group_count` / `group_sum` — aggregate checks

Fully generic — works with any field names, file formats, and DB workflows.

## Test plan
- [x] `pytest tests/unit/` — 897 passed, 83.96% coverage
- [x] 40 new cross-row tests covering all 6 check types + edge cases

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)