### PR TITLE
docs: comprehensive documentation review and update

### DIFF
--- a/docs/TRANSFORMATION_TYPES.md
+++ b/docs/TRANSFORMATION_TYPES.md
@@ -2,439 +2,427 @@
 
 ## Overview
 
-Transformations are applied to field values during data processing. They modify the data before it's validated or loaded into the target system.
+Transformations are parsed from free-text mapping spreadsheet cells by
+`parse_transform()` in `src/transforms/transform_parser.py`.  Each text
+pattern produces a typed Python dataclass from `src/transforms/models.py`.
+The engine in `src/transforms/transform_engine.py` applies those objects to
+source field values at run time.
+
+This document covers all transform types in the Phase 1–4 system.
 
 ---
 
-## 📋 Available Transformation Types
+## 1. `Transform` (noop / pass-through)
 
-### 1. `trim`
-**Remove leading and trailing whitespace**
+The base class.  Produced when the text is empty, `None`, or unrecognised.
+Downstream code treats it as a direct copy of the source field value.
 
+**Parsed from:** empty cell, `None`, or any unrecognised text
+
+**Mapping JSON:**
 ```json
-{
-  "type": "trim"
-}
+{ "transform": { "type": "noop" } }
+```
+
+**Example:** `"ABC"` → `"ABC"` (unchanged)
+
+---
+
+## 2. `DefaultTransform`
+
+Returns the source value when it is present and non-blank; otherwise returns
+the configured default string.
+
+**Parsed from:**
+- `Default to 'VALUE'`
+- `Default to VALUE`
+- `Default = VALUE`
+
+**Mapping JSON:**
+```json
+{ "transform": { "type": "default", "value": "100030" } }
 ```
 
 **Example:**
-- Input: `"  John Doe  "`
-- Output: `"John Doe"`
-
-**Use Cases:**
-- Clean up user input
-- Remove padding from fixed-width fields
-- Standardize data
+- Source `""` + default `"100030"` → `"100030"`
+- Source `"200000"` + default `"100030"` → `"200000"`
 
 ---
 
-### 2. `upper`
-**Convert text to uppercase**
+## 3. `BlankTransform`
 
+Always outputs a blank (space or custom fill) value, ignoring the source.
+
+**Parsed from:**
+- `Leave Blank`
+- `Leave blank <spaces>`
+- `Pass Blank <spaces>`
+- `Initialize to spaces`
+- `Nullable --> Leave Blank`
+- `Nullable --> 'FILL'` (sets `fill_value`)
+
+**Mapping JSON:**
 ```json
-{
-  "type": "upper"
-}
+{ "transform": { "type": "blank" } }
 ```
 
-**Example:**
-- Input: `"john doe"`
-- Output: `"JOHN DOE"`
-
-**Use Cases:**
-- Standardize names
-- Match database column naming conventions
-- Case-insensitive comparisons
+**Example:** any source → `""` (or spaces when `fill_char` is applied)
 
 ---
 
-### 3. `lower`
-**Convert text to lowercase**
+## 4. `ConstantTransform`
 
+Always outputs a fixed constant string, ignoring the source value entirely.
+
+**Parsed from:**
+- `Pass 'VALUE'`
+- `Hard-code to 'VALUE'`
+- `Hard-Code to 'VALUE'`
+- `Hardcode to 'VALUE'`
+
+**Mapping JSON:**
 ```json
-{
-  "type": "lower"
-}
+{ "transform": { "type": "constant", "value": "000" } }
 ```
 
-**Example:**
-- Input: `"JOHN DOE"`
-- Output: `"john doe"`
-
-**Use Cases:**
-- Normalize email addresses
-- Standardize codes
-- Case-insensitive matching
+**Example:** any source → `"000"`
 
 ---
 
-### 4. `substring`
-**Extract portion of text**
+## 5. `ConcatTransform` + `ConcatPart`
 
+Concatenates multiple source fields in order, with optional per-field LPAD.
+
+`ConcatPart` describes one field reference:
+
+| Attribute | Description |
+|-----------|-------------|
+| `field_name` | Source row field to read |
+| `lpad_width` | Left-pad to this width before concatenating (`0` = no pad) |
+| `lpad_char` | Pad character (default `' '`) |
+
+**Parsed from:**
+- `FIELD1 + FIELD2 + FIELD3`
+- `LPAD(FIELD,N) + FIELD2`
+- `LPAD(FIELD,N,'C') + FIELD2`
+
+**Mapping JSON:**
 ```json
 {
-  "type": "substring",
-  "parameters": {
-    "start": 0,
-    "length": 10
+  "transform": {
+    "type": "concat",
+    "parts": [
+      { "field_name": "PREFIX", "lpad_width": 0, "lpad_char": " " },
+      { "field_name": "ACCOUNT", "lpad_width": 10, "lpad_char": "0" }
+    ]
   }
 }
 ```
 
-**Parameters:**
-- `start` (required): Starting position (0-indexed)
-- `length` (optional): Number of characters to extract. If omitted, extracts to end
+**Example:** `PREFIX="ACT"`, `ACCOUNT="123"` → `"ACT0000000123"`
+
+---
+
+## 6. `FieldMapTransform`
+
+Maps a named source field directly to the output, equivalent to a column
+rename.
+
+**Parsed from:** A bare uppercase identifier with 2+ characters, e.g. `ACCOUNT_NUM`
+
+**Mapping JSON:**
+```json
+{ "transform": { "type": "field_map", "source_field": "ACCOUNT_NUM" } }
+```
+
+**Example:** row `{"ACCOUNT_NUM": "9876"}` → `"9876"`
+
+---
+
+## 7. `DateFormatTransform`
+
+Converts a date string from one `strptime` format to another `strftime`
+format.  Returns `default_value` when the source is absent or unparseable.
+
+Supported format tokens:
+
+| Input text token | Input format | Output format |
+|------------------|--------------|---------------|
+| `CCYYMMDD` / `YYYYMMDD` | `%Y-%m-%d` | `%Y%m%d` |
+| `MM/DD/CCYY` / `MM/DD/YYYY` | `%Y-%m-%d` | `%m/%d/%Y` |
+| `MMDDCCYY` / `MMDDYYYY` | `%m%d%Y` | `%Y%m%d` |
+
+**Parsed from:**
+- `Convert to CCYYMMDD`
+- `Date format CCYYMMDD`
+- `Format as YYYYMMDD`
+- `Reformat date to CCYYMMDD`
+- `Convert date MMDDYYYY`
+- `CCYYMMDD format`
+
+**Mapping JSON:**
+```json
+{
+  "transform": {
+    "type": "date_format",
+    "input_format": "%Y-%m-%d",
+    "output_format": "%Y%m%d",
+    "default_value": ""
+  }
+}
+```
+
+**Example:** `"2025-06-15"` → `"20250615"`; `""` → `""`
+
+---
+
+## 8. `NumericFormatTransform`
+
+Zero-pads a numeric source value to a fixed width, with optional sign prefix
+and implied decimal-place scaling.
+
+| Attribute | Description |
+|-----------|-------------|
+| `length` | Total output width (includes sign char when `signed=True`) |
+| `signed` | Prepend `'+'` or `'-'` to the value |
+| `decimal_places` | Multiply source by `10 ** decimal_places` before padding |
+| `default_value` | Returned for absent or non-numeric source |
+
+**Parsed from:**
+- `+9(N)` — signed COBOL picture (length = N+1)
+- `9(N)` — unsigned COBOL picture
+- `Signed numeric, length N`
+- `Zero-pad to N`
+- `Pad to N digits`
+- `N-digit zero-filled` / `N-digit zero-fill`
+- `Zero-fill to N positions`
+- `Signed N-digit`
+
+**Mapping JSON:**
+```json
+{
+  "transform": {
+    "type": "numeric_format",
+    "length": 13,
+    "signed": true,
+    "decimal_places": 0
+  }
+}
+```
+
+**Example:** `"12345"` with `length=13, signed=True` → `"+000000012345"`
+
+---
+
+## 9. `ScaleTransform`
+
+Multiplies (or divides) the numeric source value by a fixed factor and
+returns the result as a string.
+
+| Attribute | Description |
+|-----------|-------------|
+| `factor` | Multiplier (use `< 1` for division, e.g. `0.01` = divide by 100) |
+| `decimal_places` | Fixed decimal places in output (`-1` = auto via `str()`) |
+| `default_value` | Returned for absent or non-numeric source |
+
+**Parsed from:**
+- `Multiply by N`
+- `Divide by N`
+- `Scale by N`
+- `Times by N`
+- `Times N`
+- `Divide result by N`
+
+**Mapping JSON:**
+```json
+{ "transform": { "type": "scale", "factor": 100.0, "decimal_places": 0 } }
+```
+
+**Example:** `"123.45"` with `factor=100, decimal_places=0` → `"12345"`
+
+---
+
+## 10. `PadTransform`
+
+Pads a source value to a target width without truncating.
+
+| Attribute | Description |
+|-----------|-------------|
+| `length` | Target character width |
+| `pad_char` | Fill character (default `' '`) |
+| `direction` | `'left'` (LPAD) or `'right'` (RPAD) |
+
+**Parsed from:**
+- `Left pad to N with 'C'` / `LPAD to N with 'C'`
+- `Right pad to N` / `Right pad to N with 'C'`
+- `Pad to N with spaces` / `Pad to N`
+- `Space-pad to N`
+- `Zero-fill left to N`
+- `Pad left N zeros`
+
+**Mapping JSON:**
+```json
+{
+  "transform": {
+    "type": "pad",
+    "length": 10,
+    "pad_char": "0",
+    "direction": "left"
+  }
+}
+```
+
+**Example:** `"42"` with `length=5, pad_char='0', direction='left'` → `"00042"`
+
+---
+
+## 11. `TruncateTransform`
+
+Truncates a source value to at most `length` characters.
+
+| Attribute | Description |
+|-----------|-------------|
+| `length` | Maximum characters to keep |
+| `from_end` | When `True`, keep the last N chars instead of the first |
+
+**Parsed from:**
+- `Truncate to N`
+- `Truncate to N chars` / `Truncate to N characters`
+- `Truncate decimal places` (produces `length=0`, acts as annotation)
+
+**Mapping JSON:**
+```json
+{ "transform": { "type": "truncate", "length": 8, "from_end": false } }
+```
+
+**Example:** `"ABCDEFGHIJ"` with `length=5` → `"ABCDE"`
+
+---
+
+## 12. Conditions
+
+Conditions are used inside `ConditionalTransform`.  They are never produced
+directly by `parse_transform()` but are embedded in conditional objects.
+
+### `NullCheckCondition`
+
+Tests whether a field is null (absent, `None`, or whitespace-only).
+
+| `negate` | Semantics |
+|----------|-----------|
+| `False` (default) | IS NULL |
+| `True` | IS NOT NULL |
+
+**Parsed from (within IF expression):**
+- `IF FIELD IS NULL THEN ...`
+- `IF FIELD IS NOT NULL THEN ...`
+- `IF FIELD not null THEN ...`
+
+### `EqualityCondition`
+
+Tests whether a field equals (or not-equals) a given value (case-sensitive,
+whitespace-stripped).
+
+**Parsed from (within IF expression):**
+- `IF FIELD = 'VALUE' THEN ...`
+- `IF FIELD != 'VALUE' THEN ...`
+- `IF FIELD <> 'VALUE' THEN ...`
+
+### `InCondition`
+
+Tests whether a field value is a member of a list.
+
+**Parsed from (within IF expression):**
+- `IF FIELD IN ('A','B','C') THEN ...`
+- `IF FIELD = 'A' or 'B' THEN ...`
+
+---
+
+## 13. `ConditionalTransform`
+
+Dispatches to one of two child transforms depending on whether a condition
+holds against the current row.
+
+| Attribute | Description |
+|-----------|-------------|
+| `condition` | A `NullCheckCondition`, `EqualityCondition`, or `InCondition` |
+| `then_transform` | Applied when condition is `True` |
+| `else_transform` | Applied when condition is `False` (defaults to noop) |
+
+**Parsed from:** `IF <condition> THEN <branch> [ELSE <branch>]`
+
+Branch values can be:
+- A quoted literal `'VALUE'` → `ConstantTransform`
+- A bare uppercase field name → `FieldMapTransform`
+- Any other recognised phrase (e.g. `Default to 'X'`, `Leave Blank`) → recursive `parse_transform()`
+
+**Mapping JSON:**
+```json
+{
+  "transform": {
+    "type": "conditional",
+    "condition": { "type": "null_check", "field": "AMOUNT", "negate": false },
+    "then_transform": { "type": "constant", "value": "0" },
+    "else_transform": { "type": "field_map", "source_field": "AMOUNT" }
+  }
+}
+```
 
 **Examples:**
-
-Extract first 5 characters:
-```json
-{
-  "type": "substring",
-  "parameters": {"start": 0, "length": 5}
-}
-```
-- Input: `"CUSTOMER123"`
-- Output: `"CUSTO"`
-
-Extract from position 8 to end:
-```json
-{
-  "type": "substring",
-  "parameters": {"start": 8}
-}
-```
-- Input: `"CUSTOMER123"`
-- Output: `"123"`
-
-**Use Cases:**
-- Extract year from date string
-- Get prefix/suffix from codes
-- Split concatenated fields
+- `IF AMOUNT IS NULL THEN '0' ELSE AMOUNT`
+  - row `{"AMOUNT": ""}` → `"0"`
+  - row `{"AMOUNT": "99"}` → `"99"`
+- `IF STATUS = 'A' THEN 'ACTIVE' ELSE 'INACTIVE'`
 
 ---
 
-### 5. `replace`
-**Replace text with another value**
+## 14. `SequentialNumberTransform` + `SequentialCounter`
 
+Assigns an incrementing sequence number to each processed record.
+
+| Attribute | Description |
+|-----------|-------------|
+| `start` | Value emitted for the first record (default `1`) |
+| `step` | Increment per record (default `1`) |
+| `pad_length` | Zero-pad to this width (default `None` = no padding) |
+
+`SequentialCounter` (`src/transforms/sequential_counter.py`) is the stateful
+manager that tracks the current value across records.  When no counter is
+provided to `apply_transform()` the transform falls back to `str(start)`.
+
+**Parsed from:** `Sequential`, `sequential number`, `sequence`
+
+**Mapping JSON:**
 ```json
 {
-  "type": "replace",
-  "parameters": {
-    "old": "-",
-    "new": ""
+  "transform": {
+    "type": "sequential",
+    "start": 1,
+    "step": 1,
+    "pad_length": 5
   }
 }
 ```
 
-**Parameters:**
-- `old` (required): Text to find
-- `new` (required): Replacement text
-
-**Examples:**
-
-Remove dashes:
-```json
-{
-  "type": "replace",
-  "parameters": {"old": "-", "new": ""}
-}
-```
-- Input: `"555-123-4567"`
-- Output: `"5551234567"`
-
-Replace spaces with underscores:
-```json
-{
-  "type": "replace",
-  "parameters": {"old": " ", "new": "_"}
-}
-```
-- Input: `"John Doe"`
-- Output: `"John_Doe"`
-
-**Use Cases:**
-- Remove special characters
-- Standardize formats
-- Clean phone numbers, SSNs, etc.
+**Example:** records 1, 2, 3 → `"00001"`, `"00002"`, `"00003"`
 
 ---
 
-### 6. `cast`
-**Convert data type**
+## Related Source Files
 
-```json
-{
-  "type": "cast",
-  "parameters": {
-    "to_type": "number"
-  }
-}
-```
+| File | Purpose |
+|------|---------|
+| `src/transforms/models.py` | All transform and condition dataclasses |
+| `src/transforms/transform_parser.py` | `parse_transform()` — text → dataclass |
+| `src/transforms/transform_engine.py` | `apply_transform()` — dataclass → string |
+| `src/transforms/condition_evaluator.py` | `evaluate_condition()` — condition → bool |
+| `src/transforms/sequential_counter.py` | Stateful counter for sequential transforms |
+| `src/transforms/transform_orchestrator.py` | `TransformEngine` — high-level orchestration |
+| `src/transforms/multi_record_transform_engine.py` | Multi-record-type transform engine |
+| `src/transforms/transform_mismatch_reporter.py` | Mismatch reporting for transform output |
 
-**Parameters:**
-- `to_type` (required): Target type - `"number"`, `"date"`, or `"string"`
+## Related Documentation
 
-**Examples:**
-
-Convert to number:
-```json
-{
-  "type": "cast",
-  "parameters": {"to_type": "number"}
-}
-```
-- Input: `"123.45"`
-- Output: `123.45`
-
-Convert to date:
-```json
-{
-  "type": "cast",
-  "parameters": {"to_type": "date"}
-}
-```
-- Input: `"2026-02-07"`
-- Output: `2026-02-07` (datetime object)
-
-**Use Cases:**
-- Convert string amounts to numbers
-- Parse date strings
-- Type conversion for calculations
-
-**Note:** Invalid conversions will result in `NaN` or `NaT` (Not a Time)
-
----
-
-## 🔗 Chaining Transformations
-
-You can apply multiple transformations in sequence. They are executed in order:
-
-```json
-"transformations": [
-  {"type": "trim"},
-  {"type": "upper"},
-  {
-    "type": "replace",
-    "parameters": {"old": "-", "new": ""}
-  }
-]
-```
-
-**Example:**
-- Input: `"  john-doe  "`
-- After `trim`: `"john-doe"`
-- After `upper`: `"JOHN-DOE"`
-- After `replace`: `"JOHNDOE"`
-
----
-
-## 📝 Complete Examples
-
-### Example 1: Clean Customer Name
-
-```json
-{
-  "source_column": "customer_name",
-  "target_column": "CUSTOMER_NAME",
-  "data_type": "string",
-  "transformations": [
-    {"type": "trim"},
-    {"type": "upper"}
-  ]
-}
-```
-
-### Example 2: Format Phone Number
-
-```json
-{
-  "source_column": "phone",
-  "target_column": "PHONE",
-  "data_type": "string",
-  "transformations": [
-    {"type": "trim"},
-    {
-      "type": "replace",
-      "parameters": {"old": "-", "new": ""}
-    },
-    {
-      "type": "replace",
-      "parameters": {"old": "(", "new": ""}
-    },
-    {
-      "type": "replace",
-      "parameters": {"old": ")", "new": ""}
-    },
-    {
-      "type": "replace",
-      "parameters": {"old": " ", "new": ""}
-    }
-  ]
-}
-```
-- Input: `"(555) 123-4567"`
-- Output: `"5551234567"`
-
-### Example 3: Extract Year from Date
-
-```json
-{
-  "source_column": "transaction_date",
-  "target_column": "YEAR",
-  "data_type": "string",
-  "transformations": [
-    {"type": "trim"},
-    {
-      "type": "substring",
-      "parameters": {"start": 0, "length": 4}
-    }
-  ]
-}
-```
-- Input: `"2026-02-07"`
-- Output: `"2026"`
-
-### Example 4: Normalize Email
-
-```json
-{
-  "source_column": "email",
-  "target_column": "EMAIL",
-  "data_type": "string",
-  "transformations": [
-    {"type": "trim"},
-    {"type": "lower"}
-  ]
-}
-```
-- Input: `"  JOHN.DOE@EXAMPLE.COM  "`
-- Output: `"john.doe@example.com"`
-
-### Example 5: Convert Amount to Number
-
-```json
-{
-  "source_column": "amount",
-  "target_column": "AMOUNT",
-  "data_type": "number",
-  "transformations": [
-    {"type": "trim"},
-    {
-      "type": "replace",
-      "parameters": {"old": "$", "new": ""}
-    },
-    {
-      "type": "replace",
-      "parameters": {"old": ",", "new": ""}
-    },
-    {
-      "type": "cast",
-      "parameters": {"to_type": "number"}
-    }
-  ]
-}
-```
-- Input: `"$1,234.56"`
-- Output: `1234.56`
-
-### Example 6: Extract Account Number
-
-```json
-{
-  "source_column": "full_account",
-  "target_column": "ACCOUNT_NUM",
-  "data_type": "string",
-  "transformations": [
-    {"type": "trim"},
-    {
-      "type": "substring",
-      "parameters": {"start": 3, "length": 10}
-    }
-  ]
-}
-```
-- Input: `"ACC1234567890XYZ"`
-- Output: `"1234567890"`
-
----
-
-## 🎯 Common Patterns
-
-### Pattern 1: Standard Text Field
-```json
-"transformations": [
-  {"type": "trim"}
-]
-```
-
-### Pattern 2: Code/ID Field
-```json
-"transformations": [
-  {"type": "trim"},
-  {"type": "upper"}
-]
-```
-
-### Pattern 3: Email/Username
-```json
-"transformations": [
-  {"type": "trim"},
-  {"type": "lower"}
-]
-```
-
-### Pattern 4: Numeric Field
-```json
-"transformations": [
-  {"type": "trim"},
-  {"type": "cast", "parameters": {"to_type": "number"}}
-]
-```
-
-### Pattern 5: Remove All Special Characters
-```json
-"transformations": [
-  {"type": "trim"},
-  {"type": "replace", "parameters": {"old": "-", "new": ""}},
-  {"type": "replace", "parameters": {"old": " ", "new": ""}},
-  {"type": "replace", "parameters": {"old": ".", "new": ""}}
-]
-```
-
----
-
-## ⚠️ Important Notes
-
-1. **Order Matters**: Transformations are applied in the order specified
-2. **String Operations**: `trim`, `upper`, `lower`, `substring`, `replace` only work on string data
-3. **Type Conversion**: Use `cast` carefully - invalid conversions produce `NaN`/`NaT`
-4. **Null Values**: Most transformations handle null/empty values gracefully
-5. **Performance**: Minimize transformation chains for large datasets
-
----
-
-## 🔍 Transformation Implementation
-
-All transformations are implemented in:
-[`src/config/mapping_parser.py`](../src/config/mapping_parser.py)
-
-The `_apply_transformation` method (lines 149-185) handles all transformation logic.
-
----
-
-## 📚 Related Documentation
-
-- **Mapping Quick Start**: [`docs/MAPPING_QUICKSTART.md`](MAPPING_QUICKSTART.md)
-- **Universal Mapping Guide**: [`docs/UNIVERSAL_MAPPING_GUIDE.md`](UNIVERSAL_MAPPING_GUIDE.md)
-- **Validation Rules**: See mapping documentation for validation rule types
-
----
-
-## 💡 Tips
-
-1. **Always trim first**: Start with `{"type": "trim"}` to remove whitespace
-2. **Test transformations**: Use small sample files to verify transformations work as expected
-3. **Document complex chains**: Add comments in your mapping file explaining multi-step transformations
-4. **Consider performance**: Each transformation adds processing time
-5. **Handle edge cases**: Test with empty values, special characters, and boundary conditions
+- [Mapping Quick Start](MAPPING_QUICKSTART.md)
+- [Universal Mapping Guide](UNIVERSAL_MAPPING_GUIDE.md)
+- [Usage and Operations Guide](USAGE_AND_OPERATIONS_GUIDE.md)

--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -1301,6 +1301,20 @@ The `default_value` column sits between `format` and `transformation`. If both
 an explicit `default_value` and a "Default to ..." phrase in `transformation`
 are present, the explicit column value takes precedence.
 
+**Example: transformation column patterns in mapping JSON:**
+
+```json
+{"target_name": "CUST_ID",  "transformation": "Pass as is"},
+{"target_name": "ACCT_KEY", "transformation": "BR + CUS + LN"},
+{"target_name": "DATE_OUT", "transformation": "Date YYYYMMDD to MM/DD/YYYY"},
+{"target_name": "AMOUNT",   "transformation": "Pass 'DEFAULT_AMOUNT'"},
+{"target_name": "SEQ_NUM",  "transformation": "Sequential from 1"}
+```
+
+See the Transform Engine section (§ 9.5) and `docs/TRANSFORMATION_TYPES.md`
+for the full list of recognised text patterns and their generated transform
+types.
+
 **Note on fixed-width length warnings:** If any fixed-width field has a missing
 `length` value, the converter emits a warning. This warning is included in the
 upload API response so you can fix the template before validation.
@@ -1625,17 +1639,21 @@ multi-record YAML config without writing YAML by hand.
 
 1. **Select Record Types** — choose one or more mappings from the list.
 2. **Configure Discriminator** — enter the field name, position (1-indexed),
-   and length.  Click **Auto-detect** to upload a sample batch file and have
-   the server suggest the most likely discriminator position automatically.
+   and length. Click **Auto-detect** to upload a sample batch file; the UI
+   calls `POST /api/v1/multi-record/detect-discriminator` and pre-fills the
+   position and length fields with the best candidate returned by the server.
 3. **Map Codes to Record Types** — for each selected mapping, enter the
-   discriminator code value (e.g. `HDR`) and optional cardinality settings.
+   discriminator code value (e.g. `HDR`) and optional cardinality settings
+   (min/max occurrences per file).
 4. **Cross-Type Rules** *(optional)* — add rules that span record types such
    as `required_companion`, `header_trailer_count`, or `type_sequence`.
    Click **Skip** to go straight to Step 5.
 5. **Preview & Download** — click **Generate YAML** to call
-   `POST /api/v1/multi-record/generate` and display the YAML config.  Use
-   **Copy YAML**, **Download YAML**, or **Validate File With This Config**
-   (switches to the Quick Test tab with the config ready).
+   `POST /api/v1/multi-record/generate` and display the YAML config. Use
+   **Copy YAML** or **Download YAML** to save the config, or click
+   **Validate File With This Config** to store the generated YAML and
+   automatically switch to the Quick Test tab with the config pre-loaded
+   and ready for a file upload.
 
 To open the wizard: switch to the **Mapping Generator** tab and click
 **Start Wizard** in the Multi-Record Config Wizard section.
@@ -2062,6 +2080,23 @@ valdo db-compare \
 | `--key-columns` | `-k` | No | Comma-separated column names used as join keys for row matching |
 | `--output-format` | | No | `json` (default) or `html` |
 | `--output` | `-o` | No | File path for the written report |
+| `--apply-transforms` | | No | Pass each DB row through the field-level transforms defined in the mapping before comparison |
+
+#### Applying Transforms Before Comparison
+
+When set, each DB row is passed through the field-level transforms defined in
+the mapping before comparison. This is useful when DB data requires reformatting
+(e.g. date format changes, zero-padding, concatenation) to match the expected
+batch file layout.
+
+```bash
+# Apply field-level transforms from the mapping before comparing
+valdo db-compare \
+  --query-or-table "SELECT * FROM CM3INT.FOO_TABLE" \
+  --mapping config/mappings/foo_mapping.json \
+  --actual-file data/foo_batch.txt \
+  --apply-transforms
+```
 
 #### API Usage
 
@@ -2416,6 +2451,51 @@ Use the `list-runs` command to view recent run history from the terminal:
 valdo list-runs
 ```
 
+#### What Is Stored
+
+Each run record captures:
+
+| Field | Description |
+|---|---|
+| `run_id` | Unique UUID for the run |
+| `timestamp` | UTC timestamp when the run started |
+| `command` | The Valdo command that was executed (e.g. `validate`, `compare`) |
+| `status` | Overall result: `passed` or `failed` |
+| `file_paths` | Input/output file paths associated with the run |
+| `row_counts` | Number of rows processed and number of errors found |
+| `error_messages` | First-N error messages for quick diagnosis |
+
+Run history is persisted via `run_history_service` using whichever DB adapter
+is configured (`oracle`, `postgresql`, or `sqlite`). Oracle uses the
+`CM3_RUN_HISTORY` and `CM3_RUN_TESTS` tables described above; SQLite stores
+the same data in a local `.db` file, which is useful for development and
+offline environments.
+
+#### Viewing Runs in the Web UI
+
+The **Recent Runs** tab in the Web UI shows the last N runs in a sortable
+table with auto-refresh. Each row displays the run ID, timestamp, command,
+status, row count, and a link to the HTML report.
+
+#### Programmatic Access
+
+```bash
+# Fetch the 20 most recent runs (default)
+curl http://localhost:8000/api/v1/runs/
+
+# Fetch with a custom limit
+curl "http://localhost:8000/api/v1/runs/?limit=50"
+```
+
+The response is a JSON array ordered newest-first. Each element mirrors the
+`CM3_RUN_HISTORY` schema above.
+
+#### Retention
+
+Run history retention is configurable. Set the `RUN_HISTORY_RETENTION_DAYS`
+environment variable (default: `90`) to control how many days of history are
+kept before older records are purged automatically on the next run.
+
 ---
 
 ### 8.7 Cross-Row Validation with DB Data
@@ -2702,6 +2782,109 @@ steps:
 
 The command exits non-zero on failure, so the Azure DevOps pipeline step
 will fail automatically if any blocking gate does not pass.
+
+---
+
+## 9.5 Transform Engine
+
+The Transform Engine parses free-text transformation descriptions from mapping
+spreadsheet cells and applies them to field values at run time. It is used
+during `db-compare --apply-transforms` to reformat DB data before comparison,
+and is available as a Python API for use in custom pipelines.
+
+> For the complete reference, see `docs/TRANSFORMATION_TYPES.md`.
+
+### Overview
+
+Transformations are stored in the `transformation` column of a mapping CSV
+template (or the equivalent field in mapping JSON). The transform parser
+(`parse_transform()`) converts the free-text description into a typed dataclass;
+the transform engine (`apply_transform()`) then executes it against a field value.
+
+### Transform Types Reference
+
+| Transform | Example text pattern | Description |
+|---|---|---|
+| **noop** (pass-through) | *(empty cell)* | Returns the source value unchanged |
+| **DefaultTransform** | `Default to '100030'` | Returns source when present; otherwise returns the default string |
+| **BlankTransform** | `Leave Blank` | Always outputs blank/spaces, ignoring source |
+| **ConstantTransform** | `Pass 'USD'` / `Hard-code to '000'` | Always outputs a fixed constant, ignoring source |
+| **ConcatTransform** | `BR + CUS + LN` / `LPAD(FIELD,10,'0') + FIELD2` | Concatenates multiple source fields with optional LPAD per field |
+| **FieldMapTransform** | `ACCOUNT_NUM` | Maps a named source field to output (column rename) |
+| **DateFormatTransform** | `Date YYYYMMDD to MM/DD/YYYY` / `Convert to CCYYMMDD` | Converts date strings between strptime/strftime formats |
+| **NumericFormatTransform** | `9(13)` / `+9(12)` / `Zero-pad to 10` | Zero-pads numeric values to a fixed width; supports sign prefix and implied decimal scaling |
+| **ScaleTransform** | `Multiply by 100` / `Divide by 1000` | Multiplies or divides a numeric value by a fixed factor |
+| **PadTransform** | `Left pad to 10 with '0'` / `Right pad to 20` | Pads a value to a target width (left or right) without truncating |
+| **TruncateTransform** | `Truncate to 8` | Truncates a value to at most N characters |
+| **ConditionalTransform** | `IF FIELD IS NULL THEN '0' ELSE FIELD` | Dispatches to one of two child transforms based on a condition |
+| **SequentialNumberTransform** | `Sequential` / `Sequential from 1` | Assigns an incrementing sequence number to each record |
+
+### Condition System
+
+Conditions are embedded inside `ConditionalTransform` and test the current row:
+
+- **NullCheckCondition** — tests whether a field is null/blank: `IF FIELD IS NULL THEN ...` or `IF FIELD IS NOT NULL THEN ...`
+- **EqualityCondition** — tests equality or inequality: `IF STATUS = 'A' THEN ... ELSE ...` or `IF FLAG != 'Y' THEN ...`
+- **InCondition** — tests membership in a value list: `IF TYPE IN ('A','B','C') THEN ...`
+
+### Using Transforms in Mapping JSON
+
+The `transformation` column in mapping CSVs is the primary input. In the
+generated mapping JSON the parsed result is stored under the `transform` key:
+
+```json
+{
+  "fields": [
+    {"target_name": "CUST_ID",    "transformation": "Pass as is"},
+    {"target_name": "ACCT_KEY",   "transformation": "BR + CUS + LN"},
+    {"target_name": "DATE_OUT",   "transformation": "Date YYYYMMDD to MM/DD/YYYY"},
+    {"target_name": "AMOUNT",     "transformation": "Pass 'DEFAULT_AMOUNT'"},
+    {"target_name": "SEQ_NUM",    "transformation": "Sequential from 1"}
+  ]
+}
+```
+
+When the mapping CSV is uploaded via the Mapping Generator tab or
+`POST /api/v1/mappings/upload`, the converter automatically calls
+`parse_transform()` and embeds the result in each field entry.
+
+### Python API
+
+```python
+from src.transforms.transform_parser import parse_transform
+from src.transforms.transform_engine import apply_transform
+from src.transforms.condition_evaluator import evaluate_condition
+
+# Parse a transform from free text
+tx = parse_transform("Date YYYYMMDD to MM/DD/YYYY")
+
+# Apply it to a value (pass the full row dict for field-reference transforms)
+result = apply_transform(tx, "20250615", row={})
+# → "06/15/2025"
+
+# Evaluate a condition independently
+from src.transforms.models import EqualityCondition
+cond = EqualityCondition(field="STATUS", value="A")
+is_match = evaluate_condition(cond, row={"STATUS": "A"})
+# → True
+```
+
+### The --apply-transforms Flag
+
+Pass `--apply-transforms` to `valdo db-compare` to run every DB row through
+its mapping transforms before the field-by-field comparison:
+
+```bash
+valdo db-compare \
+  --query-or-table "SELECT * FROM CM3INT.FOO_TABLE" \
+  --mapping config/mappings/foo_mapping.json \
+  --actual-file data/foo_batch.txt \
+  --apply-transforms
+```
+
+This is especially useful when the DB stores data in a normalised form
+(e.g. ISO dates, unpadded numbers) while the batch file uses a legacy
+layout (e.g. `MMDDYYYY`, zero-padded fixed-width fields).
 
 ---
 

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -316,6 +316,26 @@ Transforms
    :members:
    :undoc-members:
 
+.. automodule:: src.transforms.condition_evaluator
+   :members:
+   :undoc-members:
+
+.. automodule:: src.transforms.sequential_counter
+   :members:
+   :undoc-members:
+
+.. automodule:: src.transforms.transform_orchestrator
+   :members:
+   :undoc-members:
+
+.. automodule:: src.transforms.multi_record_transform_engine
+   :members:
+   :undoc-members:
+
+.. automodule:: src.transforms.transform_mismatch_reporter
+   :members:
+   :undoc-members:
+
 Reporting & Utilities
 ---------------------
 


### PR DESCRIPTION
## Summary

- **USAGE_AND_OPERATIONS_GUIDE.md:** Added `--apply-transforms` flag to `db-compare` docs with example; new §9.5 Transform Engine section covering all 13 transform types, condition system, Python API, and mapping JSON examples; expanded run history docs (stored fields, Web UI, REST, retention); expanded multi-record wizard UI step details; transform pattern examples in mapping JSON reference
- **TRANSFORMATION_TYPES.md:** Completely rewrote — replaced obsolete pre-Phase-1 string-transform docs with accurate Phase 1–4 typed-dataclass reference covering all 14 transform types with parse patterns, examples, and condition/ConditionalTransform coverage
- **docs/sphinx/modules.rst:** Registered 5 missing transform modules (`condition_evaluator`, `sequential_counter`, `transform_orchestrator`, `multi_record_transform_engine`, `transform_mismatch_reporter`)

## Test plan

- [x] 1410 unit tests pass, 80.52% coverage (no code changes)
- [x] Sphinx build succeeds (only pre-existing errors in `db_file_compare_service.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)