### PR TITLE
fix(ui): make multi-record YAML input always visible in Quick Test

### DIFF
--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -167,23 +167,16 @@
 
     <!-- Multi-record YAML (optional) -->
     <div class="mapping-search-wrap">
-      <button type="button" id="btnToggleMrYaml"
-              style="background:none;border:none;cursor:pointer;display:flex;align-items:center;gap:6px;font-size:13px;color:var(--text-secondary);padding:0;"
-              aria-expanded="false" aria-controls="mrYamlSection"
-              onclick="toggleMrYamlSection()">
-        <svg id="mrYamlChevron" aria-hidden="true" focusable="false" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" style="transition:transform .2s">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
-        </svg>
-        Multi-record YAML <span style="font-size:11px;opacity:.65">(optional)</span>
-      </button>
-      <div id="mrYamlSection" style="display:none;margin-top:8px;">
-        <input type="file" id="qtMrYamlInput" accept=".yaml,.yml"
-               style="font-size:13px;color:var(--text-primary);"
-               aria-label="Multi-record YAML config file">
-        <div style="font-size:11px;color:var(--text-secondary);margin-top:4px;">
-          Validate against a multi-record YAML config instead of a mapping.
-          When set, no mapping selection is required.
-        </div>
+      <label style="font-size:12px;font-weight:600;color:var(--text-secondary);letter-spacing:.04em;text-transform:uppercase;display:block;margin-bottom:6px;">
+        Multi-record YAML
+        <span style="font-weight:400;text-transform:none;opacity:.7;margin-left:4px;">(optional — use instead of a mapping)</span>
+      </label>
+      <input type="file" id="qtMrYamlInput" accept=".yaml,.yml"
+             style="font-size:13px;color:var(--text-primary);width:100%;"
+             aria-label="Multi-record YAML config file">
+      <div style="font-size:11px;color:var(--text-secondary);margin-top:4px;">
+        Upload a multi-record YAML config to validate header/detail/trailer files.
+        Generate one in the <a href="#" onclick="switchTab('mapping');return false;" style="color:var(--accent);">Mapping Generator</a> tab.
       </div>
     </div>
 

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -384,20 +384,6 @@ function setBtnLoading(btn, isLoading) {
   }
 }
 
-// ===========================================================================
-// Multi-record YAML toggle (Quick Test)
-// ===========================================================================
-function toggleMrYamlSection() {
-  var section = document.getElementById('mrYamlSection');
-  var btn = document.getElementById('btnToggleMrYaml');
-  var chevron = document.getElementById('mrYamlChevron');
-  var expanded = btn.getAttribute('aria-expanded') === 'true';
-  section.style.display = expanded ? 'none' : '';
-  btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-  chevron.style.transform = expanded ? '' : 'rotate(90deg)';
-  updateButtons();
-}
-
 document.getElementById('qtMrYamlInput').addEventListener('change', updateButtons);
 
 // ===========================================================================
@@ -1469,15 +1455,6 @@ function mrValidateWithConfig() {
   var input = document.getElementById('qtMrYamlInput');
   if (input) {
     input.files = dt.files;
-    // Expand the section so the user can see it is set.
-    var section = document.getElementById('mrYamlSection');
-    var btn = document.getElementById('btnToggleMrYaml');
-    var chevron = document.getElementById('mrYamlChevron');
-    if (section && section.style.display === 'none') {
-      section.style.display = '';
-      if (btn) btn.setAttribute('aria-expanded', 'true');
-      if (chevron) chevron.style.transform = 'rotate(90deg)';
-    }
     updateButtons();
   }
 


### PR DESCRIPTION
## Summary

- Multi-record YAML file input in Quick Test was hidden behind a collapsible toggle — easy to miss
- Now always visible as a labelled file input with helper text and a link to the Mapping Generator tab
- Removed the toggle button and expand/collapse logic (dead code cleanup)

## Test plan

- [ ] Open Quick Test tab — "Multi-record YAML" input is immediately visible below the PII toggle
- [ ] Upload a `.yaml` file — Validate button enables without selecting a mapping
- [ ] All 1417 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)