### PR TITLE
feat(validation): multi-record-type file support with cross-type rules (#161, #162)

### DIFF
--- a/config/multi-record/example_atoctran.yaml
+++ b/config/multi-record/example_atoctran.yaml
@@ -1,0 +1,91 @@
+# Multi-record config example for a generic batch file with header/detail/trailer.
+#
+# This file can be used as-is with:
+#   python -m src.main validate --file <your-file> --multi-record config/multi-record/example_atoctran.yaml
+#
+# Adjust the following to match your actual file layout:
+#   discriminator.position   - 1-indexed start column of the record-type code
+#   discriminator.length     - width of the record-type code in characters
+#   record_types.*.match     - the literal value that identifies each record type
+#   record_types.*.mapping   - path to the JSON mapping file for that record type
+#   record_types.*.rules     - (optional) path to the JSON rules file for that type
+#   record_types.*.expect    - cardinality: any | exactly_one | at_least_one
+
+discriminator:
+  field: REC_TYPE        # Logical name used in violation messages
+  position: 1            # 1-indexed start column of discriminator in each line
+  length: 3              # Number of characters to read
+
+record_types:
+  header:
+    match: "HDR"
+    mapping: "config/mappings/header_mapping.json"
+    # rules: "config/rules/header_rules.json"
+    expect: exactly_one
+
+  detail:
+    match: "DTL"
+    mapping: "config/mappings/detail_mapping.json"
+    # rules: "config/rules/detail_rules.json"
+    expect: at_least_one
+
+  trailer:
+    match: "TRL"
+    mapping: "config/mappings/trailer_mapping.json"
+    # rules: "config/rules/trailer_rules.json"
+    expect: exactly_one
+
+# Uncomment and adapt the cross-type rules below as needed.
+cross_type_rules:
+
+  # Ensure detail rows are present when a header is found.
+  - check: required_companion
+    when_type: header
+    requires_type: detail
+    severity: error
+    message: "File has a header record but no detail records."
+
+  # Trailer RECORD_COUNT field must match the actual number of detail rows.
+  - check: header_trailer_count
+    record_type: trailer
+    trailer_field: RECORD_COUNT   # field in the trailer that holds the count
+    count_of: detail              # which record type to count
+    severity: error
+    message: "Trailer RECORD_COUNT does not match actual number of detail rows."
+
+  # Trailer TOTAL_AMOUNT must equal sum of AMOUNT across all detail rows.
+  - check: header_trailer_sum
+    record_type: trailer
+    trailer_field: TOTAL_AMOUNT   # field in the trailer that holds the total
+    sum_of:
+      - AMOUNT                    # field(s) in detail rows to sum
+    count_of: detail
+    severity: error
+    message: "Trailer TOTAL_AMOUNT does not match sum of detail AMOUNT fields."
+
+  # Header BATCH_ID must match trailer BATCH_ID.
+  - check: header_trailer_match
+    header_field: BATCH_ID
+    trailer_field: BATCH_ID
+    severity: error
+    message: "Header BATCH_ID does not match trailer BATCH_ID."
+
+  # Every detail row's BATCH_ID must equal the header BATCH_ID.
+  - check: header_detail_consistent
+    header_field: BATCH_ID
+    detail_field: BATCH_ID
+    severity: error
+    message: "A detail row BATCH_ID does not match the header BATCH_ID."
+
+  # Record types must appear in this order: header, then detail, then trailer.
+  - check: type_sequence
+    expected_order:
+      - header
+      - detail
+      - trailer
+    severity: error
+    message: "Record types appear out of expected order (header → detail → trailer)."
+
+# What to do when a line's discriminator value does not match any record type above.
+# Options: warn (default), error, skip
+default_action: warn

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1185,6 +1185,138 @@ with open("data.txt", "rb") as f:
 
 ---
 
+## Multi-Record-Type File Validation
+
+Some batch files contain multiple record types in a single file (e.g. a header row, one or more detail rows, and a trailer row) distinguished by a fixed-position discriminator field.  Use the `--multi-record` option on the `validate` command to validate these files.
+
+### How It Works
+
+1. A YAML config file describes the discriminator (position + length), each record type (discriminator value, mapping, rules, expected count), and optional cross-type rules.
+2. Valdo reads every line, extracts the discriminator value, and routes each line to the appropriate record type group.
+3. Per-type schema/rules validation runs using each type's mapping and rules files (if provided).
+4. Cross-type rules check relationships across groups (count consistency, sum checks, sequence order, etc.).
+5. The aggregate result is printed to stdout and optionally saved as JSON.
+
+### CLI Usage
+
+```bash
+# Basic usage
+python -m src.main validate \
+  --file data/batch_file.txt \
+  --multi-record config/multi-record/example_atoctran.yaml
+
+# Save the result to a JSON report
+python -m src.main validate \
+  --file data/batch_file.txt \
+  --multi-record config/multi-record/example_atoctran.yaml \
+  --output reports/batch_validation.json
+```
+
+### Config File Structure
+
+```yaml
+discriminator:
+  field: REC_TYPE      # Logical name (used in violation messages)
+  position: 1          # 1-indexed start column of discriminator
+  length: 3            # Character width of discriminator value
+
+record_types:
+  header:
+    match: "HDR"       # Discriminator value for this type
+    mapping: "config/mappings/header_mapping.json"
+    expect: exactly_one   # exactly_one | at_least_one | any
+
+  detail:
+    match: "DTL"
+    mapping: "config/mappings/detail_mapping.json"
+    rules: "config/rules/detail_rules.json"
+    expect: at_least_one
+
+  trailer:
+    match: "TRL"
+    mapping: "config/mappings/trailer_mapping.json"
+    expect: exactly_one
+
+# Optional: positional overrides (first/last row gets assigned regardless of value)
+# header:
+#   position: first
+#   mapping: ...
+
+cross_type_rules:
+  - check: required_companion
+    when_type: header
+    requires_type: detail
+    message: "No detail rows found."
+
+  - check: header_trailer_count
+    record_type: trailer
+    trailer_field: RECORD_COUNT
+    count_of: detail
+
+  - check: header_trailer_sum
+    record_type: trailer
+    trailer_field: TOTAL_AMOUNT
+    sum_of: [AMOUNT]
+    count_of: detail
+
+  - check: header_trailer_match
+    header_field: BATCH_ID
+    trailer_field: BATCH_ID
+
+  - check: header_detail_consistent
+    header_field: BATCH_ID
+    detail_field: BATCH_ID
+
+  - check: type_sequence
+    expected_order: [header, detail, trailer]
+
+  - check: expect_count
+    record_type: header
+    exactly: 1
+
+default_action: warn   # warn | error | skip for unrecognized record types
+```
+
+### Cross-Type Rule Reference
+
+| `check`                   | Required fields                              | Description |
+|---------------------------|----------------------------------------------|-------------|
+| `required_companion`      | `when_type`, `requires_type`                 | If `when_type` rows exist, `requires_type` rows must also exist. |
+| `header_trailer_count`    | `record_type`, `trailer_field`, `count_of`   | Count field in `record_type` must equal number of `count_of` rows. |
+| `header_trailer_sum`      | `record_type`, `trailer_field`, `sum_of`, `count_of` | Sum field in `record_type` must equal sum of `sum_of` fields in `count_of` rows. |
+| `header_detail_consistent`| `header_field`, `detail_field`               | All detail row values of `detail_field` must match the header's `header_field`. |
+| `header_trailer_match`    | `header_field`, `trailer_field`              | Header and trailer field values must be equal. |
+| `type_sequence`           | `expected_order`                             | Record types must appear in the declared order. |
+| `expect_count`            | `record_type`, `exactly`                     | Record type group must contain exactly `exactly` rows. |
+
+### API: Generate Config File
+
+```
+POST /api/v1/multi-record/generate
+Content-Type: application/json
+
+{
+  "discriminator": {"field": "REC_TYPE", "position": 1, "length": 3},
+  "record_types": {
+    "header":  {"match": "HDR", "mapping": "config/mappings/hdr.json", "expect": "exactly_one"},
+    "detail":  {"match": "DTL", "mapping": "config/mappings/dtl.json", "expect": "at_least_one"},
+    "trailer": {"match": "TRL", "mapping": "config/mappings/trl.json", "expect": "exactly_one"}
+  },
+  "cross_type_rules": [
+    {"check": "required_companion", "when_type": "header", "requires_type": "detail"}
+  ],
+  "default_action": "warn"
+}
+```
+
+Returns a `.yaml` file download ready to use with `--multi-record`.
+
+### Example Config
+
+See `config/multi-record/example_atoctran.yaml` for a fully commented example.
+
+---
+
 ## Troubleshooting
 
 ### API Server Won't Start

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -155,6 +155,10 @@ Configuration & Validators
    :members:
    :undoc-members:
 
+.. automodule:: src.config.multi_record_config
+   :members:
+   :undoc-members:
+
 .. automodule:: src.validators.mapping_validator
    :members:
    :undoc-members:
@@ -168,6 +172,14 @@ Configuration & Validators
    :undoc-members:
 
 .. automodule:: src.validators.cross_row_validator
+   :members:
+   :undoc-members:
+
+.. automodule:: src.validators.multi_record_validator
+   :members:
+   :undoc-members:
+
+.. automodule:: src.validators.cross_type_validator
    :members:
    :undoc-members:
 
@@ -269,6 +281,10 @@ Pipeline
    :undoc-members:
 
 .. automodule:: src.commands.etl_pipeline_command
+   :members:
+   :undoc-members:
+
+.. automodule:: src.commands.multi_record_command
    :members:
    :undoc-members:
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -20,6 +20,7 @@ from src.api.routers.runs import router as runs_router, schedule_router
 from src.api.routers import rules as rules_router_mod
 from src.api.routers.api_tester import router as api_tester_router
 from src.api.routers.webhook import router as webhook_router
+from src.api.routers.multi_record import router as multi_record_router
 from src.utils.cleanup import cleanup_old_files
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,12 @@ app.include_router(
     webhook_router,
     prefix="/api/v1/webhook",
     tags=["Webhook"]
+)
+app.include_router(
+    multi_record_router,
+    prefix="/api/v1/multi-record",
+    tags=["Multi-Record"],
+    dependencies=[Depends(require_api_key)],
 )
 
 # Serve generated reports

--- a/src/api/routers/multi_record.py
+++ b/src/api/routers/multi_record.py
@@ -1,0 +1,78 @@
+"""Multi-record config generation endpoint.
+
+Exposes ``POST /api/v1/multi-record/generate`` which accepts a JSON body
+describing the multi-record structure and returns a YAML file as a download.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import Response
+
+from src.config.multi_record_config import MultiRecordConfig
+
+router = APIRouter()
+
+
+@router.post(
+    "/generate",
+    summary="Generate a multi-record YAML config file",
+    response_description="YAML file as a downloadable attachment",
+)
+async def generate_multi_record_config(config: MultiRecordConfig) -> Response:
+    """Accept a multi-record config JSON body and return it as a YAML file download.
+
+    The returned file can be saved and used directly with the
+    ``validate --multi-record`` CLI option.
+
+    Args:
+        config: :class:`~src.config.multi_record_config.MultiRecordConfig` describing
+            the discriminator, record types, and optional cross-type rules.
+
+    Returns:
+        A ``application/x-yaml`` response containing the serialized YAML config,
+        with ``Content-Disposition: attachment; filename="multi_record_config.yaml"``.
+
+    Example request body::
+
+        {
+          "discriminator": {"field": "REC_TYPE", "position": 1, "length": 3},
+          "record_types": {
+            "header":  {"match": "HDR", "mapping": "config/mappings/hdr.json"},
+            "detail":  {"match": "DTL", "mapping": "config/mappings/dtl.json"},
+            "trailer": {"match": "TRL", "mapping": "config/mappings/trl.json", "expect": "exactly_one"}
+          },
+          "cross_type_rules": [
+            {"check": "required_companion", "when_type": "header", "requires_type": "detail"},
+            {"check": "header_trailer_count", "record_type": "trailer", "trailer_field": "RECORD_COUNT", "count_of": "detail"}
+          ],
+          "default_action": "warn"
+        }
+    """
+    import yaml
+
+    # Serialise via Pydantic's model_dump then to YAML.
+    data = config.model_dump(exclude_none=False)
+
+    # Convert record_types dicts: drop empty strings for cleaner YAML.
+    record_types_clean = {}
+    for key, val in data.get("record_types", {}).items():
+        if isinstance(val, dict):
+            record_types_clean[key] = {k: v for k, v in val.items() if v != ""}
+        else:
+            record_types_clean[key] = val
+    data["record_types"] = record_types_clean
+
+    # Drop empty cross_type_rules list for conciseness.
+    if not data.get("cross_type_rules"):
+        data.pop("cross_type_rules", None)
+
+    yaml_content = yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    return Response(
+        content=yaml_content,
+        media_type="application/x-yaml",
+        headers={
+            "Content-Disposition": 'attachment; filename="multi_record_config.yaml"'
+        },
+    )

--- a/src/commands/multi_record_command.py
+++ b/src/commands/multi_record_command.py
@@ -1,0 +1,108 @@
+"""CLI command handler for multi-record-type file validation.
+
+Thin orchestration layer: loads the YAML config, delegates to
+:class:`~src.validators.multi_record_validator.MultiRecordValidator`, and
+prints a human-readable summary to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+
+def run_multi_record_command(
+    file: str,
+    multi_record_config: str,
+    output: Optional[str],
+    logger,
+) -> None:
+    """Run multi-record validation and print results to stdout.
+
+    Args:
+        file: Path to the data file to validate.
+        multi_record_config: Path to the YAML multi-record config file.
+        output: Optional output path (.json) for the aggregate result.
+        logger: Logger instance for error/info messages.
+
+    Raises:
+        SystemExit: Exits with code 1 when validation errors are found or the
+            config cannot be loaded.
+    """
+    import yaml
+
+    from src.config.multi_record_config import MultiRecordConfig
+    from src.validators.multi_record_validator import MultiRecordValidator
+
+    # --- Load YAML config ---
+    try:
+        with open(multi_record_config, encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+    except Exception as exc:
+        logger.error("Failed to load multi-record config '%s': %s", multi_record_config, exc)
+        sys.exit(1)
+
+    try:
+        config = MultiRecordConfig(**raw)
+    except Exception as exc:
+        logger.error("Invalid multi-record config: %s", exc)
+        sys.exit(1)
+
+    # --- Validate ---
+    validator = MultiRecordValidator()
+    result = validator.validate(file, config)
+
+    # --- Print summary ---
+    total = result.get("total_rows", 0)
+    cross_violations = result.get("cross_type_violations", [])
+    error_count = sum(1 for v in cross_violations if v.get("severity") == "error")
+    warning_count = sum(1 for v in cross_violations if v.get("severity") == "warning")
+
+    if result.get("valid"):
+        click.echo(click.style("✓ Multi-record validation passed", fg="green"))
+    else:
+        click.echo(click.style("✗ Multi-record validation failed", fg="red"))
+
+    click.echo(f"\nTotal Rows     : {total:,}")
+    click.echo(f"Error Count    : {error_count}")
+    click.echo(f"Warning Count  : {warning_count}")
+
+    type_results = result.get("record_type_results", {})
+    if type_results:
+        click.echo("\nRecord Type Summary:")
+        for type_name, type_result in type_results.items():
+            rows = type_result.get("total_rows", type_result.get("row_count", "?"))
+            valid = "✓" if type_result.get("valid", True) else "✗"
+            click.echo(f"  {valid} {type_name}: {rows} rows")
+
+    if cross_violations:
+        click.echo(click.style(f"\nCross-type violations ({len(cross_violations)}):", fg="yellow"))
+        for v in cross_violations[:10]:
+            sev_color = "red" if v.get("severity") == "error" else "yellow"
+            click.echo(
+                click.style(f"  • [{v.get('severity', 'unknown')}] {v.get('message', '')}", fg=sev_color)
+            )
+        if len(cross_violations) > 10:
+            click.echo(f"  ... and {len(cross_violations) - 10} more")
+
+    # --- Write output ---
+    if output:
+        Path(output).parent.mkdir(parents=True, exist_ok=True)
+        if output.lower().endswith(".json"):
+            with open(output, "w", encoding="utf-8") as fh:
+                json.dump(result, fh, indent=2)
+            click.echo(f"\n✓ Multi-record validation report: {output}")
+        else:
+            click.echo(
+                click.style(
+                    f"\nUnsupported output type '{Path(output).suffix}'. Use .json",
+                    fg="yellow",
+                )
+            )
+
+    if not result.get("valid"):
+        sys.exit(1)

--- a/src/config/multi_record_config.py
+++ b/src/config/multi_record_config.py
@@ -1,0 +1,155 @@
+"""Pydantic configuration models for multi-record-type file validation.
+
+Supports files that contain multiple record types identified by a discriminator
+field at a fixed position (e.g. header/detail/trailer batch files).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, field_validator
+
+
+class DiscriminatorConfig(BaseModel):
+    """Configuration for the field that identifies the record type.
+
+    The discriminator is a fixed-width substring extracted from each line
+    using 1-indexed ``position`` and ``length``.
+
+    Attributes:
+        field: Logical name for the discriminator field (used in messages).
+        position: 1-indexed start position of the discriminator in each line.
+        length: Number of characters to read from ``position``.
+    """
+
+    field: str
+    position: int
+    length: int
+
+    @field_validator("position")
+    @classmethod
+    def position_must_be_positive(cls, v: int) -> int:
+        """Validate that position is >= 1.
+
+        Args:
+            v: The position value.
+
+        Returns:
+            The validated position.
+
+        Raises:
+            ValueError: When position is less than 1.
+        """
+        if v < 1:
+            raise ValueError("position must be >= 1 (1-indexed)")
+        return v
+
+    @field_validator("length")
+    @classmethod
+    def length_must_be_positive(cls, v: int) -> int:
+        """Validate that length is >= 1.
+
+        Args:
+            v: The length value.
+
+        Returns:
+            The validated length.
+
+        Raises:
+            ValueError: When length is less than 1.
+        """
+        if v < 1:
+            raise ValueError("length must be >= 1")
+        return v
+
+
+class RecordTypeConfig(BaseModel):
+    """Configuration for a single record type within a multi-record file.
+
+    Attributes:
+        match: Discriminator value that identifies this record type (e.g. "HDR").
+            Leave empty when using ``position`` instead.
+        position: If "first", this type matches the first row.
+            If "last", this type matches the last row.
+            Leave empty to use ``match`` exclusively.
+        mapping: Path to the mapping JSON file for this record type.
+        rules: Path to the rules JSON file for this record type (optional).
+        expect: Cardinality expectation.  One of:
+            ``exactly_one`` — exactly one row of this type must appear.
+            ``at_least_one`` — at least one row must appear.
+            ``any`` — any number (including zero) is acceptable.
+    """
+
+    match: str = ""
+    position: str = ""
+    mapping: str
+    rules: str = ""
+    expect: str = "any"
+
+
+class CrossTypeRule(BaseModel):
+    """Configuration for a single cross-record-type validation rule.
+
+    Attributes:
+        check: Rule type name.  One of:
+            ``required_companion``, ``header_trailer_count``,
+            ``header_trailer_sum``, ``header_detail_consistent``,
+            ``header_trailer_match``, ``type_sequence``, ``expect_count``.
+        when_type: For ``required_companion`` — record type that triggers the check.
+        requires_type: For ``required_companion`` — record type that must also exist.
+        key_field: Key field name (reserved for future use).
+        trailer_field: Field name in the trailer / record_type row.
+        header_field: Field name in the header row.
+        detail_field: Field name in the detail row.
+        sum_field: Field name to sum (alias; ``sum_of`` supersedes this).
+        count_of: For ``header_trailer_count`` — which record type group to count.
+            Defaults to ``"detail"``.
+        sum_of: List of field names to sum for ``header_trailer_sum``.
+        expected_order: Ordered list of record type keys for ``type_sequence``.
+        record_type: Record type key targeted by this rule (for ``header_trailer_count``,
+            ``header_trailer_sum``, ``expect_count``).
+        exactly: Expected exact row count for ``expect_count``.  -1 means unchecked.
+        strict: When True, partial-order violations are errors (reserved for future use).
+        message: Custom violation message template.
+        severity: Violation severity.  One of ``"error"`` or ``"warning"``.
+    """
+
+    check: str
+    when_type: str = ""
+    requires_type: str = ""
+    key_field: str = ""
+    trailer_field: str = ""
+    header_field: str = ""
+    detail_field: str = ""
+    sum_field: str = ""
+    count_of: str = "detail"
+    sum_of: List[str] = []
+    expected_order: List[str] = []
+    record_type: str = ""
+    exactly: int = -1
+    strict: bool = False
+    message: str = ""
+    severity: str = "error"
+
+
+class MultiRecordConfig(BaseModel):
+    """Top-level configuration for multi-record-type file validation.
+
+    Attributes:
+        discriminator: How to extract the record-type identifier from each line.
+        record_types: Mapping from logical type name (e.g. ``"header"``) to its
+            :class:`RecordTypeConfig`.
+        cross_type_rules: List of :class:`CrossTypeRule` applied after per-type
+            validation.
+        default_action: Action to take when a line's discriminator does not match
+            any configured record type.  One of:
+            ``"warn"`` — emit a warning violation.
+            ``"error"`` — emit an error violation.
+            ``"skip"`` — silently discard the row.
+    """
+
+    discriminator: DiscriminatorConfig
+    record_types: dict
+    cross_type_rules: List[CrossTypeRule] = []
+    default_action: str = "warn"

--- a/src/main.py
+++ b/src/main.py
@@ -77,12 +77,19 @@ def parse(file, mapping, format, output, use_chunked, chunk_size):
               help='Parallel worker processes for chunked validation (1 disables parallel mode)')
 @click.option('--suppress-pii/--no-suppress-pii', default=True, show_default=True,
               help='Redact raw field values from HTML reports (default: enabled)')
+@click.option('--multi-record', default=None, type=click.Path(exists=True),
+              help='Multi-record YAML config for files with multiple record types')
 def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
-             strict_fixed_width, strict_level, workers, suppress_pii):
+             strict_fixed_width, strict_level, workers, suppress_pii, multi_record):
     """Validate file format and content."""
     logger = setup_logger('valdo', log_to_file=False)
 
     try:
+        if multi_record:
+            from src.commands.multi_record_command import run_multi_record_command
+            run_multi_record_command(file, multi_record, output, logger)
+            return
+
         from src.commands.validate_command import run_validate_command
         run_validate_command(
             file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,

--- a/src/validators/cross_type_validator.py
+++ b/src/validators/cross_type_validator.py
@@ -1,0 +1,475 @@
+"""Cross-record-type validation engine — issues #161/#162.
+
+Validates rules that span multiple record type groups within a single file.
+
+Supported check types:
+
+- ``required_companion``     -- if when_type present, requires_type must also exist
+- ``header_trailer_count``   -- trailer count field must match actual detail row count
+- ``header_trailer_sum``     -- trailer sum field must match sum of detail field values
+- ``header_detail_consistent`` -- header field value must match all detail field values
+- ``header_trailer_match``   -- header and trailer fields must have equal values
+- ``type_sequence``          -- record types must appear in declared order
+- ``expect_count``           -- record type group must have exactly N rows
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from src.config.multi_record_config import CrossTypeRule
+from src.validators.rule_engine import RuleViolation
+
+_logger = logging.getLogger(__name__)
+
+# Issue code prefix for cross-type violations.
+_ISSUE_PREFIX = "CT"
+
+
+class CrossTypeValidator:
+    """Validate rules that span multiple record-type groups.
+
+    Each check method accepts the grouped rows dict and a rule, and returns a
+    list of :class:`~src.validators.rule_engine.RuleViolation` objects.
+
+    The entry point is :meth:`validate`, which dispatches to the correct check
+    method based on ``rule.check``.
+    """
+
+    _DISPATCH: dict[str, str] = {
+        "required_companion": "_check_required_companion",
+        "header_trailer_count": "_check_header_trailer_count",
+        "header_trailer_sum": "_check_header_trailer_sum",
+        "header_detail_consistent": "_check_header_detail_consistent",
+        "header_trailer_match": "_check_header_trailer_match",
+        "type_sequence": "_check_type_sequence",
+        "expect_count": "_check_expect_count",
+    }
+
+    def validate(
+        self,
+        groups: Dict[str, List[Any]],
+        rules: List[CrossTypeRule],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Run all cross-type rules and return accumulated violations.
+
+        Args:
+            groups: Dict mapping record type name to list of row dicts.
+            rules: List of :class:`~src.config.multi_record_config.CrossTypeRule`
+                to evaluate.
+            all_rows_types: Ordered list of record type names, one per row
+                (used only by ``type_sequence``).
+
+        Returns:
+            List of :class:`~src.validators.rule_engine.RuleViolation` objects.
+            Empty list when all rules pass.
+
+        Raises:
+            ValueError: When ``rule.check`` is not a recognised check type.
+        """
+        violations: List[RuleViolation] = []
+        for rule in rules:
+            method_name = self._DISPATCH.get(rule.check)
+            if method_name is None:
+                raise ValueError(
+                    f"Unknown cross_type check: '{rule.check}'. "
+                    f"Supported: {sorted(self._DISPATCH)}"
+                )
+            method = getattr(self, method_name)
+            try:
+                result = method(rule, groups, all_rows_types)
+                violations.extend(result)
+            except Exception as exc:
+                _logger.warning(
+                    "cross_type check '%s' raised an exception: %s", rule.check, exc
+                )
+        return violations
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _make_violation(
+        self,
+        rule: CrossTypeRule,
+        field: str,
+        value: Any,
+        message: str,
+        row_number: int = 0,
+    ) -> RuleViolation:
+        """Build a :class:`~src.validators.rule_engine.RuleViolation`.
+
+        Args:
+            rule: The cross-type rule being evaluated.
+            field: Field name(s) for display.
+            value: Observed value for display.
+            message: Human-readable violation message.
+            row_number: 1-indexed row number (0 = file-level, not row-specific).
+
+        Returns:
+            Populated :class:`~src.validators.rule_engine.RuleViolation`.
+        """
+        check_upper = rule.check.upper().replace("_", "-")
+        issue_code = f"{_ISSUE_PREFIX}_{check_upper}"
+        display_message = rule.message if rule.message else message
+        return RuleViolation(
+            rule_id=f"CT_{rule.check}",
+            rule_name=rule.check,
+            severity=rule.severity,
+            row_number=row_number,
+            field=field,
+            value=value,
+            message=display_message,
+            issue_code=issue_code,
+        )
+
+    @staticmethod
+    def _get_field(row: Any, field_name: str) -> Any:
+        """Extract a field value from a row (dict) by name.
+
+        Args:
+            row: A row dict.
+            field_name: The field key to extract.
+
+        Returns:
+            The field value, or None if the field is absent or row is not a dict.
+        """
+        if isinstance(row, dict):
+            return row.get(field_name)
+        return None
+
+    # ------------------------------------------------------------------
+    # Check implementations
+    # ------------------------------------------------------------------
+
+    def _check_required_companion(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return a violation when when_type is present but requires_type is absent.
+
+        Args:
+            rule: Must have ``when_type`` and ``requires_type`` populated.
+            groups: Record type groups dict.
+            all_rows_types: Not used by this check.
+
+        Returns:
+            List with one violation if the companion is missing, else empty list.
+        """
+        when_rows = groups.get(rule.when_type, [])
+        requires_rows = groups.get(rule.requires_type, [])
+
+        if when_rows and not requires_rows:
+            msg = (
+                rule.message
+                or f"Record type '{rule.when_type}' is present but "
+                f"required companion '{rule.requires_type}' is absent."
+            )
+            return [
+                self._make_violation(
+                    rule,
+                    field=rule.requires_type,
+                    value=None,
+                    message=msg,
+                )
+            ]
+        return []
+
+    def _check_header_trailer_count(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return a violation when the count field in the record_type group does not
+        match the actual number of rows in the count_of group.
+
+        Args:
+            rule: Must have ``record_type``, ``trailer_field``, and ``count_of``.
+            groups: Record type groups dict.
+            all_rows_types: Not used by this check.
+
+        Returns:
+            List of violations (one per mismatched trailer row).
+        """
+        type_rows = groups.get(rule.record_type, [])
+        count_of_rows = groups.get(rule.count_of, [])
+        actual_count = len(count_of_rows)
+        violations: List[RuleViolation] = []
+
+        for row in type_rows:
+            declared = self._get_field(row, rule.trailer_field)
+            if declared is None:
+                continue
+            try:
+                declared_int = int(str(declared).strip())
+            except (ValueError, TypeError):
+                continue
+            if declared_int != actual_count:
+                msg = (
+                    rule.message
+                    or f"'{rule.record_type}' field '{rule.trailer_field}' declares "
+                    f"{declared_int} rows but '{rule.count_of}' has {actual_count}."
+                )
+                violations.append(
+                    self._make_violation(
+                        rule,
+                        field=rule.trailer_field,
+                        value=declared,
+                        message=msg,
+                    )
+                )
+        return violations
+
+    def _check_header_trailer_sum(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return a violation when the sum field in the record_type group does not
+        match the computed sum of detail field(s) in the count_of group.
+
+        Args:
+            rule: Must have ``record_type``, ``trailer_field``, ``sum_of``, and
+                ``count_of``.
+            groups: Record type groups dict.
+            all_rows_types: Not used by this check.
+
+        Returns:
+            List of violations (one per mismatched sum row).
+        """
+        type_rows = groups.get(rule.record_type, [])
+        count_of_rows = groups.get(rule.count_of, [])
+        violations: List[RuleViolation] = []
+
+        # Compute actual sum across all sum_of fields in count_of rows.
+        fields_to_sum = rule.sum_of or ([rule.sum_field] if rule.sum_field else [])
+        actual_sum: float = 0.0
+        for row in count_of_rows:
+            for field_name in fields_to_sum:
+                raw = self._get_field(row, field_name)
+                if raw is None:
+                    continue
+                try:
+                    actual_sum += float(str(raw).strip())
+                except (ValueError, TypeError):
+                    pass
+
+        for row in type_rows:
+            declared = self._get_field(row, rule.trailer_field)
+            if declared is None:
+                continue
+            try:
+                declared_float = float(str(declared).strip())
+            except (ValueError, TypeError):
+                continue
+            if abs(declared_float - actual_sum) > 1e-9:
+                msg = (
+                    rule.message
+                    or f"'{rule.record_type}' field '{rule.trailer_field}' declares "
+                    f"sum={declared_float} but computed sum={actual_sum} "
+                    f"from '{rule.count_of}' fields {fields_to_sum}."
+                )
+                violations.append(
+                    self._make_violation(
+                        rule,
+                        field=rule.trailer_field,
+                        value=declared,
+                        message=msg,
+                    )
+                )
+        return violations
+
+    def _check_header_detail_consistent(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return violations when any detail row's field value differs from the header.
+
+        Args:
+            rule: Must have ``header_field`` and ``detail_field``.
+                ``when_type`` defaults to ``"header"``; ``count_of`` defaults to
+                ``"detail"`` if not set.
+            groups: Record type groups dict.
+            all_rows_types: Not used by this check.
+
+        Returns:
+            One violation per inconsistent detail row.
+        """
+        header_type = rule.when_type or "header"
+        detail_type = rule.count_of or "detail"
+        header_rows = groups.get(header_type, [])
+        detail_rows = groups.get(detail_type, [])
+        violations: List[RuleViolation] = []
+
+        if not header_rows:
+            return violations
+
+        header_value = self._get_field(header_rows[0], rule.header_field)
+        if header_value is None:
+            return violations
+        header_str = str(header_value).strip()
+
+        for idx, row in enumerate(detail_rows):
+            detail_value = self._get_field(row, rule.detail_field)
+            if detail_value is None:
+                continue
+            if str(detail_value).strip() != header_str:
+                msg = (
+                    rule.message
+                    or f"Detail row {idx + 1} field '{rule.detail_field}' value "
+                    f"'{detail_value}' does not match header field "
+                    f"'{rule.header_field}' value '{header_value}'."
+                )
+                violations.append(
+                    self._make_violation(
+                        rule,
+                        field=rule.detail_field,
+                        value=detail_value,
+                        message=msg,
+                        row_number=idx + 1,
+                    )
+                )
+        return violations
+
+    def _check_header_trailer_match(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return a violation when header and trailer field values do not match.
+
+        Args:
+            rule: Must have ``header_field`` and ``trailer_field``.
+                ``when_type`` defaults to ``"header"``; ``record_type`` defaults to
+                ``"trailer"``.
+            groups: Record type groups dict.
+            all_rows_types: Not used by this check.
+
+        Returns:
+            List with one violation if values differ, else empty list.
+        """
+        header_type = rule.when_type or "header"
+        trailer_type = rule.record_type or "trailer"
+        header_rows = groups.get(header_type, [])
+        trailer_rows = groups.get(trailer_type, [])
+        violations: List[RuleViolation] = []
+
+        if not header_rows or not trailer_rows:
+            return violations
+
+        header_value = self._get_field(header_rows[0], rule.header_field)
+        trailer_value = self._get_field(trailer_rows[0], rule.trailer_field)
+
+        if header_value is None or trailer_value is None:
+            return violations
+
+        if str(header_value).strip() != str(trailer_value).strip():
+            msg = (
+                rule.message
+                or f"Header '{rule.header_field}'='{header_value}' does not match "
+                f"trailer '{rule.trailer_field}'='{trailer_value}'."
+            )
+            violations.append(
+                self._make_violation(
+                    rule,
+                    field=f"{rule.header_field}/{rule.trailer_field}",
+                    value=f"{header_value} vs {trailer_value}",
+                    message=msg,
+                )
+            )
+        return violations
+
+    def _check_type_sequence(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return a violation when record types do not appear in expected order.
+
+        Order is determined by the position of the *first* occurrence of each
+        type in ``all_rows_types``.
+
+        Args:
+            rule: Must have ``expected_order`` (list of record type names).
+            groups: Not used directly by this check.
+            all_rows_types: Ordered list of record type names (one per row).
+
+        Returns:
+            List with one violation if order is wrong, else empty list.
+        """
+        expected = rule.expected_order
+        if not expected or not all_rows_types:
+            return []
+
+        # Build the observed first-occurrence order, skipping None/unknown.
+        seen_order: list[str] = []
+        seen_set: set[str] = set()
+        for t in all_rows_types:
+            if t and t not in seen_set and t in expected:
+                seen_order.append(t)
+                seen_set.add(t)
+
+        # Compute the expected subsequence (only types that actually appear).
+        expected_filtered = [t for t in expected if t in seen_set]
+
+        if seen_order != expected_filtered:
+            msg = (
+                rule.message
+                or f"Record type sequence {seen_order} does not match "
+                f"expected order {expected_filtered}."
+            )
+            return [
+                self._make_violation(
+                    rule,
+                    field="record_type_sequence",
+                    value=str(seen_order),
+                    message=msg,
+                )
+            ]
+        return []
+
+    def _check_expect_count(
+        self,
+        rule: CrossTypeRule,
+        groups: Dict[str, List[Any]],
+        all_rows_types: List[str],
+    ) -> List[RuleViolation]:
+        """Return a violation when a group's row count does not match ``exactly``.
+
+        Args:
+            rule: Must have ``record_type`` and ``exactly`` (>= 0).
+            groups: Record type groups dict.
+            all_rows_types: Not used by this check.
+
+        Returns:
+            List with one violation if count mismatches, else empty list.
+        """
+        if rule.exactly < 0:
+            return []
+
+        actual = len(groups.get(rule.record_type, []))
+        if actual != rule.exactly:
+            msg = (
+                rule.message
+                or f"Expected exactly {rule.exactly} row(s) for record type "
+                f"'{rule.record_type}' but found {actual}."
+            )
+            return [
+                self._make_violation(
+                    rule,
+                    field="row_count",
+                    value=actual,
+                    message=msg,
+                )
+            ]
+        return []

--- a/src/validators/multi_record_validator.py
+++ b/src/validators/multi_record_validator.py
@@ -1,0 +1,404 @@
+"""Multi-record-type file validation — issues #161/#162.
+
+Validates files that contain multiple record types identified by a discriminator
+field at a fixed byte position (e.g. header/detail/trailer batch files).
+
+Workflow:
+1. Read the file line by line.
+2. Extract the discriminator value from each line.
+3. Identify which record type each line belongs to (by value, or by position).
+4. Group rows by record type.
+5. Enforce ``expect`` cardinality constraints on each type.
+6. Optionally run per-type validation via :func:`~src.services.validate_service.run_validate_service`.
+7. Run cross-type rules via :class:`~src.validators.cross_type_validator.CrossTypeValidator`.
+8. Return an aggregate result dict.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.config.multi_record_config import (
+    CrossTypeRule,
+    DiscriminatorConfig,
+    MultiRecordConfig,
+    RecordTypeConfig,
+)
+from src.validators.cross_type_validator import CrossTypeValidator
+from src.validators.rule_engine import RuleViolation
+
+_logger = logging.getLogger(__name__)
+
+# Sentinel for rows that couldn't be identified.
+_UNKNOWN_TYPE = "__unknown__"
+
+
+class MultiRecordValidator:
+    """Validate a file containing multiple record types.
+
+    Usage::
+
+        from src.config.multi_record_config import MultiRecordConfig
+        from src.validators.multi_record_validator import MultiRecordValidator
+
+        config = MultiRecordConfig(...)
+        result = MultiRecordValidator().validate("path/to/file.txt", config)
+    """
+
+    def validate(self, file_path: str, config: MultiRecordConfig) -> Dict[str, Any]:
+        """Validate a multi-record file against the given configuration.
+
+        Steps:
+            1. Read and group all rows by record type.
+            2. Emit violations for unknown rows according to ``default_action``.
+            3. Enforce ``expect`` cardinality on each configured record type.
+            4. Run per-type schema/rules validation when a mapping path is given.
+            5. Run cross-type rules.
+            6. Return an aggregate result dict.
+
+        Args:
+            file_path: Path to the multi-record data file.
+            config: :class:`~src.config.multi_record_config.MultiRecordConfig`
+                describing the file structure.
+
+        Returns:
+            Dict with keys:
+              - ``total_rows`` (int): Total non-empty lines in the file.
+              - ``record_type_results`` (dict): Per-type validation results.
+              - ``cross_type_violations`` (list[dict]): Cross-type rule violations.
+              - ``valid`` (bool): True when no error-severity violations exist.
+        """
+        groups, all_rows_types, total_rows = self._read_and_group(file_path, config)
+
+        cross_type_violations: List[RuleViolation] = []
+
+        # --- Handle unknown rows ---
+        unknown_rows = groups.pop(_UNKNOWN_TYPE, [])
+        if unknown_rows:
+            cross_type_violations.extend(
+                self._handle_unknown_rows(unknown_rows, config)
+            )
+
+        # --- Enforce expect cardinality ---
+        cross_type_violations.extend(
+            self._enforce_expect(groups, config)
+        )
+
+        # --- Per-type validation ---
+        record_type_results: Dict[str, Any] = {}
+        for type_name, type_config in config.record_types.items():
+            rows = groups.get(type_name, [])
+            if rows and type_config.mapping:
+                try:
+                    result = self._validate_record_group(
+                        type_name, rows, type_config
+                    )
+                    record_type_results[type_name] = result
+                except Exception as exc:
+                    _logger.warning(
+                        "Per-type validation for '%s' failed: %s", type_name, exc
+                    )
+                    record_type_results[type_name] = {
+                        "error": str(exc),
+                        "valid": False,
+                    }
+            else:
+                record_type_results[type_name] = {
+                    "row_count": len(rows),
+                    "valid": True,
+                    "skipped": "no_mapping" if not type_config.mapping else "no_rows",
+                }
+
+        # --- Cross-type rules ---
+        cross_type_validator = CrossTypeValidator()
+        cross_type_violations.extend(
+            cross_type_validator.validate(groups, config.cross_type_rules, all_rows_types)
+        )
+
+        # Determine overall validity: any error-severity violation makes it invalid.
+        has_errors = any(
+            v.severity == "error" for v in cross_type_violations
+        )
+        # Also propagate per-type errors.
+        for type_result in record_type_results.values():
+            if not type_result.get("valid", True):
+                has_errors = True
+                break
+
+        return {
+            "total_rows": total_rows,
+            "record_type_results": record_type_results,
+            "cross_type_violations": [v.to_dict() for v in cross_type_violations],
+            "valid": not has_errors,
+        }
+
+    # ------------------------------------------------------------------
+    # Public helpers (used by tests)
+    # ------------------------------------------------------------------
+
+    def _group_rows(
+        self, file_path: str, config: MultiRecordConfig
+    ) -> Dict[str, List[str]]:
+        """Group raw lines by record type name.
+
+        Exposed for unit testing the grouping logic independently.
+
+        Args:
+            file_path: Path to the data file.
+            config: Multi-record configuration.
+
+        Returns:
+            Dict mapping type name (or ``_UNKNOWN_TYPE``) to list of raw line strings.
+        """
+        groups, _, _ = self._read_and_group(file_path, config)
+        return groups
+
+    # ------------------------------------------------------------------
+    # Internal implementation
+    # ------------------------------------------------------------------
+
+    def _read_and_group(
+        self, file_path: str, config: MultiRecordConfig
+    ) -> Tuple[Dict[str, List[str]], List[str], int]:
+        """Read the file and group lines by record type.
+
+        Args:
+            file_path: Path to the data file.
+            config: Multi-record configuration.
+
+        Returns:
+            Tuple of:
+              - groups: Dict mapping type name to list of line strings.
+              - all_rows_types: Ordered list of type names (one per line).
+              - total_rows: Total number of non-empty lines.
+        """
+        lines: List[str] = []
+        try:
+            with open(file_path, encoding="utf-8", errors="replace") as fh:
+                lines = [line.rstrip("\n\r") for line in fh if line.strip()]
+        except OSError as exc:
+            _logger.error("Cannot open file '%s': %s", file_path, exc)
+            return {}, [], 0
+
+        total_rows = len(lines)
+
+        groups: Dict[str, List[str]] = {name: [] for name in config.record_types}
+        groups[_UNKNOWN_TYPE] = []
+        all_rows_types: List[str] = []
+
+        for idx, line in enumerate(lines):
+            disc_value = self._extract_discriminator(line, config.discriminator)
+            type_name = self._identify_record_type(
+                disc_value, idx, total_rows, config
+            )
+            if type_name is None:
+                groups[_UNKNOWN_TYPE].append(line)
+                all_rows_types.append(None)
+            else:
+                groups[type_name].append(line)
+                all_rows_types.append(type_name)
+
+        return groups, all_rows_types, total_rows
+
+    def _extract_discriminator(
+        self, line: str, disc: DiscriminatorConfig
+    ) -> str:
+        """Extract the discriminator value from a line using position/length.
+
+        The position is 1-indexed. For example, ``position=1, length=3`` extracts
+        characters 0-2 (0-indexed).
+
+        Args:
+            line: A single raw line from the file.
+            disc: Discriminator configuration specifying position and length.
+
+        Returns:
+            Stripped substring, or empty string if the line is too short.
+        """
+        start = disc.position - 1  # Convert to 0-indexed
+        end = start + disc.length
+        if len(line) < start + 1:
+            return ""
+        return line[start:end].strip()
+
+    def _identify_record_type(
+        self,
+        value: str,
+        row_index: int,
+        total_rows: int,
+        config: MultiRecordConfig,
+    ) -> Optional[str]:
+        """Match a discriminator value to a configured record type name.
+
+        Matching priority:
+        1. If ``row_index == 0`` and any type has ``position="first"``, that type wins.
+        2. If ``row_index == total_rows - 1`` and any type has ``position="last"``, that type wins.
+        3. Otherwise, the first type whose ``match`` equals ``value`` wins.
+
+        Args:
+            value: Extracted discriminator string.
+            row_index: 0-indexed row position in the file.
+            total_rows: Total number of non-empty rows.
+            config: Multi-record configuration.
+
+        Returns:
+            Record type name string, or None if no type matches.
+        """
+        # Check positional overrides first.
+        if row_index == 0:
+            for type_name, type_config in config.record_types.items():
+                if type_config.position == "first":
+                    return type_name
+
+        if total_rows > 0 and row_index == total_rows - 1:
+            for type_name, type_config in config.record_types.items():
+                if type_config.position == "last":
+                    return type_name
+
+        # Fall back to value matching.
+        for type_name, type_config in config.record_types.items():
+            if type_config.match and type_config.match == value:
+                return type_name
+
+        return None
+
+    def _handle_unknown_rows(
+        self, unknown_rows: List[str], config: MultiRecordConfig
+    ) -> List[RuleViolation]:
+        """Generate violations for unrecognized record type lines.
+
+        Args:
+            unknown_rows: List of raw lines that did not match any configured type.
+            config: Multi-record configuration (used for ``default_action``).
+
+        Returns:
+            List of :class:`~src.validators.rule_engine.RuleViolation` objects,
+            or empty list when ``default_action="skip"``.
+        """
+        if config.default_action == "skip":
+            return []
+
+        severity = "error" if config.default_action == "error" else "warning"
+        violations: List[RuleViolation] = []
+
+        for idx, line in enumerate(unknown_rows):
+            disc_value = self._extract_discriminator(line, config.discriminator)
+            violations.append(
+                RuleViolation(
+                    rule_id="CT_UNKNOWN_RECORD_TYPE",
+                    rule_name="unknown_record_type",
+                    severity=severity,
+                    row_number=idx + 1,
+                    field=config.discriminator.field,
+                    value=disc_value,
+                    message=(
+                        f"Unrecognized record type: discriminator value "
+                        f"'{disc_value}' does not match any configured type."
+                    ),
+                    issue_code="CT_UNKNOWN",
+                )
+            )
+        return violations
+
+    def _enforce_expect(
+        self,
+        groups: Dict[str, List[str]],
+        config: MultiRecordConfig,
+    ) -> List[RuleViolation]:
+        """Enforce ``expect`` cardinality constraints on each record type group.
+
+        Args:
+            groups: Dict mapping type name to list of grouped lines.
+            config: Multi-record configuration.
+
+        Returns:
+            List of :class:`~src.validators.rule_engine.RuleViolation` objects.
+        """
+        violations: List[RuleViolation] = []
+
+        for type_name, type_config in config.record_types.items():
+            count = len(groups.get(type_name, []))
+            expect = type_config.expect
+
+            if expect == "exactly_one" and count != 1:
+                violations.append(
+                    RuleViolation(
+                        rule_id="CT_EXPECT",
+                        rule_name="expect_cardinality",
+                        severity="error",
+                        row_number=0,
+                        field=type_name,
+                        value=count,
+                        message=(
+                            f"Expected exactly 1 row of type '{type_name}' "
+                            f"but found {count}."
+                        ),
+                        issue_code="CT_EXPECT_EXACTLY_ONE",
+                    )
+                )
+            elif expect == "at_least_one" and count < 1:
+                violations.append(
+                    RuleViolation(
+                        rule_id="CT_EXPECT",
+                        rule_name="expect_cardinality",
+                        severity="error",
+                        row_number=0,
+                        field=type_name,
+                        value=count,
+                        message=(
+                            f"Expected at least 1 row of type '{type_name}' "
+                            f"but found {count}."
+                        ),
+                        issue_code="CT_EXPECT_AT_LEAST_ONE",
+                    )
+                )
+
+        return violations
+
+    def _validate_record_group(
+        self,
+        record_type: str,
+        rows: List[str],
+        type_config: RecordTypeConfig,
+    ) -> Dict[str, Any]:
+        """Write grouped rows to a temp file and run per-type validation.
+
+        Args:
+            record_type: Logical record type name (for logging).
+            rows: List of raw line strings for this record type.
+            type_config: :class:`~src.config.multi_record_config.RecordTypeConfig`
+                containing the mapping and rules paths.
+
+        Returns:
+            Validation result dict from
+            :func:`~src.services.validate_service.run_validate_service`.
+        """
+        from src.services.validate_service import run_validate_service
+
+        # Write rows to a temp file for the validate service.
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".txt",
+            delete=False,
+            encoding="utf-8",
+            prefix=f"valdo_mr_{record_type}_",
+        ) as tmp:
+            tmp.write("\n".join(rows))
+            tmp_path = tmp.name
+
+        try:
+            result = run_validate_service(
+                file=tmp_path,
+                mapping=type_config.mapping or None,
+                rules=type_config.rules or None,
+            )
+        finally:
+            try:
+                Path(tmp_path).unlink()
+            except OSError:
+                pass
+
+        return result

--- a/tests/unit/test_multi_record_validator.py
+++ b/tests/unit/test_multi_record_validator.py
@@ -1,0 +1,783 @@
+"""Tests for MultiRecordValidator and CrossTypeValidator — issues #161/#162.
+
+Covers:
+- Discriminator extraction (various positions/lengths)
+- Record type routing (multiple types correctly grouped)
+- Header/trailer detection by value AND by position (first/last)
+- Unknown record type handling (warn/error/skip)
+- expect: exactly_one enforcement
+- Cross-type: required_companion
+- Cross-type: header_trailer_count
+- Cross-type: header_trailer_sum
+- Cross-type: header_detail_consistent
+- Cross-type: header_trailer_match
+- Cross-type: type_sequence
+- Cross-type: expect_count
+- Empty file, single-row file
+- Integration: end-to-end validate with multi-record config
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from src.config.multi_record_config import (
+    CrossTypeRule,
+    DiscriminatorConfig,
+    MultiRecordConfig,
+    RecordTypeConfig,
+)
+from src.validators.cross_type_validator import CrossTypeValidator
+from src.validators.multi_record_validator import MultiRecordValidator
+from src.validators.rule_engine import RuleViolation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_disc(position: int = 1, length: int = 3) -> DiscriminatorConfig:
+    """Return a DiscriminatorConfig for tests."""
+    return DiscriminatorConfig(field="REC_TYPE", position=position, length=length)
+
+
+def _make_config(
+    disc: DiscriminatorConfig | None = None,
+    record_types: dict | None = None,
+    cross_type_rules: list | None = None,
+    default_action: str = "warn",
+) -> MultiRecordConfig:
+    """Return a minimal MultiRecordConfig for tests."""
+    if disc is None:
+        disc = _make_disc()
+    if record_types is None:
+        record_types = {
+            "header": RecordTypeConfig(match="HDR", mapping=""),
+            "detail": RecordTypeConfig(match="DTL", mapping=""),
+            "trailer": RecordTypeConfig(match="TRL", mapping=""),
+        }
+    return MultiRecordConfig(
+        discriminator=disc,
+        record_types=record_types,
+        cross_type_rules=cross_type_rules or [],
+        default_action=default_action,
+    )
+
+
+def _write_lines(lines: list[str], suffix: str = ".txt") -> Path:
+    """Write lines to a temp file and return the Path."""
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False, encoding="utf-8"
+    )
+    tmp.write("\n".join(lines))
+    tmp.close()
+    return Path(tmp.name)
+
+
+def _write_mapping(fields: list[dict]) -> Path:
+    """Write a minimal mapping JSON to a temp file and return the Path."""
+    mapping = {
+        "source": {"format": "pipe_delimited", "delimiter": "|", "has_header": False},
+        "fields": fields,
+    }
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    )
+    json.dump(mapping, tmp)
+    tmp.close()
+    return Path(tmp.name)
+
+
+# ---------------------------------------------------------------------------
+# DiscriminatorConfig
+# ---------------------------------------------------------------------------
+
+
+class TestDiscriminatorConfig:
+    """Tests for the DiscriminatorConfig Pydantic model."""
+
+    def test_valid_config_created(self):
+        """Model is created with expected field, position, and length."""
+        disc = DiscriminatorConfig(field="REC_TYPE", position=1, length=3)
+        assert disc.field == "REC_TYPE"
+        assert disc.position == 1
+        assert disc.length == 3
+
+    def test_position_must_be_positive(self):
+        """Position must be >= 1."""
+        with pytest.raises(Exception):
+            DiscriminatorConfig(field="X", position=0, length=3)
+
+    def test_length_must_be_positive(self):
+        """Length must be >= 1."""
+        with pytest.raises(Exception):
+            DiscriminatorConfig(field="X", position=1, length=0)
+
+
+# ---------------------------------------------------------------------------
+# _extract_discriminator
+# ---------------------------------------------------------------------------
+
+
+class TestExtractDiscriminator:
+    """Tests for MultiRecordValidator._extract_discriminator."""
+
+    def setup_method(self):
+        self.validator = MultiRecordValidator()
+
+    def test_extracts_from_start_of_line(self):
+        """Extracts correctly when position=1, length=3."""
+        disc = DiscriminatorConfig(field="T", position=1, length=3)
+        assert self.validator._extract_discriminator("HDR12345", disc) == "HDR"
+
+    def test_extracts_from_middle_of_line(self):
+        """Extracts from position=4, length=3 (0-indexed slice [3:6])."""
+        disc = DiscriminatorConfig(field="T", position=4, length=3)
+        assert self.validator._extract_discriminator("AAADTLBBB", disc) == "DTL"
+
+    def test_strips_trailing_whitespace(self):
+        """Extracted value is stripped."""
+        disc = DiscriminatorConfig(field="T", position=1, length=5)
+        assert self.validator._extract_discriminator("HDR  XYZ", disc) == "HDR"
+
+    def test_short_line_returns_empty_string(self):
+        """Returns '' when line is shorter than position+length."""
+        disc = DiscriminatorConfig(field="T", position=10, length=3)
+        assert self.validator._extract_discriminator("SHORTLINE", disc) == ""
+
+    def test_empty_line_returns_empty_string(self):
+        """Returns '' for an empty line."""
+        disc = DiscriminatorConfig(field="T", position=1, length=3)
+        assert self.validator._extract_discriminator("", disc) == ""
+
+
+# ---------------------------------------------------------------------------
+# _identify_record_type
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifyRecordType:
+    """Tests for MultiRecordValidator._identify_record_type."""
+
+    def setup_method(self):
+        self.validator = MultiRecordValidator()
+        self.config = _make_config()
+
+    def test_matches_by_value(self):
+        """Returns record type key when discriminator value matches."""
+        result = self.validator._identify_record_type("HDR", 0, 10, self.config)
+        assert result == "header"
+
+    def test_matches_detail(self):
+        """Returns detail key for 'DTL'."""
+        result = self.validator._identify_record_type("DTL", 3, 10, self.config)
+        assert result == "detail"
+
+    def test_matches_trailer_by_value(self):
+        """Returns trailer key for 'TRL'."""
+        result = self.validator._identify_record_type("TRL", 9, 10, self.config)
+        assert result == "trailer"
+
+    def test_first_row_matches_position_first(self):
+        """Row 0 matches a type configured with position='first' even if value differs."""
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="", position="first", mapping=""),
+                "detail": RecordTypeConfig(match="DTL", mapping=""),
+            }
+        )
+        result = self.validator._identify_record_type("DTL", 0, 5, config)
+        assert result == "header"
+
+    def test_last_row_matches_position_last(self):
+        """Last row matches a type configured with position='last' even if value differs."""
+        config = _make_config(
+            record_types={
+                "detail": RecordTypeConfig(match="DTL", mapping=""),
+                "trailer": RecordTypeConfig(match="", position="last", mapping=""),
+            }
+        )
+        result = self.validator._identify_record_type("DTL", 4, 5, config)
+        assert result == "trailer"
+
+    def test_unknown_value_returns_none(self):
+        """Returns None when no type matches the discriminator value."""
+        result = self.validator._identify_record_type("ZZZ", 3, 10, self.config)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Record grouping
+# ---------------------------------------------------------------------------
+
+
+class TestRecordGrouping:
+    """Tests that rows are grouped into the correct record types."""
+
+    def test_groups_three_record_types(self):
+        """Three different record type lines are split into three groups."""
+        lines = [
+            "HDR000001",
+            "DTL000002",
+            "DTL000003",
+            "TRL000004",
+        ]
+        file_path = _write_lines(lines)
+        config = _make_config()
+        validator = MultiRecordValidator()
+        groups = validator._group_rows(str(file_path), config)
+
+        assert len(groups["header"]) == 1
+        assert len(groups["detail"]) == 2
+        assert len(groups["trailer"]) == 1
+
+    def test_only_detail_rows(self):
+        """File with only detail rows produces one group."""
+        lines = ["DTL000001", "DTL000002"]
+        file_path = _write_lines(lines)
+        config = _make_config()
+        validator = MultiRecordValidator()
+        groups = validator._group_rows(str(file_path), config)
+
+        assert len(groups.get("detail", [])) == 2
+        assert len(groups.get("header", [])) == 0
+
+    def test_header_by_position_first(self):
+        """First row assigned to header even when it has a DTL discriminator value."""
+        lines = ["DTL000001", "DTL000002", "DTL000003"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="", position="first", mapping=""),
+                "detail": RecordTypeConfig(match="DTL", mapping=""),
+            }
+        )
+        validator = MultiRecordValidator()
+        groups = validator._group_rows(str(file_path), config)
+
+        assert len(groups.get("header", [])) == 1
+        assert len(groups.get("detail", [])) == 2
+
+    def test_trailer_by_position_last(self):
+        """Last row assigned to trailer even when it has a DTL discriminator value."""
+        lines = ["DTL000001", "DTL000002", "DTL000003"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "detail": RecordTypeConfig(match="DTL", mapping=""),
+                "trailer": RecordTypeConfig(match="", position="last", mapping=""),
+            }
+        )
+        validator = MultiRecordValidator()
+        groups = validator._group_rows(str(file_path), config)
+
+        assert len(groups.get("trailer", [])) == 1
+        assert len(groups.get("detail", [])) == 2
+
+    def test_empty_file_returns_empty_groups(self):
+        """Empty file produces empty groups (no violations from grouping itself)."""
+        file_path = _write_lines([])
+        config = _make_config()
+        validator = MultiRecordValidator()
+        groups = validator._group_rows(str(file_path), config)
+        assert all(len(v) == 0 for v in groups.values())
+
+    def test_single_row_file(self):
+        """Single-row file is grouped correctly."""
+        lines = ["HDR000001"]
+        file_path = _write_lines(lines)
+        config = _make_config()
+        validator = MultiRecordValidator()
+        groups = validator._group_rows(str(file_path), config)
+        assert len(groups.get("header", [])) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unknown record type handling
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownRecordType:
+    """Tests for default_action: warn, error, skip."""
+
+    def test_unknown_warn_produces_warning_violation(self):
+        """default_action=warn produces a warning-severity violation for unknown rows."""
+        lines = ["HDR000001", "UNK000002"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={"header": RecordTypeConfig(match="HDR", mapping="")},
+            default_action="warn",
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        unknown_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "unknown" in v.get("message", "").lower() or "unrecognized" in v.get("message", "").lower()
+        ]
+        assert len(unknown_violations) >= 1
+        assert unknown_violations[0]["severity"] == "warning"
+
+    def test_unknown_error_produces_error_violation(self):
+        """default_action=error produces an error-severity violation for unknown rows."""
+        lines = ["HDR000001", "UNK000002"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={"header": RecordTypeConfig(match="HDR", mapping="")},
+            default_action="error",
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        unknown_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "unknown" in v.get("message", "").lower() or "unrecognized" in v.get("message", "").lower()
+        ]
+        assert len(unknown_violations) >= 1
+        assert unknown_violations[0]["severity"] == "error"
+
+    def test_unknown_skip_produces_no_violations(self):
+        """default_action=skip silently discards unknown rows without a violation."""
+        lines = ["HDR000001", "UNK000002"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={"header": RecordTypeConfig(match="HDR", mapping="")},
+            default_action="skip",
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        unknown_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "unknown" in v.get("message", "").lower() or "unrecognized" in v.get("message", "").lower()
+        ]
+        assert len(unknown_violations) == 0
+
+
+# ---------------------------------------------------------------------------
+# expect enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestExpectEnforcement:
+    """Tests for RecordTypeConfig.expect field."""
+
+    def test_exactly_one_passes_when_one_row(self):
+        """expect=exactly_one does not produce a violation when one row exists."""
+        lines = ["HDR000001", "DTL000002"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="HDR", mapping="", expect="exactly_one"),
+                "detail": RecordTypeConfig(match="DTL", mapping="", expect="any"),
+            }
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        expect_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "expect" in v.get("message", "").lower() or "exactly" in v.get("message", "").lower()
+        ]
+        assert len(expect_violations) == 0
+
+    def test_exactly_one_fails_when_zero_rows(self):
+        """expect=exactly_one produces a violation when record type is absent."""
+        lines = ["DTL000002"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="HDR", mapping="", expect="exactly_one"),
+                "detail": RecordTypeConfig(match="DTL", mapping="", expect="any"),
+            }
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        expect_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "header" in v.get("message", "").lower()
+        ]
+        assert len(expect_violations) >= 1
+
+    def test_exactly_one_fails_when_two_rows(self):
+        """expect=exactly_one produces a violation when two rows match."""
+        lines = ["HDR000001", "HDR000002", "DTL000003"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="HDR", mapping="", expect="exactly_one"),
+                "detail": RecordTypeConfig(match="DTL", mapping="", expect="any"),
+            }
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        expect_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "header" in v.get("message", "").lower()
+        ]
+        assert len(expect_violations) >= 1
+
+    def test_at_least_one_passes_when_one_row(self):
+        """expect=at_least_one passes when one or more rows exist."""
+        lines = ["DTL000001"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "detail": RecordTypeConfig(match="DTL", mapping="", expect="at_least_one"),
+            }
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        violations = result.get("cross_type_violations", [])
+        assert len(violations) == 0
+
+    def test_at_least_one_fails_when_absent(self):
+        """expect=at_least_one produces a violation when record type is absent."""
+        lines = ["HDR000001"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="HDR", mapping="", expect="any"),
+                "detail": RecordTypeConfig(match="DTL", mapping="", expect="at_least_one"),
+            }
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        expect_violations = [
+            v for v in result.get("cross_type_violations", [])
+            if "detail" in v.get("message", "").lower()
+        ]
+        assert len(expect_violations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# CrossTypeValidator — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTypeValidator:
+    """Unit tests for CrossTypeValidator check methods."""
+
+    def setup_method(self):
+        self.validator = CrossTypeValidator()
+
+    # ---- required_companion ------------------------------------------------
+
+    def test_required_companion_passes_when_both_present(self):
+        """No violation when both when_type and requires_type are present."""
+        groups = {"header": ["HDR|1"], "detail": ["DTL|1"]}
+        rule = CrossTypeRule(
+            check="required_companion",
+            when_type="header",
+            requires_type="detail",
+            message="detail required when header present",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert violations == []
+
+    def test_required_companion_fails_when_requires_absent(self):
+        """Violation when when_type is present but requires_type is absent."""
+        groups = {"header": ["HDR|1"]}
+        rule = CrossTypeRule(
+            check="required_companion",
+            when_type="header",
+            requires_type="detail",
+            message="detail required when header present",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert len(violations) == 1
+        assert violations[0].severity == "error"
+
+    def test_required_companion_no_violation_when_when_type_absent(self):
+        """No violation when the when_type itself is absent (nothing to require)."""
+        groups = {"detail": ["DTL|1"]}
+        rule = CrossTypeRule(
+            check="required_companion",
+            when_type="header",
+            requires_type="detail",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert violations == []
+
+    # ---- header_trailer_count ----------------------------------------------
+
+    def test_header_trailer_count_passes(self):
+        """No violation when trailer count field matches number of detail rows."""
+        # Trailer row: "TRL|3" — count field at index 1 (value "3"), 3 detail rows
+        groups = {
+            "detail": ["DTL|a", "DTL|b", "DTL|c"],
+            "trailer": ["TRL|3"],
+        }
+        rule = CrossTypeRule(
+            check="header_trailer_count",
+            record_type="trailer",
+            trailer_field="1",
+            count_of="detail",
+            message="trailer count mismatch",
+        )
+        # Provide rows as list of dicts for count extraction
+        groups_dict = {
+            "detail": [{"REC_TYPE": "DTL", "VAL": "a"},
+                        {"REC_TYPE": "DTL", "VAL": "b"},
+                        {"REC_TYPE": "DTL", "VAL": "c"}],
+            "trailer": [{"REC_TYPE": "TRL", "COUNT": "3"}],
+        }
+        rule2 = CrossTypeRule(
+            check="header_trailer_count",
+            record_type="trailer",
+            trailer_field="COUNT",
+            count_of="detail",
+            message="trailer count mismatch",
+        )
+        violations = self.validator.validate(groups_dict, [rule2], [])
+        assert violations == []
+
+    def test_header_trailer_count_fails(self):
+        """Violation when trailer count field does not match number of detail rows."""
+        groups = {
+            "detail": [{"REC_TYPE": "DTL", "VAL": "a"}, {"REC_TYPE": "DTL", "VAL": "b"}],
+            "trailer": [{"REC_TYPE": "TRL", "COUNT": "5"}],
+        }
+        rule = CrossTypeRule(
+            check="header_trailer_count",
+            record_type="trailer",
+            trailer_field="COUNT",
+            count_of="detail",
+            message="trailer count mismatch",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert len(violations) >= 1
+
+    # ---- header_trailer_sum ------------------------------------------------
+
+    def test_header_trailer_sum_passes(self):
+        """No violation when sum of detail field matches trailer sum field."""
+        groups = {
+            "detail": [
+                {"REC_TYPE": "DTL", "AMOUNT": "100"},
+                {"REC_TYPE": "DTL", "AMOUNT": "200"},
+            ],
+            "trailer": [{"REC_TYPE": "TRL", "TOTAL": "300"}],
+        }
+        rule = CrossTypeRule(
+            check="header_trailer_sum",
+            record_type="trailer",
+            trailer_field="TOTAL",
+            sum_of=["AMOUNT"],
+            count_of="detail",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert violations == []
+
+    def test_header_trailer_sum_fails(self):
+        """Violation when sum of detail field does not match trailer sum field."""
+        groups = {
+            "detail": [
+                {"REC_TYPE": "DTL", "AMOUNT": "100"},
+                {"REC_TYPE": "DTL", "AMOUNT": "200"},
+            ],
+            "trailer": [{"REC_TYPE": "TRL", "TOTAL": "999"}],
+        }
+        rule = CrossTypeRule(
+            check="header_trailer_sum",
+            record_type="trailer",
+            trailer_field="TOTAL",
+            sum_of=["AMOUNT"],
+            count_of="detail",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert len(violations) >= 1
+
+    # ---- header_detail_consistent ------------------------------------------
+
+    def test_header_detail_consistent_passes(self):
+        """No violation when header field value matches all detail field values."""
+        groups = {
+            "header": [{"REC_TYPE": "HDR", "BATCH_ID": "B001"}],
+            "detail": [
+                {"REC_TYPE": "DTL", "BATCH_ID": "B001"},
+                {"REC_TYPE": "DTL", "BATCH_ID": "B001"},
+            ],
+        }
+        rule = CrossTypeRule(
+            check="header_detail_consistent",
+            header_field="BATCH_ID",
+            detail_field="BATCH_ID",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert violations == []
+
+    def test_header_detail_consistent_fails(self):
+        """Violation when a detail row has a different value than the header field."""
+        groups = {
+            "header": [{"REC_TYPE": "HDR", "BATCH_ID": "B001"}],
+            "detail": [
+                {"REC_TYPE": "DTL", "BATCH_ID": "B001"},
+                {"REC_TYPE": "DTL", "BATCH_ID": "B999"},
+            ],
+        }
+        rule = CrossTypeRule(
+            check="header_detail_consistent",
+            header_field="BATCH_ID",
+            detail_field="BATCH_ID",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert len(violations) >= 1
+
+    # ---- header_trailer_match ----------------------------------------------
+
+    def test_header_trailer_match_passes(self):
+        """No violation when header and trailer fields have matching values."""
+        groups = {
+            "header": [{"REC_TYPE": "HDR", "BATCH_ID": "B001"}],
+            "trailer": [{"REC_TYPE": "TRL", "BATCH_ID": "B001"}],
+        }
+        rule = CrossTypeRule(
+            check="header_trailer_match",
+            header_field="BATCH_ID",
+            trailer_field="BATCH_ID",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert violations == []
+
+    def test_header_trailer_match_fails(self):
+        """Violation when header and trailer field values differ."""
+        groups = {
+            "header": [{"REC_TYPE": "HDR", "BATCH_ID": "B001"}],
+            "trailer": [{"REC_TYPE": "TRL", "BATCH_ID": "B999"}],
+        }
+        rule = CrossTypeRule(
+            check="header_trailer_match",
+            header_field="BATCH_ID",
+            trailer_field="BATCH_ID",
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert len(violations) >= 1
+
+    # ---- type_sequence -----------------------------------------------------
+
+    def test_type_sequence_passes(self):
+        """No violation when record types appear in expected order."""
+        all_rows_types = ["header", "detail", "detail", "trailer"]
+        groups = {
+            "header": [{"REC_TYPE": "HDR"}],
+            "detail": [{"REC_TYPE": "DTL"}, {"REC_TYPE": "DTL"}],
+            "trailer": [{"REC_TYPE": "TRL"}],
+        }
+        rule = CrossTypeRule(
+            check="type_sequence",
+            expected_order=["header", "detail", "trailer"],
+        )
+        violations = self.validator.validate(groups, [rule], all_rows_types)
+        assert violations == []
+
+    def test_type_sequence_fails_when_trailer_before_detail(self):
+        """Violation when trailer appears before detail rows."""
+        all_rows_types = ["header", "trailer", "detail"]
+        groups = {
+            "header": [{"REC_TYPE": "HDR"}],
+            "detail": [{"REC_TYPE": "DTL"}],
+            "trailer": [{"REC_TYPE": "TRL"}],
+        }
+        rule = CrossTypeRule(
+            check="type_sequence",
+            expected_order=["header", "detail", "trailer"],
+        )
+        violations = self.validator.validate(groups, [rule], all_rows_types)
+        assert len(violations) >= 1
+
+    # ---- expect_count ------------------------------------------------------
+
+    def test_expect_count_exactly_passes(self):
+        """No violation when group row count matches exactly."""
+        groups = {
+            "header": [{"REC_TYPE": "HDR"}],
+        }
+        rule = CrossTypeRule(
+            check="expect_count",
+            record_type="header",
+            exactly=1,
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert violations == []
+
+    def test_expect_count_exactly_fails(self):
+        """Violation when group has wrong number of rows for exactly check."""
+        groups = {
+            "header": [{"REC_TYPE": "HDR"}, {"REC_TYPE": "HDR"}],
+        }
+        rule = CrossTypeRule(
+            check="expect_count",
+            record_type="header",
+            exactly=1,
+        )
+        violations = self.validator.validate(groups, [rule], [])
+        assert len(violations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# MultiRecordValidator.validate — integration
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRecordValidatorIntegration:
+    """End-to-end integration tests for MultiRecordValidator.validate."""
+
+    def test_returns_aggregate_result_keys(self):
+        """Result dict always contains required top-level keys."""
+        lines = ["HDR000001", "DTL000002"]
+        file_path = _write_lines(lines)
+        config = _make_config()
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+
+        assert "record_type_results" in result
+        assert "cross_type_violations" in result
+        assert "total_rows" in result
+        assert "valid" in result
+
+    def test_total_rows_counts_all_lines(self):
+        """total_rows equals the number of non-empty lines in the file."""
+        lines = ["HDR000001", "DTL000002", "DTL000003", "TRL000004"]
+        file_path = _write_lines(lines)
+        config = _make_config()
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+
+        assert result["total_rows"] == 4
+
+    def test_valid_is_false_when_cross_type_errors_present(self):
+        """valid=False when cross-type error violations are found."""
+        # expect=exactly_one for header, but provide two headers
+        lines = ["HDR000001", "HDR000002", "DTL000003"]
+        file_path = _write_lines(lines)
+        config = _make_config(
+            record_types={
+                "header": RecordTypeConfig(match="HDR", mapping="", expect="exactly_one"),
+                "detail": RecordTypeConfig(match="DTL", mapping="", expect="any"),
+            }
+        )
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        assert result["valid"] is False
+
+    def test_valid_is_true_with_no_violations(self):
+        """valid=True when file has clean structure and no cross-type rules."""
+        lines = ["HDR000001", "DTL000002", "DTL000003", "TRL000004"]
+        file_path = _write_lines(lines)
+        config = _make_config()
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        # No cross-type rules, no per-type mappings — should have no violations
+        assert result["valid"] is True
+
+    def test_empty_file_is_valid_with_any_expect(self):
+        """Empty file with all record types expecting 'any' produces valid=True."""
+        file_path = _write_lines([])
+        config = _make_config()
+        validator = MultiRecordValidator()
+        result = validator.validate(str(file_path), config)
+        assert result["total_rows"] == 0
+        assert result["valid"] is True


### PR DESCRIPTION
## Summary
- **Multi-record validation**: configurable discriminator routes rows to per-type mappings
- **Header/trailer support**: detected by value match or row position (first/last)
- **7 cross-type rules**: companion, count, sum, consistent, match, sequence, expect
- **CLI**: `valdo validate --multi-record config.yaml`
- **API**: `POST /api/v1/multi-record/generate` generates YAML from JSON config
- All generic — discriminator, fields, match values from config, nothing hardcoded

## Test plan
- [x] `pytest tests/unit/` — 1024 passed, 80.46% coverage
- [x] 48 new multi-record tests

Closes #161 #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)