### PR TITLE
fix(api): return generated JSON in upload responses for UI preview

### DIFF
--- a/src/api/routers/mappings.py
+++ b/src/api/routers/mappings.py
@@ -82,12 +82,21 @@ async def upload_template(
         output_path = MAPPINGS_DIR / f"{mapping_id}.json"
         converter.save(str(output_path))
         
-        return UploadResponse(
-            filename=file.filename,
-            size=upload_path.stat().st_size,
-            mapping_id=mapping_id,
-            message=f"Template converted successfully. Mapping saved as '{mapping_id}'"
-        )
+        # Read back the generated JSON for preview
+        mapping_content = None
+        if output_path.exists():
+            import json as _json
+            with open(output_path) as _f:
+                mapping_content = _json.load(_f)
+
+        response = {
+            "filename": file.filename,
+            "size": upload_path.stat().st_size,
+            "mapping_id": mapping_id,
+            "message": f"Template converted successfully. Mapping saved as '{mapping_id}'",
+            "mapping_content": mapping_content,
+        }
+        return response
     
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error converting template: {str(e)}")

--- a/src/api/routers/rules.py
+++ b/src/api/routers/rules.py
@@ -71,11 +71,19 @@ async def upload_rules_template(
         output_path = RULES_DIR / f"{rules_id}.json"
         converter.save(str(output_path))
 
+        # Read back generated JSON for preview
+        rules_content = None
+        if output_path.exists():
+            import json as _json
+            with open(output_path) as _f:
+                rules_content = _json.load(_f)
+
         return {
             "rules_id": rules_id,
             "filename": file.filename,
             "size": upload_path.stat().st_size,
             "message": f"Rules template converted and created successfully. Rules saved as '{rules_id}'",
+            "rules_content": rules_content,
         }
 
     except Exception as e:


### PR DESCRIPTION
The JSON preview panel in the Mapping Generator tab was always empty because the upload endpoints didn't return the generated JSON content. Now includes `mapping_content` and `rules_content` in responses.

- [x] 1024 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)