### PR TITLE
feat(transforms): Phase 1 — parser + default/constant/blank rules (#185)

### DIFF
--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -15,8 +15,9 @@ This guide provides practical examples for using Valdo in both **CLI mode** and 
 2. [CLI Usage](#cli-usage)
 3. [API Usage](#api-usage)
 4. [Universal Mapping](#universal-mapping)
-5. [Common Workflows](#common-workflows)
-6. [Troubleshooting](#troubleshooting)
+5. [Transformation Engine](#transformation-engine)
+6. [Common Workflows](#common-workflows)
+7. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -1995,3 +1996,98 @@ python -m src.main submit-task \
 ```
 
 If input is invalid, CLI exits non-zero and prints machine-readable errors when `--machine-errors` is set.
+
+---
+
+## Transformation Engine
+
+The `src.transforms` package provides a two-stage pipeline for applying
+field-level transformations that appear as free-text annotations in mapping
+spreadsheets.
+
+### Transform types
+
+| Type | Class | Behaviour |
+|------|-------|-----------|
+| `noop` | `Transform` | Pass source value through unchanged |
+| `default` | `DefaultTransform` | Use source when present; fall back to configured value |
+| `blank` | `BlankTransform` | Always output blank / space-filled result |
+| `constant` | `ConstantTransform` | Always output a fixed constant, ignoring source |
+
+### Parsing mapping text
+
+`parse_transform(text)` converts a free-text mapping cell into a typed object.
+
+```python
+from src.transforms import parse_transform
+
+t = parse_transform("Default to '100030'")
+# DefaultTransform(value='100030', type='default')
+
+t = parse_transform("Nullable --> Leave Blank")
+# BlankTransform(fill_char=' ', fill_value='', type='blank')
+
+t = parse_transform("Pass '000'")
+# ConstantTransform(value='000', type='constant')
+
+t = parse_transform("Hard-code to 'USD'")
+# ConstantTransform(value='USD', type='constant')
+
+t = parse_transform("Initialize to spaces")
+# BlankTransform(fill_char=' ', fill_value='', type='blank')
+
+t = parse_transform(None)
+# Transform(type='noop')
+```
+
+Recognised patterns include:
+
+- `Default to 'VALUE'` / `Default to VALUE` / `Default = VALUE`
+- `Nullable --> Leave Blank` / `Nullable --> 'FILL'`
+- `Leave Blank` / `Leave blank <spaces>`
+- `Pass Blank <spaces>`
+- `Initialize to spaces`
+- `Pass 'VALUE'`
+- `Hard-code to 'VALUE'` / `Hard-Code to 'VALUE'` / `Hardcode to 'VALUE'`
+
+Any unrecognised text (including complex conditional expressions) returns
+`Transform(type='noop')` so callers can safely fall back to a direct copy.
+
+### Applying a transform
+
+`apply_transform(source_value, transform, field_length=0)` executes the
+transform and returns a string.  Pass `field_length` to right-pad or
+right-truncate the result to an exact width.
+
+```python
+from src.transforms import apply_transform, parse_transform
+from src.transforms.models import ConstantTransform, DefaultTransform
+
+# Constant — ignores source
+apply_transform("ANYTHING", ConstantTransform(value="000"))
+# '000'
+
+# Default — uses source when present
+apply_transform("REAL", DefaultTransform(value="FB"))
+# 'REAL'
+
+# Default — falls back when source is absent/whitespace
+apply_transform("  ", DefaultTransform(value="FB"))
+# 'FB'
+
+# Padding / truncation
+apply_transform("AB", parse_transform("Pass as is"), field_length=5)
+# 'AB   '
+
+apply_transform("ABCDEF", parse_transform("Pass as is"), field_length=4)
+# 'ABCD'
+```
+
+### API location
+
+| Symbol | Module |
+|--------|--------|
+| `Transform`, `DefaultTransform`, `BlankTransform`, `ConstantTransform` | `src.transforms.models` |
+| `parse_transform` | `src.transforms.transform_parser` |
+| `apply_transform` | `src.transforms.transform_engine` |
+| All of the above (re-exported) | `src.transforms` |

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -292,6 +292,26 @@ Pipeline
    :members:
    :undoc-members:
 
+Transforms
+----------
+
+.. automodule:: src.transforms
+   :members:
+   :undoc-members:
+
+.. automodule:: src.transforms.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: src.transforms.transform_parser
+   :members:
+   :undoc-members:
+
+.. automodule:: src.transforms.transform_engine
+   :members:
+   :undoc-members:
+
 Reporting & Utilities
 ---------------------
 

--- a/src/transforms/__init__.py
+++ b/src/transforms/__init__.py
@@ -1,0 +1,39 @@
+"""Transform system for field-level data transformations.
+
+Provides a parser that converts free-text mapping descriptions into typed
+``Transform`` objects, and an engine that applies those objects to source
+field values.
+
+Exported names
+--------------
+``Transform``
+    Base pass-through (noop) transform.
+``DefaultTransform``
+    Use source value when present; fall back to a configured default.
+``BlankTransform``
+    Always output blank / space-filled value.
+``ConstantTransform``
+    Always output a fixed constant, ignoring the source.
+``parse_transform``
+    Parse a free-text transform description into a typed ``Transform``.
+``apply_transform``
+    Apply a ``Transform`` to a source value, returning the output string.
+"""
+
+from src.transforms.models import (
+    BlankTransform,
+    ConstantTransform,
+    DefaultTransform,
+    Transform,
+)
+from src.transforms.transform_engine import apply_transform
+from src.transforms.transform_parser import parse_transform
+
+__all__ = [
+    "Transform",
+    "DefaultTransform",
+    "BlankTransform",
+    "ConstantTransform",
+    "parse_transform",
+    "apply_transform",
+]

--- a/src/transforms/models.py
+++ b/src/transforms/models.py
@@ -1,0 +1,73 @@
+"""Dataclasses representing parsed field-level transforms.
+
+Each transform type is a lightweight value object.  The base ``Transform``
+carries ``type='noop'`` and acts as a pass-through sentinel.  Subclasses add
+the parameters specific to their behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Transform:
+    """Base transform — pass-through sentinel.
+
+    Attributes:
+        type: Machine-readable transform kind. Defaults to ``'noop'``.
+    """
+
+    type: str = "noop"
+
+
+@dataclass
+class DefaultTransform(Transform):
+    """Return the source value when present; otherwise fall back to *value*.
+
+    Attributes:
+        value: The fallback/default string to use when source is absent.
+        type: Always ``'default'``.
+    """
+
+    value: str = ""
+    type: str = field(default="default", init=False)
+
+    def __post_init__(self) -> None:
+        self.type = "default"
+
+
+@dataclass
+class BlankTransform(Transform):
+    """Always output a blank (space-padded or fixed fill) value.
+
+    Attributes:
+        fill_char: Character used to pad when no explicit ``fill_value`` is
+            set and a ``field_length`` is provided.  Defaults to ``' '``.
+        fill_value: Optional explicit fill string.  When set, this takes
+            priority over ``fill_char`` padding.  Defaults to ``''``.
+        type: Always ``'blank'``.
+    """
+
+    fill_char: str = " "
+    fill_value: str = ""
+    type: str = field(default="blank", init=False)
+
+    def __post_init__(self) -> None:
+        self.type = "blank"
+
+
+@dataclass
+class ConstantTransform(Transform):
+    """Always output a fixed constant, ignoring the source value entirely.
+
+    Attributes:
+        value: The constant string to emit unconditionally.
+        type: Always ``'constant'``.
+    """
+
+    value: str = ""
+    type: str = field(default="constant", init=False)
+
+    def __post_init__(self) -> None:
+        self.type = "constant"

--- a/src/transforms/transform_engine.py
+++ b/src/transforms/transform_engine.py
@@ -1,0 +1,112 @@
+"""Apply a Transform to a source field value, producing a final output string.
+
+This module is the execution side of the transform system.  It consumes the
+typed ``Transform`` objects produced by ``transform_parser`` and produces
+strings ready for output-file writing.
+
+Padding / truncation rules
+--------------------------
+When ``field_length`` is a positive integer the result is always exactly
+``field_length`` characters:
+
+- Values shorter than ``field_length`` are **right-padded with spaces**.
+- Values longer than ``field_length`` are **truncated on the right**.
+
+When ``field_length`` is zero or negative, no padding or truncation is applied.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from src.transforms.models import (
+    BlankTransform,
+    ConstantTransform,
+    DefaultTransform,
+    Transform,
+)
+
+# Sentinel used to detect the absence of a meaningful source value.
+_ABSENT = frozenset({"", None})
+
+
+def _is_absent(value: Optional[str]) -> bool:
+    """Return True when *value* is None, empty, or whitespace-only."""
+    if value is None:
+        return True
+    return not value.strip()
+
+
+def _fit(value: str, field_length: int, pad_char: str = " ") -> str:
+    """Pad or truncate *value* to exactly *field_length* characters.
+
+    Args:
+        value: The string to fit.
+        field_length: Desired output width.  Values ≤ 0 disable fitting.
+        pad_char: Character used for right-padding.  Defaults to ``' '``.
+
+    Returns:
+        The fitted string, or the original string when ``field_length <= 0``.
+    """
+    if field_length <= 0:
+        return value
+    if len(value) >= field_length:
+        return value[:field_length]
+    return value + pad_char * (field_length - len(value))
+
+
+def apply_transform(
+    source_value: Optional[str],
+    transform: Transform,
+    field_length: int = 0,
+) -> str:
+    """Apply *transform* to *source_value* and return the output string.
+
+    Args:
+        source_value: The raw value read from the source file field.  ``None``
+            is treated identically to an empty string.
+        transform: A ``Transform`` instance (or subclass) produced by
+            ``parse_transform``.
+        field_length: Target output field width.  ``0`` means no constraint.
+            Positive values trigger right-padding / right-truncation.
+
+    Returns:
+        The transformed string, fitted to ``field_length`` when positive.
+
+    Examples:
+        >>> apply_transform("REAL", DefaultTransform(value="FB"))
+        'REAL'
+
+        >>> apply_transform("", DefaultTransform(value="FB"))
+        'FB'
+
+        >>> apply_transform("X", ConstantTransform(value="000"))
+        '000'
+
+        >>> apply_transform("AB", Transform(type="noop"), field_length=5)
+        'AB   '
+    """
+    raw_source = "" if source_value is None else source_value
+
+    if isinstance(transform, ConstantTransform):
+        result = transform.value
+
+    elif isinstance(transform, DefaultTransform):
+        result = raw_source if not _is_absent(raw_source) else transform.value
+
+    elif isinstance(transform, BlankTransform):
+        if transform.fill_value:
+            base = transform.fill_value
+            # Extend fill_value with fill_char to meet field_length, then fit.
+            if field_length > 0 and len(base) < field_length:
+                base = base + transform.fill_char * (field_length - len(base))
+            result = base
+        else:
+            # No explicit fill_value: produce fill_char * field_length, or ""
+            result = transform.fill_char * field_length if field_length > 0 else ""
+
+    else:
+        # Noop — pass through.
+        result = raw_source
+
+    return _fit(result, field_length)

--- a/src/transforms/transform_parser.py
+++ b/src/transforms/transform_parser.py
@@ -1,0 +1,151 @@
+"""Parse free-text mapping transformation descriptions into typed Transform objects.
+
+Recognises patterns found in real Shaw→C360 mapping spreadsheets:
+
+- ``Default to 'VALUE'`` / ``Default to VALUE`` / ``Default = VALUE``
+- ``Nullable --> Leave Blank`` / ``Nullable --> 'FILL'``
+- ``Leave Blank`` / ``Leave blank <spaces>``
+- ``Pass Blank <spaces>``
+- ``Initialize to spaces``
+- ``Pass 'VALUE'``
+- ``Hard-code to 'VALUE'`` / ``Hard-Code to 'VALUE'`` / ``Hardcode to 'VALUE'``
+
+Anything else — including complex conditional expressions — returns a noop
+``Transform`` so that downstream code can safely fall back to a direct
+source-field copy.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from src.transforms.models import (
+    BlankTransform,
+    ConstantTransform,
+    DefaultTransform,
+    Transform,
+)
+
+# ---------------------------------------------------------------------------
+# Pre-compiled patterns (order matters — more specific first)
+# ---------------------------------------------------------------------------
+
+# "Default to VALUE" or "Default = VALUE" (unquoted, single-token value)
+# Captures a contiguous non-whitespace token immediately after "to" / "=".
+_DEFAULT_UNQUOTED_RE = re.compile(
+    r"^default\s*(?:to|=)\s*(\S+)",
+    re.IGNORECASE,
+)
+
+# "Nullable --> Leave Blank" or "Nullable --> '<FILL>'"
+_NULLABLE_LEAVE_BLANK_RE = re.compile(
+    r"nullable\s*-->\s*leave\s+blank",
+    re.IGNORECASE,
+)
+_NULLABLE_FILL_RE = re.compile(
+    r"nullable\s*-->\s*['\"]([^'\"]+)['\"]",
+    re.IGNORECASE,
+)
+
+# "Leave Blank" / "Leave blank <spaces>"
+_LEAVE_BLANK_RE = re.compile(r"^leave\s+blank", re.IGNORECASE)
+
+# "Pass Blank <spaces>"
+_PASS_BLANK_RE = re.compile(r"^pass\s+blank", re.IGNORECASE)
+
+# "Initialize to spaces"
+_INIT_SPACES_RE = re.compile(r"^initialize\s+to\s+spaces", re.IGNORECASE)
+
+# "Pass 'VALUE'" — quoted token after 'pass' only
+_PASS_CONSTANT_RE = re.compile(
+    r"^pass\s+['\"]([^'\"]+)['\"]",
+    re.IGNORECASE,
+)
+
+# "Hard-code to 'VALUE'" / "Hard-Code to 'VALUE'" / "Hardcode to 'VALUE'"
+# Accepts single or double quotes.
+_HARDCODE_RE = re.compile(
+    r"^hard-?code\s+to\s+['\"]([^'\"]+)['\"]",
+    re.IGNORECASE,
+)
+
+# Simple "Default to 'VALUE'" with strict quoted capture (used as fallback
+# to avoid the greedy unquoted branch swallowing trailing context).
+_DEFAULT_QUOTED_RE = re.compile(
+    r"^default\s*(?:to|=)\s*['\"]([^'\"]+)['\"]",
+    re.IGNORECASE,
+)
+
+
+def parse_transform(text: Optional[str]) -> Transform:
+    """Parse a free-text transformation description into a typed Transform.
+
+    Args:
+        text: The raw transformation text from a mapping spreadsheet cell.
+            May be ``None`` or empty.
+
+    Returns:
+        A ``Transform`` subclass instance whose type matches the recognised
+        pattern, or a base ``Transform(type='noop')`` when the text is empty,
+        ``None``, or unrecognised.
+
+    Examples:
+        >>> parse_transform("Default to '100030'")
+        DefaultTransform(value='100030', type='default')
+
+        >>> parse_transform("Nullable --> Leave Blank")
+        BlankTransform(fill_char=' ', fill_value='', type='blank')
+
+        >>> parse_transform("Pass '000'")
+        ConstantTransform(value='000', type='constant')
+
+        >>> parse_transform(None)
+        Transform(type='noop')
+    """
+    if not text or not text.strip():
+        return Transform(type="noop")
+
+    t = text.strip()
+
+    # --- Blank / space patterns (check before generic "pass" pattern) ---
+
+    if _INIT_SPACES_RE.match(t):
+        return BlankTransform(fill_char=" ")
+
+    if _LEAVE_BLANK_RE.match(t):
+        return BlankTransform()
+
+    if _PASS_BLANK_RE.match(t):
+        return BlankTransform()
+
+    # --- Nullable patterns ---
+
+    if _NULLABLE_LEAVE_BLANK_RE.search(t):
+        return BlankTransform()
+
+    m = _NULLABLE_FILL_RE.search(t)
+    if m:
+        return BlankTransform(fill_value=m.group(1))
+
+    # --- Constant patterns ---
+
+    m = _HARDCODE_RE.match(t)
+    if m:
+        return ConstantTransform(value=m.group(1))
+
+    m = _PASS_CONSTANT_RE.match(t)
+    if m:
+        return ConstantTransform(value=m.group(1))
+
+    # --- Default patterns (quoted first, then unquoted) ---
+
+    m = _DEFAULT_QUOTED_RE.match(t)
+    if m:
+        return DefaultTransform(value=m.group(1))
+
+    m = _DEFAULT_UNQUOTED_RE.match(t)
+    if m:
+        return DefaultTransform(value=m.group(1).strip())
+
+    return Transform(type="noop")

--- a/tests/unit/test_transform_engine.py
+++ b/tests/unit/test_transform_engine.py
@@ -1,0 +1,197 @@
+"""Unit tests for the transform engine.
+
+Tests are written before implementation — they are expected to fail initially.
+Covers apply_transform for each Transform subtype, padding, and truncation.
+"""
+
+import pytest
+from src.transforms import apply_transform
+from src.transforms.models import (
+    Transform,
+    DefaultTransform,
+    BlankTransform,
+    ConstantTransform,
+)
+
+
+# ---------------------------------------------------------------------------
+# Noop transform
+# ---------------------------------------------------------------------------
+
+class TestNoopTransform:
+    """Noop transform passes the source value through unchanged."""
+
+    def test_noop_returns_source(self):
+        """Noop with a present source value returns that value."""
+        result = apply_transform("HELLO", Transform(type="noop"))
+        assert result == "HELLO"
+
+    def test_noop_empty_source(self):
+        """Noop with empty source returns empty string."""
+        result = apply_transform("", Transform(type="noop"))
+        assert result == ""
+
+    def test_noop_none_source(self):
+        """Noop with None source returns empty string."""
+        result = apply_transform(None, Transform(type="noop"))
+        assert result == ""
+
+    def test_noop_with_padding(self):
+        """Noop pads short value to field_length with spaces on the right."""
+        result = apply_transform("AB", Transform(type="noop"), field_length=5)
+        assert result == "AB   "
+        assert len(result) == 5
+
+    def test_noop_with_truncation(self):
+        """Noop truncates value longer than field_length."""
+        result = apply_transform("ABCDEF", Transform(type="noop"), field_length=4)
+        assert result == "ABCD"
+        assert len(result) == 4
+
+
+# ---------------------------------------------------------------------------
+# ConstantTransform
+# ---------------------------------------------------------------------------
+
+class TestConstantTransform:
+    """ConstantTransform always returns its configured value."""
+
+    def test_constant_ignores_source(self):
+        """Source value is ignored; constant is returned."""
+        result = apply_transform("ANYTHING", ConstantTransform(value="000"))
+        assert result == "000"
+
+    def test_constant_with_empty_source(self):
+        """Empty source still returns constant."""
+        result = apply_transform("", ConstantTransform(value="500"))
+        assert result == "500"
+
+    def test_constant_with_none_source(self):
+        """None source still returns constant."""
+        result = apply_transform(None, ConstantTransform(value="XYZ"))
+        assert result == "XYZ"
+
+    def test_constant_padded_to_field_length(self):
+        """Constant value is padded when shorter than field_length."""
+        result = apply_transform("X", ConstantTransform(value="A"), field_length=3)
+        assert result == "A  "
+        assert len(result) == 3
+
+    def test_constant_truncated_to_field_length(self):
+        """Constant value is truncated when longer than field_length."""
+        result = apply_transform("X", ConstantTransform(value="ABCDE"), field_length=3)
+        assert result == "ABC"
+
+
+# ---------------------------------------------------------------------------
+# DefaultTransform
+# ---------------------------------------------------------------------------
+
+class TestDefaultTransform:
+    """DefaultTransform returns source when present, otherwise the default."""
+
+    def test_source_present_returns_source(self):
+        """Non-empty source value is returned as-is."""
+        result = apply_transform("REAL", DefaultTransform(value="FALLBACK"))
+        assert result == "REAL"
+
+    def test_source_empty_returns_default(self):
+        """Empty source triggers the default value."""
+        result = apply_transform("", DefaultTransform(value="FALLBACK"))
+        assert result == "FALLBACK"
+
+    def test_source_none_returns_default(self):
+        """None source triggers the default value."""
+        result = apply_transform(None, DefaultTransform(value="FALLBACK"))
+        assert result == "FALLBACK"
+
+    def test_source_whitespace_returns_default(self):
+        """Whitespace-only source is treated as absent; default is used."""
+        result = apply_transform("   ", DefaultTransform(value="FALLBACK"))
+        assert result == "FALLBACK"
+
+    def test_default_padded_to_field_length(self):
+        """Default value is padded when shorter than field_length."""
+        result = apply_transform("", DefaultTransform(value="AB"), field_length=5)
+        assert result == "AB   "
+        assert len(result) == 5
+
+    def test_source_padded_to_field_length(self):
+        """Source value is padded when shorter than field_length."""
+        result = apply_transform("AB", DefaultTransform(value="XX"), field_length=5)
+        assert result == "AB   "
+
+    def test_source_truncated_to_field_length(self):
+        """Source value is truncated when longer than field_length."""
+        result = apply_transform("ABCDEF", DefaultTransform(value="X"), field_length=4)
+        assert result == "ABCD"
+
+
+# ---------------------------------------------------------------------------
+# BlankTransform
+# ---------------------------------------------------------------------------
+
+class TestBlankTransform:
+    """BlankTransform returns fill_value (or fill_char * field_length)."""
+
+    def test_blank_returns_empty_string(self):
+        """BlankTransform with default fill_value returns empty string."""
+        result = apply_transform("ANYTHING", BlankTransform())
+        assert result == ""
+
+    def test_blank_with_fill_value(self):
+        """BlankTransform with explicit fill_value returns that value."""
+        result = apply_transform("ANYTHING", BlankTransform(fill_value="0000"))
+        assert result == "0000"
+
+    def test_blank_fill_char_with_field_length(self):
+        """BlankTransform with fill_char=' ' pads to field_length."""
+        result = apply_transform("ANYTHING", BlankTransform(fill_char=" "), field_length=5)
+        assert result == "     "
+        assert len(result) == 5
+
+    def test_blank_fill_value_padded_to_field_length(self):
+        """fill_value shorter than field_length is padded with fill_char."""
+        result = apply_transform(
+            "X",
+            BlankTransform(fill_value="00", fill_char="0"),
+            field_length=5,
+        )
+        assert result == "00000"
+
+    def test_blank_fill_value_truncated_to_field_length(self):
+        """fill_value longer than field_length is truncated."""
+        result = apply_transform(
+            "X",
+            BlankTransform(fill_value="0000000000"),
+            field_length=4,
+        )
+        assert result == "0000"
+
+    def test_blank_none_source_still_blanks(self):
+        """None source still returns fill_value."""
+        result = apply_transform(None, BlankTransform(fill_value="0000"))
+        assert result == "0000"
+
+
+# ---------------------------------------------------------------------------
+# Field-length edge cases
+# ---------------------------------------------------------------------------
+
+class TestFieldLengthEdgeCases:
+    """apply_transform handles zero and unset field_length correctly."""
+
+    def test_zero_field_length_no_padding(self):
+        """field_length=0 means no padding or truncation is applied."""
+        result = apply_transform("HELLO", Transform(type="noop"), field_length=0)
+        assert result == "HELLO"
+
+    def test_negative_field_length_treated_as_zero(self):
+        """Negative field_length is treated as no constraint."""
+        result = apply_transform("HELLO", Transform(type="noop"), field_length=-1)
+        assert result == "HELLO"
+
+    def test_exact_length_unchanged(self):
+        """Value with exactly field_length chars is unchanged."""
+        result = apply_transform("ABC", Transform(type="noop"), field_length=3)
+        assert result == "ABC"

--- a/tests/unit/test_transform_parser.py
+++ b/tests/unit/test_transform_parser.py
@@ -1,0 +1,189 @@
+"""Unit tests for the transformation text parser.
+
+Tests cover all recognized patterns from real mapping CSVs:
+  Default to, Nullable -->, Pass, Hard-code, Hard-Code,
+  Initialize to spaces, Leave Blank, and unknown/empty inputs.
+"""
+
+import pytest
+from src.transforms import parse_transform, Transform
+from src.transforms.models import (
+    DefaultTransform,
+    BlankTransform,
+    ConstantTransform,
+)
+
+
+# ---------------------------------------------------------------------------
+# DefaultTransform patterns
+# ---------------------------------------------------------------------------
+
+class TestDefaultTransform:
+    def test_default_to_with_single_quotes(self):
+        result = parse_transform("Default to '100030'")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "100030"
+
+    def test_default_to_trailing_context_ignored(self):
+        """Trailing comment text after the value is stripped."""
+        result = parse_transform(
+            "Default to '100030' FDR – Credit Card = 100010"
+        )
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "100030"
+
+    def test_default_to_with_numeric_no_quotes(self):
+        result = parse_transform("Default to +000000000000")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "+000000000000"
+
+    def test_default_to_plus_zeros_no_quotes_long(self):
+        result = parse_transform("Default to +000000000000000000")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "+000000000000000000"
+
+    def test_default_to_quoted_zeros(self):
+        result = parse_transform("Default to '00000000'")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "00000000"
+
+    def test_default_to_case_insensitive(self):
+        result = parse_transform("default to '001'")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "001"
+
+    def test_default_to_quoted_string(self):
+        result = parse_transform("Default to 'BATCH'")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "BATCH"
+
+    def test_default_to_single_char(self):
+        result = parse_transform("Default to 'C'")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "C"
+
+    def test_default_equals_usd(self):
+        result = parse_transform("Default = USD")
+        assert isinstance(result, DefaultTransform)
+        assert result.value == "USD"
+
+
+# ---------------------------------------------------------------------------
+# BlankTransform patterns
+# ---------------------------------------------------------------------------
+
+class TestBlankTransform:
+    def test_nullable_leave_blank(self):
+        result = parse_transform("Nullable --> Leave Blank")
+        assert isinstance(result, BlankTransform)
+        assert result.fill_value == ""
+        assert result.fill_char == " "
+
+    def test_nullable_with_quoted_fill_value(self):
+        result = parse_transform("Nullable --> '0000'")
+        assert isinstance(result, BlankTransform)
+        assert result.fill_value == "0000"
+
+    def test_nullable_with_quoted_zeros_8(self):
+        result = parse_transform("Nullable --> '00000000'")
+        assert isinstance(result, BlankTransform)
+        assert result.fill_value == "00000000"
+
+    def test_leave_blank_spaces(self):
+        result = parse_transform("Leave Blank <spaces>")
+        assert isinstance(result, BlankTransform)
+        assert result.fill_value == ""
+
+    def test_leave_blank_plain(self):
+        result = parse_transform("Leave Blank")
+        assert isinstance(result, BlankTransform)
+
+    def test_leave_blank_lowercase(self):
+        result = parse_transform("Leave blank")
+        assert isinstance(result, BlankTransform)
+
+    def test_pass_blank_spaces(self):
+        result = parse_transform("Pass Blank <spaces>")
+        assert isinstance(result, BlankTransform)
+
+    def test_initialize_to_spaces(self):
+        result = parse_transform("Initialize to spaces")
+        assert isinstance(result, BlankTransform)
+        assert result.fill_char == " "
+
+
+# ---------------------------------------------------------------------------
+# ConstantTransform patterns
+# ---------------------------------------------------------------------------
+
+class TestConstantTransform:
+    def test_pass_quoted_value(self):
+        result = parse_transform("Pass '000'")
+        assert isinstance(result, ConstantTransform)
+        assert result.value == "000"
+
+    def test_hard_code_lowercase_h(self):
+        result = parse_transform("Hard-code to '500'")
+        assert isinstance(result, ConstantTransform)
+        assert result.value == "500"
+
+    def test_hard_code_capitalized(self):
+        result = parse_transform("Hard-Code to '500'")
+        assert isinstance(result, ConstantTransform)
+        assert result.value == "500"
+
+    def test_hard_code_double_quotes(self):
+        result = parse_transform('Hard-Code to "DPD"')
+        assert isinstance(result, ConstantTransform)
+        assert result.value == "DPD"
+
+    def test_hardcode_no_dash(self):
+        result = parse_transform("Hardcode to 'USD'")
+        assert isinstance(result, ConstantTransform)
+        assert result.value == "USD"
+
+    def test_pass_value_unquoted(self):
+        """'Pass Value' is treated as noop — not a constant."""
+        result = parse_transform("Pass Value")
+        # generic "Pass Value" with no quoted token → noop
+        assert isinstance(result, Transform)
+        assert not isinstance(result, ConstantTransform)
+
+    def test_pass_quoted_single_digit(self):
+        result = parse_transform("pass '1'")
+        assert isinstance(result, ConstantTransform)
+        assert result.value == "1"
+
+
+# ---------------------------------------------------------------------------
+# Noop / unknown patterns
+# ---------------------------------------------------------------------------
+
+class TestNoopTransform:
+    def test_empty_string(self):
+        result = parse_transform("")
+        assert result.type == "noop"
+        assert type(result) is Transform
+
+    def test_none_input(self):
+        result = parse_transform(None)
+        assert result.type == "noop"
+
+    def test_complex_conditional(self):
+        """Conditional logic we cannot pattern-match → noop."""
+        result = parse_transform(
+            "IF LN-BAL not null then LN-BAL; ELSE Default to +000000000000000000"
+        )
+        assert result.type == "noop"
+
+    def test_pass_as_is(self):
+        result = parse_transform("Pass as is")
+        assert result.type == "noop"
+
+    def test_transform_as_is(self):
+        result = parse_transform("Transform as is")
+        assert result.type == "noop"
+
+    def test_ilmast_key_formula(self):
+        result = parse_transform("ILMAST-KEY = BR + CUS + LN")
+        assert result.type == "noop"


### PR DESCRIPTION
## Summary
New \`src/transforms/\` package: parser + engine for default, constant, blank transforms (71% of all patterns).

- [x] 1119 tests passing, 80.48% coverage
- [x] 56 new tests (97-100% transform coverage)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)