### PR TITLE
fix(api): add rules list endpoint + fix dropdown

### DIFF
--- a/src/api/routers/rules.py
+++ b/src/api/routers/rules.py
@@ -24,6 +24,26 @@ UPLOADS_DIR = _REPO_ROOT / "uploads"
 UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 
 
+@router.get("/")
+async def list_rules():
+    """List all available rules configurations."""
+    import json
+    rules = []
+    for f in sorted(RULES_DIR.glob("*.json")):
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            meta = data.get("metadata", {})
+            rules.append({
+                "id": f.stem,
+                "name": meta.get("name", f.stem),
+                "filename": f.name,
+                "rule_count": len(data.get("rules", [])),
+            })
+        except Exception:
+            rules.append({"id": f.stem, "name": f.stem, "filename": f.name, "rule_count": 0})
+    return rules
+
+
 @router.post("/upload")
 async def upload_rules_template(
     _=Depends(require_role("mapping_owner")),

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -271,7 +271,7 @@ async function loadRules() {
     var resp = await fetch('/api/v1/rules/');
     if (!resp.ok) throw new Error('HTTP ' + resp.status);
     var list = await resp.json();
-    while (sel.childNodes.length > 1) sel.removeChild(sel.lastChild);
+    while (sel.options.length > 1) sel.removeChild(sel.lastChild);
     if (Array.isArray(list)) {
       list.forEach(function(r) {
         var o = document.createElement('option');


### PR DESCRIPTION
Rules dropdown in Quick Test was empty because GET /api/v1/rules/ didn't exist.

- Added list endpoint returning all rules configs from config/rules/
- Fixed JS to preserve "— no rules —" default option

- [x] 1024 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)