### PR TITLE
fix(ui): add 'Use in Quick Test' link for generated rules

### DIFF
--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -2788,7 +2788,18 @@ document.getElementById('btnGenRules').addEventListener('click', async function(
     var rid  = data.rules_id;
     if (data.rules_content) { renderJsonPreview('rulesJsonPreview', data.rules_content); }
     setGenResult('rulesResultBar', 'success', '\u2705 \u2018' + rid + '\u2019 created\u00a0\u00a0', [
-      { text: 'Download JSON', href: '/api/v1/rules/' + encodeURIComponent(rid) + '.json', download: rid + '.json', tooltip: 'Download the generated JSON config to your machine' }
+      { text: 'Download JSON', href: '/api/v1/rules/' + encodeURIComponent(rid) + '.json', download: rid + '.json', tooltip: 'Download the generated JSON config to your machine' },
+      { text: 'Use in Quick Test \u2192', tooltip: 'Load these rules into the Quick Test tab and switch to it', onClick: function(e) {
+          e.preventDefault();
+          loadRules();
+          setTimeout(function() {
+            var sel = document.getElementById('rulesSelect');
+            for (var i = 0; i < sel.options.length; i++) {
+              if (sel.options[i].value === rid) { sel.selectedIndex = i; break; }
+            }
+          }, 500);
+          switchTab('quick');
+      }}
     ]);
   } catch (err) {
     setGenResult('rulesResultBar', 'error', 'Error: ' + err.message, null);


### PR DESCRIPTION
After generating rules, "Use in Quick Test →" now appears — reloads rules list, pre-selects the rule, switches to Quick Test.

- [x] 1024 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)