### PR TITLE
feat(cli): interactive multi-record YAML generator (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,12 @@ Follow these 12 steps in order for every feature or bug fix:
 
 5. **No hardcoded paths** — Use `Path(__file__).parent` for relative paths. Config-driven directories (uploads, reports, mappings, rules) must come from settings, not string literals.
 
+6. **Manageable file sizes** — Keep individual files under 500 lines where practical. Split large files:
+   - `ui.html` (HTML only) + `ui.css` (styles) + `ui.js` (JavaScript) — never combine back
+   - Python files: one class/concern per file, new commands go in `src/commands/`, not inline in `src/main.py`
+   - `src/main.py` is a thin CLI registration layer — all logic must be in `src/commands/` or `src/services/`
+   - Before modifying a file, check if the change belongs in an existing split file (e.g. CSS changes go in `ui.css`, not `ui.html`)
+
 ---
 
 ## Test Commands

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -1317,6 +1317,78 @@ See `config/multi-record/example_atoctran.yaml` for a fully commented example.
 
 ---
 
+## Generating a Multi-Record YAML Config (`generate-multi-record`)
+
+The `generate-multi-record` command writes a ready-to-use YAML config without
+requiring manual editing.  It supports two modes.
+
+### Non-interactive mode
+
+Supply all parameters on the command line:
+
+```bash
+python -m src.main generate-multi-record \
+  --output config/multi-record/my_batch.yaml \
+  --discriminator REC_TYPE:1:3 \
+  --type HDR=header_mapping \
+  --type DTL=detail_mapping \
+  --type TRL=trailer_mapping \
+  --mappings-dir config/mappings \
+  --rules-dir config/rules
+```
+
+**`--discriminator` format:** `FIELD_NAME:START_POSITION:LENGTH`
+
+| Part | Example | Meaning |
+|------|---------|---------|
+| `FIELD_NAME` | `REC_TYPE` | Logical name used in violation messages |
+| `START_POSITION` | `1` | 1-indexed column where the discriminator starts |
+| `LENGTH` | `3` | Number of characters to read |
+
+**`--type` format:** `CODE=MAPPING_NAME` (repeatable)
+
+```bash
+--type HDR=header_mapping        # Match literal "HDR" → header_mapping.json
+--type header:first=hdr_mapping  # Position-based: first row → hdr_mapping.json
+--type header:last=trl_mapping   # Position-based: last row → trl_mapping.json
+```
+
+If a rules file matching `MAPPING_NAME` is found in `--rules-dir` it is
+automatically included in the generated config.  Two naming patterns are
+tried:
+
+1. `{mapping_name}_rules.json`
+2. `{mapping_name_without__mapping}_rules.json`  (e.g. `detail_rules.json` for `detail_mapping`)
+
+### Interactive mode
+
+Omit `--discriminator` or `--type` and the wizard will guide you:
+
+```bash
+python -m src.main generate-multi-record --output config/multi-record/my_batch.yaml
+```
+
+Steps:
+1. Lists all mapping files found in `--mappings-dir`.
+2. Asks which to include (comma-separated numbers or `all`).
+3. Prompts for the discriminator field name, start position, and length.
+4. For each selected mapping, asks for the discriminator code (or `first`/`last`).
+5. Offers to include any auto-matched rules file.
+6. Optionally adds a `required_companion` cross-type rule.
+7. Writes the YAML file.
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--output`, `-o` | *(required)* | Output YAML file path |
+| `--discriminator` | *(interactive)* | `FIELD:POSITION:LENGTH` string |
+| `--type` | *(interactive)* | `CODE=MAPPING_NAME` — repeatable |
+| `--mappings-dir` | `config/mappings` | Directory containing mapping JSON files |
+| `--rules-dir` | `config/rules` | Directory to search for rules files |
+
+---
+
 ## Troubleshooting
 
 ### API Server Won't Start

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -288,6 +288,10 @@ Pipeline
    :members:
    :undoc-members:
 
+.. automodule:: src.commands.generate_multi_record_command
+   :members:
+   :undoc-members:
+
 Reporting & Utilities
 ---------------------
 

--- a/src/commands/generate_multi_record_command.py
+++ b/src/commands/generate_multi_record_command.py
@@ -1,0 +1,332 @@
+"""CLI command handler for generating multi-record YAML configuration files.
+
+Supports two modes:
+
+* **Non-interactive** — all parameters supplied via CLI flags; writes the YAML
+  directly without prompting the user.
+* **Interactive** — when ``discriminator`` or ``types`` are absent, guides the
+  user through selecting mappings, entering discriminator details, and
+  (optionally) assigning cross-type rules.
+
+The public entry point is :func:`run_generate_multi_record_command`.  All
+helper functions are intentionally small and independently testable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Public helpers (tested directly)
+# ---------------------------------------------------------------------------
+
+def _find_matching_rules(mapping_stem: str, rules_dir: str) -> Optional[Path]:
+    """Locate a rules JSON file that corresponds to a mapping file stem.
+
+    Two patterns are tried in order:
+
+    1. ``{mapping_stem}_rules.json``  (e.g. ``header_mapping_rules.json``)
+    2. ``{base}_rules.json`` where ``base`` strips a trailing ``_mapping``
+       suffix (e.g. ``header_rules.json`` for ``header_mapping``).
+
+    Args:
+        mapping_stem: Stem of the mapping filename (no extension).
+        rules_dir: Directory to search for rules files.
+
+    Returns:
+        Path to the matching rules file, or ``None`` if none is found.
+    """
+    rules_path = Path(rules_dir) / f"{mapping_stem}_rules.json"
+    if rules_path.exists():
+        return rules_path
+
+    base = mapping_stem.replace("_mapping", "")
+    rules_path = Path(rules_dir) / f"{base}_rules.json"
+    if rules_path.exists():
+        return rules_path
+
+    return None
+
+
+def _parse_discriminator(discriminator_str: str) -> Dict:
+    """Parse a ``FIELD:POSITION:LENGTH`` discriminator string into a dict.
+
+    Args:
+        discriminator_str: String in the form ``"FIELD_NAME:POSITION:LENGTH"``
+            where POSITION and LENGTH are positive integers.
+
+    Returns:
+        Dict with keys ``field`` (str), ``position`` (int), ``length`` (int).
+
+    Raises:
+        ValueError: When the string does not have exactly three colon-separated
+            segments or POSITION/LENGTH are not integers.
+    """
+    parts = discriminator_str.split(":")
+    if len(parts) != 3:
+        raise ValueError(
+            f"Discriminator must be in FIELD:POSITION:LENGTH format, got: {discriminator_str!r}"
+        )
+    field, position_str, length_str = parts
+    try:
+        position = int(position_str)
+        length = int(length_str)
+    except ValueError:
+        raise ValueError(
+            f"POSITION and LENGTH must be integers, got: {position_str!r}, {length_str!r}"
+        )
+    return {"field": field, "position": position, "length": length}
+
+
+def _parse_type_string(type_str: str):
+    """Parse a ``CODE=MAPPING_NAME`` type-mapping string.
+
+    The code portion may include a position qualifier separated by a colon,
+    e.g. ``header:first=batch_header`` means code ``header:first`` maps to
+    mapping ``batch_header``.
+
+    Args:
+        type_str: String in the form ``"CODE=MAPPING_NAME"``.
+
+    Returns:
+        Tuple of ``(code, mapping_name)`` as strings.
+
+    Raises:
+        ValueError: When the string does not contain an ``=`` sign.
+    """
+    if "=" not in type_str:
+        raise ValueError(
+            f"Type mapping must be in CODE=MAPPING_NAME format, got: {type_str!r}"
+        )
+    code, mapping_name = type_str.split("=", 1)
+    return code.strip(), mapping_name.strip()
+
+
+def _write_yaml(
+    output_path: str,
+    discriminator: Dict,
+    record_types: Dict,
+    cross_type_rules: Optional[List[Dict]],
+) -> None:
+    """Write a multi-record YAML config to disk.
+
+    Parent directories are created automatically.
+
+    Args:
+        output_path: Destination file path (including filename).
+        discriminator: Dict with keys ``field``, ``position``, ``length``.
+        record_types: Mapping of type-name → record-type config dict.
+        cross_type_rules: List of cross-type rule dicts, or ``None`` to omit
+            the ``cross_type_rules`` key entirely.
+    """
+    import yaml
+
+    config: Dict = {
+        "multi_record": {
+            "discriminator": discriminator,
+            "record_types": record_types,
+            "default_action": "warn",
+        }
+    }
+    if cross_type_rules:
+        config["multi_record"]["cross_type_rules"] = cross_type_rules
+
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with open(out, "w", encoding="utf-8") as fh:
+        yaml.dump(config, fh, default_flow_style=False, sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Type-string → record_types dict entry
+# ---------------------------------------------------------------------------
+
+def _build_record_type_entry(
+    code: str,
+    mapping_name: str,
+    mappings_dir: str,
+    rules_dir: str,
+) -> Dict:
+    """Build a record-type config dict for one code/mapping pair.
+
+    If a rules file matching the mapping is found automatically, it is
+    included in the entry.
+
+    The code may optionally embed a position qualifier using a colon, e.g.
+    ``header:first`` sets ``match=""`` and ``position="first"``.
+
+    Args:
+        code: Discriminator code value (e.g. ``"HDR"``).  May contain a
+            ``:first`` or ``:last`` qualifier.
+        mapping_name: Stem of the mapping JSON file (without ``.json``).
+        mappings_dir: Directory containing mapping JSON files.
+        rules_dir: Directory to search for matching rules files.
+
+    Returns:
+        Dict suitable for use as a ``record_types`` entry in the YAML config.
+    """
+    entry: Dict = {}
+
+    # Handle position qualifier (e.g. "header:first")
+    if ":" in code:
+        name_part, position_qualifier = code.rsplit(":", 1)
+        entry["position"] = position_qualifier
+        # match left empty when using position
+    else:
+        entry["match"] = code
+
+    mapping_path = str(Path(mappings_dir) / f"{mapping_name}.json")
+    entry["mapping"] = mapping_path
+    entry["expect"] = "any"
+
+    rules_path = _find_matching_rules(mapping_name, rules_dir)
+    if rules_path:
+        entry["rules"] = str(rules_path)
+
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Interactive mode
+# ---------------------------------------------------------------------------
+
+def run_interactive_mode(output: str, mappings_dir: str, rules_dir: str) -> None:
+    """Guide the user interactively to build a multi-record YAML config.
+
+    Guides the user through six steps: listing and selecting mapping files,
+    collecting discriminator field details, assigning a discriminator code to
+    each mapping, optionally attaching auto-matched rules, optionally adding a
+    ``required_companion`` cross-type rule, and finally writing the YAML.
+
+    Args:
+        output: Destination YAML file path.
+        mappings_dir: Directory containing mapping JSON files.
+        rules_dir: Directory to search for matching rules files.
+    """
+    import click
+
+    mappings = sorted(Path(mappings_dir).glob("*.json"))
+    if not mappings:
+        click.echo(click.style(f"No mapping files found in {mappings_dir}", fg="red"))
+        return
+
+    click.echo("\nAvailable mappings:")
+    for i, m in enumerate(mappings, 1):
+        click.echo(f"  {i}. {m.stem}")
+
+    selection = input("\nSelect mappings (comma-separated numbers or 'all') [all]: ").strip() or "all"
+
+    if selection.lower() == "all":
+        selected_mappings = mappings
+    else:
+        try:
+            indices = [int(s.strip()) - 1 for s in selection.split(",")]
+            selected_mappings = [mappings[i] for i in indices]
+        except (ValueError, IndexError):
+            click.echo(click.style("Invalid selection.", fg="red"))
+            return
+
+    # Discriminator
+    field = input("\nDiscriminator field name: ").strip()
+    position = int(input("Discriminator start position (1-indexed): ").strip())
+    length = int(input("Discriminator field length (characters): ").strip())
+    discriminator = {"field": field, "position": position, "length": length}
+
+    # Record types
+    record_types: Dict = {}
+    for mapping in selected_mappings:
+        click.echo(f"\n  Mapping: {mapping.stem}")
+        code = input(f"    Discriminator code (or 'first'/'last' for position-based): ").strip()
+
+        entry: Dict = {}
+        if code in ("first", "last"):
+            entry["position"] = code
+        else:
+            entry["match"] = code
+        entry["mapping"] = str(mapping)
+        entry["expect"] = "any"
+
+        rules_path = _find_matching_rules(mapping.stem, rules_dir)
+        if rules_path:
+            use_rules = input(f"    Found rules {rules_path.name}. Use it? [Y/n]: ").strip().lower()
+            if use_rules in ("", "y", "yes"):
+                entry["rules"] = str(rules_path)
+
+        type_key = mapping.stem.replace("_mapping", "")
+        record_types[type_key] = entry
+
+    # Optional cross-type rules
+    cross_type_rules: Optional[List[Dict]] = None
+    add_rules = input("\nAdd a required_companion cross-type rule? [y/N]: ").strip().lower()
+    if add_rules in ("y", "yes"):
+        when_type = input("  When type (e.g. 'header'): ").strip()
+        requires_type = input("  Requires type (e.g. 'detail'): ").strip()
+        severity = input("  Severity [error]: ").strip() or "error"
+        cross_type_rules = [
+            {
+                "check": "required_companion",
+                "when_type": when_type,
+                "requires_type": requires_type,
+                "severity": severity,
+            }
+        ]
+
+    _write_yaml(output, discriminator, record_types, cross_type_rules)
+    click.echo(click.style(f"\nGenerated: {output}", fg="green"))
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def run_generate_multi_record_command(
+    output: str,
+    discriminator: Optional[str],
+    types: Optional[List[str]],
+    rules_dir: str = "config/rules",
+    mappings_dir: str = "config/mappings",
+) -> None:
+    """Generate a multi-record YAML config — non-interactive or interactive.
+
+    When ``discriminator`` and ``types`` are both provided the YAML is written
+    immediately without any prompts.  When either is absent the user is guided
+    through the interactive wizard.
+
+    Args:
+        output: Destination YAML file path.
+        discriminator: Discriminator spec as ``"FIELD:POSITION:LENGTH"``, or
+            ``None`` to trigger interactive mode.
+        types: List of ``"CODE=MAPPING_NAME"`` strings, or ``None`` / empty
+            list to trigger interactive mode.
+        rules_dir: Directory to search for matching rules files.
+        mappings_dir: Directory containing mapping JSON files.
+
+    Raises:
+        ValueError: When ``discriminator`` cannot be parsed.
+    """
+    if not discriminator or not types:
+        run_interactive_mode(output, mappings_dir, rules_dir)
+        return
+
+    disc_dict = _parse_discriminator(discriminator)
+
+    record_types: Dict = {}
+    for type_str in types:
+        code, mapping_name = _parse_type_string(type_str)
+
+        entry = _build_record_type_entry(code, mapping_name, mappings_dir, rules_dir)
+
+        # Determine the dict key: strip position qualifier from code if present
+        if ":" in code:
+            type_key = code.split(":")[0]
+        else:
+            type_key = code
+
+        record_types[type_key] = entry
+
+    _write_yaml(output, disc_dict, record_types, cross_type_rules=None)
+
+    import click
+    click.echo(click.style(f"Generated: {output}", fg="green"))

--- a/src/main.py
+++ b/src/main.py
@@ -287,6 +287,32 @@ def infer_mapping(file, fmt, output, sample_lines):
         sys.exit(1)
 
 
+@cli.command('generate-multi-record')
+@click.option('--output', '-o', required=True, help='Output YAML path')
+@click.option('--discriminator', default=None,
+              help='Discriminator as FIELD:POSITION:LENGTH (e.g. REC_TYPE:1:3)')
+@click.option('--type', 'types', multiple=True,
+              help='Type mapping as CODE=MAPPING_NAME (repeatable)')
+@click.option('--mappings-dir', default='config/mappings', show_default=True,
+              help='Directory containing mapping JSON files')
+@click.option('--rules-dir', default='config/rules', show_default=True,
+              help='Directory to search for matching rules files')
+def generate_multi_record(output, discriminator, types, mappings_dir, rules_dir):
+    """Generate a multi-record YAML config interactively or from parameters."""
+    try:
+        from src.commands.generate_multi_record_command import run_generate_multi_record_command
+        run_generate_multi_record_command(
+            output=output,
+            discriminator=discriminator,
+            types=list(types),
+            mappings_dir=mappings_dir,
+            rules_dir=rules_dir,
+        )
+    except Exception as e:
+        click.echo(click.style(f"Error: {e}", fg="red"))
+        sys.exit(1)
+
+
 @cli.command()
 def info():
     """Display system information and check dependencies."""

--- a/tests/unit/test_generate_multi_record.py
+++ b/tests/unit/test_generate_multi_record.py
@@ -1,0 +1,343 @@
+"""Unit tests for generate_multi_record_command.
+
+Tests cover the non-interactive helpers and the full YAML-generation path.
+Interactive prompts are not tested here — they rely on builtins.input and
+are exercised manually or via E2E.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mappings_dir(tmp_path):
+    """Scratch directory pre-populated with three mapping JSON stubs."""
+    d = tmp_path / "mappings"
+    d.mkdir()
+    for name in ("header_mapping", "detail_mapping", "trailer_mapping"):
+        (d / f"{name}.json").write_text(json.dumps({"fields": []}))
+    return d
+
+
+@pytest.fixture()
+def rules_dir(tmp_path):
+    """Scratch directory pre-populated with a matching rules file."""
+    d = tmp_path / "rules"
+    d.mkdir()
+    # exact-match variant
+    (d / "header_mapping_rules.json").write_text(json.dumps({"rules": []}))
+    # base-name variant (no _mapping suffix in rules filename)
+    (d / "detail_rules.json").write_text(json.dumps({"rules": []}))
+    return d
+
+
+# ---------------------------------------------------------------------------
+# _find_matching_rules
+# ---------------------------------------------------------------------------
+
+class TestFindMatchingRules:
+    def test_finds_exact_match(self, rules_dir):
+        from src.commands.generate_multi_record_command import _find_matching_rules
+
+        result = _find_matching_rules("header_mapping", str(rules_dir))
+        assert result is not None
+        assert result.name == "header_mapping_rules.json"
+
+    def test_finds_base_name_match(self, rules_dir):
+        from src.commands.generate_multi_record_command import _find_matching_rules
+
+        # detail_mapping → strips _mapping → looks for detail_rules.json
+        result = _find_matching_rules("detail_mapping", str(rules_dir))
+        assert result is not None
+        assert result.name == "detail_rules.json"
+
+    def test_returns_none_when_no_match(self, rules_dir):
+        from src.commands.generate_multi_record_command import _find_matching_rules
+
+        result = _find_matching_rules("nonexistent_mapping", str(rules_dir))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_discriminator
+# ---------------------------------------------------------------------------
+
+class TestParseDiscriminator:
+    def test_parses_valid_string(self):
+        from src.commands.generate_multi_record_command import _parse_discriminator
+
+        disc = _parse_discriminator("REC_TYPE:1:3")
+        assert disc["field"] == "REC_TYPE"
+        assert disc["position"] == 1
+        assert disc["length"] == 3
+
+    def test_parses_numeric_position_and_length(self):
+        from src.commands.generate_multi_record_command import _parse_discriminator
+
+        disc = _parse_discriminator("TRAN_CODE:25:5")
+        assert disc["position"] == 25
+        assert disc["length"] == 5
+
+    def test_raises_on_wrong_segment_count(self):
+        from src.commands.generate_multi_record_command import _parse_discriminator
+
+        with pytest.raises(ValueError, match="FIELD:POSITION:LENGTH"):
+            _parse_discriminator("FIELD:1")
+
+    def test_raises_on_non_integer_position(self):
+        from src.commands.generate_multi_record_command import _parse_discriminator
+
+        with pytest.raises(ValueError):
+            _parse_discriminator("FIELD:abc:3")
+
+
+# ---------------------------------------------------------------------------
+# _parse_type_string
+# ---------------------------------------------------------------------------
+
+class TestParseTypeString:
+    def test_parses_code_equals_mapping(self):
+        from src.commands.generate_multi_record_command import _parse_type_string
+
+        code, mapping_name = _parse_type_string("32005=tranert_cus")
+        assert code == "32005"
+        assert mapping_name == "tranert_cus"
+
+    def test_parses_position_code(self):
+        from src.commands.generate_multi_record_command import _parse_type_string
+
+        code, mapping_name = _parse_type_string("header:first=batch_header")
+        assert code == "header:first"
+        assert mapping_name == "batch_header"
+
+    def test_raises_on_missing_equals(self):
+        from src.commands.generate_multi_record_command import _parse_type_string
+
+        with pytest.raises(ValueError, match="CODE=MAPPING_NAME"):
+            _parse_type_string("no_equals_sign")
+
+
+# ---------------------------------------------------------------------------
+# _write_yaml
+# ---------------------------------------------------------------------------
+
+class TestWriteYaml:
+    def test_writes_valid_yaml_file(self, tmp_path):
+        from src.commands.generate_multi_record_command import _write_yaml
+
+        out = tmp_path / "output.yaml"
+        discriminator = {"field": "REC_TYPE", "position": 1, "length": 3}
+        record_types = {
+            "header": {"match": "HDR", "mapping": "config/mappings/h.json", "expect": "exactly_one"},
+            "detail": {"match": "DTL", "mapping": "config/mappings/d.json", "expect": "at_least_one"},
+        }
+
+        _write_yaml(str(out), discriminator, record_types, cross_type_rules=None)
+
+        assert out.exists()
+        content = yaml.safe_load(out.read_text())
+        assert "multi_record" in content
+        mr = content["multi_record"]
+        assert mr["discriminator"]["field"] == "REC_TYPE"
+        assert "header" in mr["record_types"]
+        assert mr["default_action"] == "warn"
+
+    def test_includes_cross_type_rules_when_provided(self, tmp_path):
+        from src.commands.generate_multi_record_command import _write_yaml
+
+        out = tmp_path / "with_rules.yaml"
+        discriminator = {"field": "F", "position": 1, "length": 1}
+        record_types = {"detail": {"match": "D", "mapping": "m.json", "expect": "any"}}
+        cross_rules = [{"check": "required_companion", "when_type": "header", "requires_type": "detail"}]
+
+        _write_yaml(str(out), discriminator, record_types, cross_type_rules=cross_rules)
+
+        content = yaml.safe_load(out.read_text())
+        assert "cross_type_rules" in content["multi_record"]
+        assert content["multi_record"]["cross_type_rules"][0]["check"] == "required_companion"
+
+    def test_omits_cross_type_rules_when_none(self, tmp_path):
+        from src.commands.generate_multi_record_command import _write_yaml
+
+        out = tmp_path / "no_rules.yaml"
+        _write_yaml(str(out), {"field": "F", "position": 1, "length": 1},
+                    {"d": {"match": "D", "mapping": "m.json", "expect": "any"}},
+                    cross_type_rules=None)
+
+        content = yaml.safe_load(out.read_text())
+        assert "cross_type_rules" not in content["multi_record"]
+
+    def test_creates_parent_directories(self, tmp_path):
+        from src.commands.generate_multi_record_command import _write_yaml
+
+        out = tmp_path / "deep" / "nested" / "output.yaml"
+        _write_yaml(str(out), {"field": "F", "position": 1, "length": 1},
+                    {"d": {"match": "D", "mapping": "m.json", "expect": "any"}},
+                    cross_type_rules=None)
+
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Generated YAML round-trips through MultiRecordConfig
+# ---------------------------------------------------------------------------
+
+class TestYamlLoadsIntoMultiRecordConfig:
+    def test_generated_yaml_is_valid_config(self, tmp_path):
+        from src.commands.generate_multi_record_command import _write_yaml
+        from src.config.multi_record_config import MultiRecordConfig
+
+        out = tmp_path / "roundtrip.yaml"
+        discriminator = {"field": "REC_TYPE", "position": 1, "length": 3}
+        record_types = {
+            "header": {"match": "HDR", "mapping": "config/mappings/h.json", "expect": "exactly_one"},
+            "detail": {"match": "DTL", "mapping": "config/mappings/d.json", "expect": "at_least_one"},
+            "trailer": {"match": "TRL", "mapping": "config/mappings/t.json", "expect": "exactly_one"},
+        }
+
+        _write_yaml(str(out), discriminator, record_types, cross_type_rules=None)
+
+        raw = yaml.safe_load(out.read_text())
+        config = MultiRecordConfig(**raw["multi_record"])
+
+        assert config.discriminator.field == "REC_TYPE"
+        assert config.discriminator.position == 1
+        assert config.discriminator.length == 3
+        assert "header" in config.record_types
+        assert config.default_action == "warn"
+
+
+# ---------------------------------------------------------------------------
+# run_generate_multi_record_command (non-interactive path)
+# ---------------------------------------------------------------------------
+
+class TestRunGenerateMultiRecordCommandNonInteractive:
+    def test_generates_yaml_from_all_params(self, tmp_path, mappings_dir, rules_dir):
+        from src.commands.generate_multi_record_command import run_generate_multi_record_command
+
+        out = tmp_path / "output.yaml"
+
+        run_generate_multi_record_command(
+            output=str(out),
+            discriminator="REC_TYPE:1:3",
+            types=["header=header_mapping", "detail=detail_mapping"],
+            rules_dir=str(rules_dir),
+            mappings_dir=str(mappings_dir),
+        )
+
+        assert out.exists()
+        content = yaml.safe_load(out.read_text())
+        mr = content["multi_record"]
+        assert mr["discriminator"]["field"] == "REC_TYPE"
+        assert "header" in mr["record_types"]
+        assert "detail" in mr["record_types"]
+
+    def test_raises_when_discriminator_malformed(self, tmp_path, mappings_dir, rules_dir):
+        from src.commands.generate_multi_record_command import run_generate_multi_record_command
+
+        with pytest.raises(ValueError):
+            run_generate_multi_record_command(
+                output=str(tmp_path / "out.yaml"),
+                discriminator="BAD_FORMAT",
+                types=["header=header_mapping"],
+                rules_dir=str(rules_dir),
+                mappings_dir=str(mappings_dir),
+            )
+
+    def test_type_string_with_position_qualifier(self, tmp_path, mappings_dir, rules_dir):
+        """Code with colon qualifier like 'header:first' should work."""
+        from src.commands.generate_multi_record_command import run_generate_multi_record_command
+
+        out = tmp_path / "pos.yaml"
+        run_generate_multi_record_command(
+            output=str(out),
+            discriminator="REC_TYPE:1:3",
+            types=["header:first=header_mapping"],
+            rules_dir=str(rules_dir),
+            mappings_dir=str(mappings_dir),
+        )
+
+        content = yaml.safe_load(out.read_text())
+        rt = content["multi_record"]["record_types"]
+        assert "header" in rt
+        assert rt["header"]["position"] == "first"
+
+
+class TestInteractiveMode:
+    """Test interactive mode with mocked input()."""
+
+    def test_interactive_mode_generates_yaml(self, tmp_path, monkeypatch):
+        """Interactive wizard should generate valid YAML."""
+        from src.commands.generate_multi_record_command import run_interactive_mode
+
+        # Create test mappings
+        mappings_dir = tmp_path / "mappings"
+        mappings_dir.mkdir()
+        (mappings_dir / "cus.json").write_text('{"mapping_name":"cus"}')
+        (mappings_dir / "ori.json").write_text('{"mapping_name":"ori"}')
+
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir()
+
+        output = str(tmp_path / "out.yaml")
+
+        # Mock input() responses
+        responses = iter([
+            "all",              # select mappings
+            "TRN-CODE",         # discriminator field
+            "25",               # position
+            "5",                # length
+            "32005",            # cus code
+            "32010",            # ori code
+            "n",                # no cross-type rules
+        ])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(responses))
+
+        run_interactive_mode(output, str(mappings_dir), str(rules_dir))
+
+        import yaml
+        with open(output) as f:
+            config = yaml.safe_load(f)
+        assert "multi_record" in config
+        assert config["multi_record"]["discriminator"]["field"] == "TRN-CODE"
+        assert config["multi_record"]["discriminator"]["position"] == 25
+        assert len(config["multi_record"]["record_types"]) == 2
+
+    def test_interactive_mode_no_mappings(self, tmp_path, monkeypatch, capsys):
+        """Should exit cleanly when no mappings found."""
+        from src.commands.generate_multi_record_command import run_interactive_mode
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        output = str(tmp_path / "out.yaml")
+
+        run_interactive_mode(output, str(empty_dir), str(empty_dir))
+
+        captured = capsys.readouterr()
+        assert "No mapping files found" in captured.out
+
+    def test_entry_point_routes_to_interactive(self, tmp_path, monkeypatch):
+        """When discriminator is None, should route to interactive mode."""
+        from src.commands.generate_multi_record_command import run_generate_multi_record_command
+
+        mappings_dir = tmp_path / "mappings"
+        mappings_dir.mkdir()
+        (mappings_dir / "test.json").write_text('{"mapping_name":"test"}')
+
+        output = str(tmp_path / "out.yaml")
+
+        responses = iter(["all", "CODE", "1", "3", "100", "n"])
+        monkeypatch.setattr("builtins.input", lambda prompt="": next(responses))
+
+        run_generate_multi_record_command(output, None, [], str(tmp_path / "rules"), str(mappings_dir))
+
+        assert Path(output).exists()


### PR DESCRIPTION
## Summary
- `valdo generate-multi-record` — interactive wizard or non-interactive CLI
- Auto-matches rules files to mappings by naming convention
- Generates valid multi-record YAML for `valdo validate --multi-record`
- CLAUDE.md: added architecture principle #6 (file size limits)

- [x] 1063 tests passing, 80.48% coverage

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)