### PR TITLE
feat(service): trend_service.py — daily aggregation logic (JSON + DB path) (#240)

### DIFF
--- a/src/services/baseline_service.py
+++ b/src/services/baseline_service.py
@@ -1,0 +1,240 @@
+"""JSON-backed rolling baseline store for per-suite quality metrics.
+
+Baselines are persisted to ``reports/baselines.json`` using the same
+read-modify-write pattern as ``reports/run_history.json``.  Each suite
+maintains a rolling window of its last 10 runs; averages are recomputed
+on every call to :func:`update_baseline`.
+
+Storage format (``reports/baselines.json``)::
+
+    {
+        "SUITE_A": {
+            "baseline": {
+                "suite_name": "SUITE_A",
+                "pass_rate": 87.5,
+                "avg_quality_score": 91.2,
+                "avg_error_rate": 2.3,
+                "sample_size": 10,
+                "updated_at": "2026-03-30T14:00:00"
+            },
+            "history": [
+                {"pass_rate": 80.0, "quality_score": 90.0, "error_rate": 1.0},
+                ...
+            ]
+        },
+        ...
+    }
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BASELINES_PATH: Path = Path(__file__).parent.parent.parent / "reports" / "baselines.json"
+"""Absolute path to the JSON file that stores all suite baselines and history."""
+
+_ROLLING_WINDOW: int = 10
+"""Maximum number of historical runs to keep per suite when computing averages."""
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_store(path: Path) -> dict[str, Any]:
+    """Read the baselines JSON file from disk.
+
+    Returns an empty dict when the file does not exist or contains corrupt JSON.
+    The corrupt-JSON case is logged as a warning and treated as a fresh store
+    (consistent with the run_history pattern).
+
+    Args:
+        path: Path to the baselines JSON file.
+
+    Returns:
+        Dict mapping suite_name to its ``{"baseline": ..., "history": [...]}`` record.
+    """
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("baselines.json is unreadable, starting fresh: %s", exc)
+        return {}
+
+
+def _save_store(path: Path, store: dict[str, Any]) -> None:
+    """Write the baselines store dict to disk as formatted JSON.
+
+    Creates parent directories as needed.
+
+    Args:
+        path: Path to the baselines JSON file.
+        store: Full in-memory store dict to persist.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+
+
+def _compute_error_rate(invalid_rows: int, total_rows: int) -> float:
+    """Compute per-run error rate as a percentage.
+
+    Args:
+        invalid_rows: Number of rows that failed validation.
+        total_rows: Total rows processed.
+
+    Returns:
+        ``invalid_rows / total_rows * 100``, or ``0.0`` when ``total_rows`` is zero.
+    """
+    if total_rows == 0:
+        return 0.0
+    return invalid_rows / total_rows * 100.0
+
+
+def _average_or_none(values: list[float]) -> Optional[float]:
+    """Return the arithmetic mean of *values*, or ``None`` for an empty list.
+
+    Args:
+        values: Non-empty list of floats to average.
+
+    Returns:
+        Mean value, or ``None`` if *values* is empty.
+    """
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _recompute_baseline(suite_name: str, history: list[dict[str, Any]]) -> dict[str, Any]:
+    """Recompute the baseline summary from the rolling history window.
+
+    Args:
+        suite_name: Name of the suite.
+        history: List of per-run snapshot dicts with keys ``pass_rate``,
+            ``quality_score`` (optional), and ``error_rate``.
+
+    Returns:
+        Baseline dict with keys: suite_name, pass_rate, avg_quality_score,
+        avg_error_rate, sample_size, updated_at.
+    """
+    pass_rates = [h["pass_rate"] for h in history]
+    quality_scores = [h["quality_score"] for h in history if h.get("quality_score") is not None]
+    error_rates = [h["error_rate"] for h in history]
+
+    return {
+        "suite_name": suite_name,
+        "pass_rate": _average_or_none(pass_rates),
+        "avg_quality_score": _average_or_none(quality_scores),
+        "avg_error_rate": _average_or_none(error_rates) or 0.0,
+        "sample_size": len(history),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
+    """Append *result* to the rolling history and recompute the baseline.
+
+    Reads the current store from ``reports/baselines.json``, appends a
+    per-run snapshot derived from *result* to the suite's history, caps
+    the history at :data:`_ROLLING_WINDOW` entries (oldest dropped first),
+    recomputes all averages, persists the updated store, and returns the
+    new baseline dict.
+
+    Args:
+        suite_name: Logical name of the test suite (e.g. ``"ATOCTRAN"``).
+        result: Run result dict.  Expected keys (all optional — missing keys
+            are treated as zero or absent):
+
+            * ``pass_count`` — number of tests that passed.
+            * ``total_count`` — total tests executed.
+            * ``invalid_rows`` — row-level validation failures.
+            * ``total_rows`` — total rows inspected.
+            * ``quality_score`` — optional float quality score (0–100).
+
+    Returns:
+        Updated baseline dict with keys: suite_name, pass_rate,
+        avg_quality_score, avg_error_rate, sample_size, updated_at.
+    """
+    path = _BASELINES_PATH
+
+    store = _load_store(path)
+    suite_record = store.get(suite_name, {"baseline": {}, "history": []})
+
+    # Build per-run snapshot
+    pass_count = result.get("pass_count", 0)
+    total_count = result.get("total_count", 0)
+    pass_rate = (pass_count / total_count * 100.0) if total_count > 0 else 0.0
+
+    invalid_rows = result.get("invalid_rows", 0)
+    total_rows = result.get("total_rows", 0)
+    error_rate = _compute_error_rate(invalid_rows, total_rows)
+
+    snapshot: dict[str, Any] = {
+        "pass_rate": pass_rate,
+        "quality_score": result.get("quality_score"),  # None when absent
+        "error_rate": error_rate,
+    }
+
+    # Append and cap the rolling window
+    history: list[dict[str, Any]] = suite_record["history"]
+    history.append(snapshot)
+    if len(history) > _ROLLING_WINDOW:
+        history = history[-_ROLLING_WINDOW:]
+
+    # Recompute and persist
+    baseline = _recompute_baseline(suite_name, history)
+    store[suite_name] = {"baseline": baseline, "history": history}
+    _save_store(path, store)
+
+    return baseline
+
+
+def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
+    """Return the stored baseline for *suite_name*, or ``None`` if absent.
+
+    Args:
+        suite_name: Name of the suite to look up.
+
+    Returns:
+        Baseline dict with keys: suite_name, pass_rate, avg_quality_score,
+        avg_error_rate, sample_size, updated_at; or ``None`` if no baseline
+        has been recorded for this suite yet.
+    """
+    path = _BASELINES_PATH
+    store = _load_store(path)
+    record = store.get(suite_name)
+    if record is None:
+        return None
+    return record.get("baseline") or None
+
+
+def list_baselines() -> list[dict[str, Any]]:
+    """Return all stored baselines sorted alphabetically by suite name.
+
+    Returns:
+        List of baseline dicts (see :func:`get_baseline`), sorted by
+        ``suite_name``.  Returns an empty list when no baselines exist.
+    """
+    path = _BASELINES_PATH
+    store = _load_store(path)
+    baselines = [
+        record["baseline"]
+        for record in store.values()
+        if record.get("baseline")
+    ]
+    return sorted(baselines, key=lambda b: b.get("suite_name", ""))

--- a/src/services/deviation_detector.py
+++ b/src/services/deviation_detector.py
@@ -1,0 +1,112 @@
+"""Statistical deviation detector — compares a run result against its suite baseline."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+DEFAULT_THRESHOLDS = {
+    'pass_rate_drop': 10.0,    # percentage points
+    'quality_drop': 5.0,       # percentage points
+    'error_rate_spike': 20.0,  # percentage points
+}
+
+
+def check_deviation(
+    suite_name: str,
+    result: dict,
+    thresholds: Optional[dict] = None,
+) -> dict:
+    """Compare a completed run against the stored suite baseline.
+
+    Fetches the baseline for *suite_name* via ``baseline_service.get_baseline``
+    and checks whether any of the three tracked metrics has moved beyond its
+    configured threshold.
+
+    Args:
+        suite_name: Name of the suite to check.
+        result: Run result dict with keys: passed, total_rows, invalid_rows,
+            quality_score.
+        thresholds: Override thresholds dict. Recognised keys:
+            ``pass_rate_drop``, ``quality_drop``, ``error_rate_spike``.
+            Defaults to ``DEFAULT_THRESHOLDS`` when ``None``.
+
+    Returns:
+        A dict with two guaranteed keys:
+
+        - ``deviated`` (bool): True when at least one alert was raised.
+        - ``alerts`` (list[dict]): One entry per breached threshold.
+          Each alert contains: ``metric``, ``baseline_value``,
+          ``current_value``, ``delta``, ``threshold``.
+
+        When no baseline exists the dict also carries
+        ``reason: 'no_baseline'`` and ``deviated`` is always ``False``.
+
+    Raises:
+        Nothing — all arithmetic edge cases (zero rows, missing keys) are
+        handled gracefully.
+    """
+    from src.services.baseline_service import get_baseline
+
+    baseline = get_baseline(suite_name)
+    if baseline is None:
+        return {'deviated': False, 'alerts': [], 'reason': 'no_baseline'}
+
+    effective = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
+    alerts: list[dict] = []
+
+    # Derive current metrics from the result dict
+    total = result.get('total_rows') or 0
+    passed = bool(result.get('passed'))
+    invalid = result.get('invalid_rows') or 0
+    quality = result.get('quality_score')
+
+    # pass_rate: percentage of rows that are valid
+    # When total_rows is available use arithmetic; fall back to the boolean flag.
+    current_pass_rate = (
+        (1 - invalid / total) * 100 if total else (100.0 if passed else 0.0)
+    )
+    current_error_rate = (invalid / total * 100) if total else 0.0
+
+    # --- pass_rate drop check -------------------------------------------
+    bl_pass_rate = baseline.get('pass_rate')
+    if bl_pass_rate is not None:
+        delta = current_pass_rate - bl_pass_rate
+        if delta < -effective['pass_rate_drop']:
+            alerts.append({
+                'metric': 'pass_rate',
+                'baseline_value': bl_pass_rate,
+                'current_value': round(current_pass_rate, 2),
+                'delta': round(delta, 2),
+                'threshold': effective['pass_rate_drop'],
+            })
+
+    # --- quality_score drop check ----------------------------------------
+    bl_quality = baseline.get('avg_quality_score')
+    if bl_quality is not None and quality is not None:
+        delta = float(quality) - bl_quality
+        if delta < -effective['quality_drop']:
+            alerts.append({
+                'metric': 'quality_score',
+                'baseline_value': bl_quality,
+                'current_value': round(float(quality), 2),
+                'delta': round(delta, 2),
+                'threshold': effective['quality_drop'],
+            })
+
+    # --- error_rate spike check ------------------------------------------
+    bl_error_rate = baseline.get('avg_error_rate')
+    if bl_error_rate is not None:
+        delta = current_error_rate - bl_error_rate
+        if delta > effective['error_rate_spike']:
+            alerts.append({
+                'metric': 'error_rate',
+                'baseline_value': bl_error_rate,
+                'current_value': round(current_error_rate, 2),
+                'delta': round(delta, 2),
+                'threshold': effective['error_rate_spike'],
+            })
+
+    return {
+        'deviated': len(alerts) > 0,
+        'alerts': alerts,
+    }

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -1,0 +1,223 @@
+"""Daily trend aggregation for run history — used by the trend API endpoint.
+
+Aggregates run history into daily buckets, returning pass/fail counts and
+average quality score per day. Supports both a JSON file path (default) and
+a database path when ``DB_ADAPTER`` environment variable is set.
+"""
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+# Top-level import allows tests to patch src.services.trend_service.get_database_adapter
+# and src.services.trend_service.get_db_config without needing to reach into sub-modules.
+try:
+    from src.database.adapters.factory import get_database_adapter
+    from src.config.db_config import get_db_config
+except ImportError:  # pragma: no cover
+    get_database_adapter = None  # type: ignore[assignment]
+    get_db_config = None  # type: ignore[assignment]
+
+VALID_DAYS = (7, 14, 30, 90)
+
+_RUN_HISTORY_PATH = Path("reports") / "run_history.json"
+
+
+def _load_history() -> list[dict]:
+    """Load run history entries from the JSON file.
+
+    Returns:
+        List of run history entry dicts. Returns an empty list if the file
+        does not exist or cannot be parsed.
+    """
+    if not _RUN_HISTORY_PATH.exists():
+        return []
+    try:
+        return json.loads(_RUN_HISTORY_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+
+def get_trend(suite: Optional[str] = None, days: int = 30) -> list[dict]:
+    """Return daily-aggregated run history buckets.
+
+    Tries the database path first when ``DB_ADAPTER`` is set, then falls back
+    to reading ``reports/run_history.json``.
+
+    Args:
+        suite: Filter to a specific suite name. ``None`` means all suites.
+        days: Number of days to look back. Must be one of ``(7, 14, 30, 90)``.
+
+    Returns:
+        List of daily bucket dicts sorted ascending by date::
+
+            [
+                {
+                    "date": "2026-03-30",
+                    "total_runs": 5,
+                    "pass_runs": 4,
+                    "fail_runs": 1,
+                    "avg_quality_score": 88.5,  # or None
+                    "pass_rate": 80.0,
+                }
+            ]
+
+    Raises:
+        ValueError: If ``days`` is not in :data:`VALID_DAYS`.
+    """
+    if days not in VALID_DAYS:
+        raise ValueError(f"days must be one of {VALID_DAYS}, got {days}")
+
+    db_adapter = os.getenv("DB_ADAPTER")
+    if db_adapter:
+        try:
+            return _get_trend_from_db(suite, days)
+        except Exception:
+            pass  # fall through to JSON
+
+    return _get_trend_from_json(suite, days)
+
+
+def _get_trend_from_json(suite: Optional[str], days: int) -> list[dict]:
+    """Aggregate run history from the JSON file into daily buckets.
+
+    Args:
+        suite: Optional suite name filter. ``None`` includes all suites.
+        days: Number of past days to include.
+
+    Returns:
+        List of daily bucket dicts sorted ascending by date.
+    """
+    history = _load_history()
+    cutoff = datetime.utcnow() - timedelta(days=days)
+
+    # bucket structure: date_key -> aggregation state
+    buckets: dict[str, dict] = defaultdict(lambda: {
+        "total_runs": 0,
+        "pass_runs": 0,
+        "fail_runs": 0,
+        "quality_scores": [],
+    })
+
+    for entry in history:
+        # Suite filter
+        if suite and entry.get("suite_name") != suite:
+            continue
+
+        # Parse timestamp — JSON entries use the "timestamp" key
+        raw_ts = entry.get("timestamp") or entry.get("run_timestamp") or entry.get("run_date") or ""
+        if isinstance(raw_ts, str):
+            try:
+                run_dt = datetime.fromisoformat(raw_ts[:19])
+            except (ValueError, TypeError):
+                continue
+        elif isinstance(raw_ts, datetime):
+            run_dt = raw_ts
+        else:
+            continue
+
+        if run_dt < cutoff:
+            continue
+
+        date_key = run_dt.strftime("%Y-%m-%d")
+        bucket = buckets[date_key]
+        bucket["total_runs"] += 1
+
+        status = entry.get("status", "")
+        if status == "PASS":
+            bucket["pass_runs"] += 1
+        else:
+            bucket["fail_runs"] += 1
+
+        qs = entry.get("quality_score")
+        if qs is not None:
+            bucket["quality_scores"].append(float(qs))
+
+    result = []
+    for date_key in sorted(buckets.keys()):
+        b = buckets[date_key]
+        scores = b.pop("quality_scores")
+        b["date"] = date_key
+        b["avg_quality_score"] = round(sum(scores) / len(scores), 2) if scores else None
+        b["pass_rate"] = round(b["pass_runs"] / b["total_runs"] * 100, 2) if b["total_runs"] else 0.0
+        result.append(b)
+
+    return result
+
+
+def _get_trend_from_db(suite: Optional[str], days: int) -> list[dict]:
+    """Aggregate run history from the configured database adapter.
+
+    Uses :func:`~src.database.adapters.factory.get_database_adapter` to
+    query the ``CM3_RUN_HISTORY`` table and aggregate results into daily
+    buckets via SQL GROUP BY.
+
+    Args:
+        suite: Optional suite name filter passed as a SQL bind parameter.
+        days: Number of past days to include (used to compute the cutoff).
+
+    Returns:
+        List of daily bucket dicts sorted ascending by date.
+
+    Raises:
+        Exception: Re-raises any exception from the adapter so that
+            :func:`get_trend` can fall back to the JSON path.
+    """
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    schema = get_db_config().schema
+    table = f"{schema}.CM3_RUN_HISTORY"
+
+    suite_filter = "AND suite_name = :suite" if suite else ""
+    sql = f"""
+        SELECT
+            CAST(run_timestamp AS DATE) AS run_date,
+            COUNT(*) AS total_runs,
+            SUM(CASE WHEN status = 'PASS' THEN 1 ELSE 0 END) AS pass_runs,
+            SUM(CASE WHEN status != 'PASS' THEN 1 ELSE 0 END) AS fail_runs,
+            AVG(quality_score) AS avg_quality_score
+        FROM {table}
+        WHERE run_timestamp >= :cutoff
+        {suite_filter}
+        GROUP BY CAST(run_timestamp AS DATE)
+        ORDER BY CAST(run_timestamp AS DATE)
+    """
+
+    params: dict = {"cutoff": cutoff}
+    if suite:
+        params["suite"] = suite
+
+    adapter = get_database_adapter()
+    with adapter:
+        df = adapter.execute_query(sql, params)
+
+    if df is None or df.empty:
+        return []
+
+    result = []
+    for _, row in df.iterrows():
+        total = int(row["total_runs"] or 0)
+        pass_r = int(row["pass_runs"] or 0)
+        fail_r = int(row["fail_runs"] or 0)
+        qs_raw = row.get("avg_quality_score") if hasattr(row, "get") else row["avg_quality_score"]
+        avg_qs: Optional[float] = round(float(qs_raw), 2) if qs_raw is not None else None
+
+        run_date = row["run_date"]
+        if isinstance(run_date, datetime):
+            date_str = run_date.strftime("%Y-%m-%d")
+        else:
+            date_str = str(run_date)[:10]
+
+        result.append({
+            "date": date_str,
+            "total_runs": total,
+            "pass_runs": pass_r,
+            "fail_runs": fail_r,
+            "avg_quality_score": avg_qs,
+            "pass_rate": round(pass_r / total * 100, 2) if total else 0.0,
+        })
+
+    return result

--- a/tests/unit/test_deviation_detector.py
+++ b/tests/unit/test_deviation_detector.py
@@ -1,0 +1,258 @@
+"""Unit tests for src/services/deviation_detector.py — check_deviation()."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+MODULE = "src.services.baseline_service.get_baseline"
+
+
+def _make_result(
+    passed: bool = True,
+    total_rows: int = 100,
+    invalid_rows: int = 0,
+    quality_score: float = 95.0,
+) -> dict:
+    """Helper to build a minimal run result dict."""
+    return {
+        "passed": passed,
+        "total_rows": total_rows,
+        "invalid_rows": invalid_rows,
+        "quality_score": quality_score,
+    }
+
+
+def _baseline(
+    pass_rate: float = 90.0,
+    avg_quality_score: float = 90.0,
+    avg_error_rate: float = 5.0,
+) -> dict:
+    """Helper to build a minimal baseline dict."""
+    return {
+        "pass_rate": pass_rate,
+        "avg_quality_score": avg_quality_score,
+        "avg_error_rate": avg_error_rate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# No baseline
+# ---------------------------------------------------------------------------
+
+def test_no_baseline_returns_no_deviation():
+    """When get_baseline returns None, result should indicate no_baseline."""
+    with patch(MODULE, return_value=None):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("my_suite", _make_result())
+
+    assert result["deviated"] is False
+    assert result["alerts"] == []
+    assert result["reason"] == "no_baseline"
+
+
+# ---------------------------------------------------------------------------
+# pass_rate checks
+# ---------------------------------------------------------------------------
+
+def test_pass_rate_drop_exceeds_threshold():
+    """Pass rate drop of 15pp (> default 10pp threshold) triggers an alert."""
+    # baseline pass_rate=90, current invalid=25/100 → pass_rate=75 → delta=-15
+    with patch(MODULE, return_value=_baseline(pass_rate=90.0)):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("my_suite", _make_result(total_rows=100, invalid_rows=25))
+
+    assert result["deviated"] is True
+    assert len(result["alerts"]) == 1
+    alert = result["alerts"][0]
+    assert alert["metric"] == "pass_rate"
+    assert alert["baseline_value"] == 90.0
+    assert alert["current_value"] == 75.0
+    assert alert["delta"] == -15.0
+    assert alert["threshold"] == 10.0
+
+
+def test_pass_rate_drop_within_threshold():
+    """Pass rate drop of 5pp (≤ default 10pp threshold) does NOT trigger alert."""
+    # baseline pass_rate=90, current invalid=5/100 → pass_rate=95 → delta=+5 (improvement)
+    # Use invalid_rows=15 → pass_rate=85 → delta=-5 which is within threshold
+    with patch(MODULE, return_value=_baseline(pass_rate=90.0)):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("my_suite", _make_result(total_rows=100, invalid_rows=15))
+
+    assert result["deviated"] is False
+    assert result["alerts"] == []
+
+
+# ---------------------------------------------------------------------------
+# quality_score checks
+# ---------------------------------------------------------------------------
+
+def test_quality_drop_exceeds_threshold():
+    """Quality score drop of 10pp (> default 5pp threshold) triggers an alert."""
+    baseline = _baseline(avg_quality_score=90.0)
+    result_data = _make_result(quality_score=78.0)  # delta = -12
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_q", result_data)
+
+    quality_alerts = [a for a in result["alerts"] if a["metric"] == "quality_score"]
+    assert len(quality_alerts) == 1
+    alert = quality_alerts[0]
+    assert alert["baseline_value"] == 90.0
+    assert alert["current_value"] == 78.0
+    assert alert["delta"] == -12.0
+    assert alert["threshold"] == 5.0
+
+
+def test_both_pass_rate_and_quality_drop():
+    """Two metrics deviating produces two separate alerts."""
+    baseline = _baseline(pass_rate=90.0, avg_quality_score=90.0, avg_error_rate=5.0)
+    # pass_rate drops 15pp, quality drops 12pp, error_rate unchanged
+    result_data = {
+        "passed": False,
+        "total_rows": 100,
+        "invalid_rows": 25,   # pass_rate=75, delta=-15
+        "quality_score": 78.0,  # delta=-12
+    }
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_both", result_data)
+
+    assert result["deviated"] is True
+    metrics = {a["metric"] for a in result["alerts"]}
+    assert metrics == {"pass_rate", "quality_score"}
+    assert len(result["alerts"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# error_rate checks
+# ---------------------------------------------------------------------------
+
+def test_all_three_metrics_deviated():
+    """All three metrics deviating produces three alerts."""
+    baseline = _baseline(pass_rate=90.0, avg_quality_score=90.0, avg_error_rate=5.0)
+    # pass_rate=75 (drop 15), quality=78 (drop 12), error_rate=25 (spike +20 → delta=20, > threshold 20 → NOT triggered)
+    # Use error_rate spike of 30 (> 20 threshold): invalid_rows=55/100 → error_rate=55, delta=50
+    result_data = {
+        "passed": False,
+        "total_rows": 100,
+        "invalid_rows": 55,   # pass_rate=45 (drop 45), error_rate=55 (spike 50)
+        "quality_score": 78.0,  # quality drop 12
+    }
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_all", result_data)
+
+    assert result["deviated"] is True
+    metrics = {a["metric"] for a in result["alerts"]}
+    assert metrics == {"pass_rate", "quality_score", "error_rate"}
+    assert len(result["alerts"]) == 3
+
+
+def test_error_rate_spike_exactly_at_threshold_not_triggered():
+    """Error rate spike equal to threshold does NOT trigger (strict > check)."""
+    # baseline error_rate=5, current error_rate=25 → delta=20, threshold=20 → NOT triggered
+    baseline = _baseline(pass_rate=100.0, avg_quality_score=95.0, avg_error_rate=5.0)
+    result_data = _make_result(total_rows=100, invalid_rows=25, quality_score=95.0)  # error_rate=25
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_at_threshold", result_data)
+
+    error_alerts = [a for a in result["alerts"] if a["metric"] == "error_rate"]
+    assert error_alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Custom thresholds
+# ---------------------------------------------------------------------------
+
+def test_custom_thresholds_override_defaults():
+    """Custom thresholds dict overrides DEFAULT_THRESHOLDS values."""
+    # With default threshold=10, a 5pp drop would NOT trigger.
+    # With custom threshold=3, a 5pp drop SHOULD trigger.
+    baseline = _baseline(pass_rate=90.0)
+    result_data = _make_result(total_rows=100, invalid_rows=15)  # pass_rate=85, delta=-5
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_custom", result_data, thresholds={"pass_rate_drop": 3.0})
+
+    assert result["deviated"] is True
+    pass_alerts = [a for a in result["alerts"] if a["metric"] == "pass_rate"]
+    assert len(pass_alerts) == 1
+    assert pass_alerts[0]["threshold"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_missing_quality_score_skips_quality_check():
+    """Result without quality_score key does not raise and skips quality alert."""
+    baseline = _baseline(avg_quality_score=90.0)
+    result_data = {"passed": True, "total_rows": 100, "invalid_rows": 0}  # no quality_score
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_no_quality", result_data)
+
+    quality_alerts = [a for a in result["alerts"] if a["metric"] == "quality_score"]
+    assert quality_alerts == []
+
+
+def test_total_rows_zero_no_crash():
+    """total_rows=0 should not cause a ZeroDivisionError and returns no deviation."""
+    baseline = _baseline(pass_rate=90.0, avg_error_rate=5.0)
+    result_data = {"passed": True, "total_rows": 0, "invalid_rows": 0, "quality_score": 95.0}
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_zero_rows", result_data)
+
+    # With total_rows=0 and passed=True, pass_rate=100. baseline=90 → no drop.
+    assert isinstance(result, dict)
+    assert "deviated" in result
+    assert result["deviated"] is False
+
+
+def test_return_shape_contains_deviated_and_alerts():
+    """Result always contains 'deviated' (bool) and 'alerts' (list) keys."""
+    with patch(MODULE, return_value=_baseline()):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_shape", _make_result())
+
+    assert isinstance(result["deviated"], bool)
+    assert isinstance(result["alerts"], list)
+
+
+def test_alert_contains_required_keys():
+    """Each alert dict has metric, baseline_value, current_value, delta, threshold."""
+    baseline = _baseline(pass_rate=90.0)
+    result_data = _make_result(total_rows=100, invalid_rows=25)  # pass_rate=75, drop=15
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_keys", result_data)
+
+    assert result["deviated"] is True
+    alert = result["alerts"][0]
+    for key in ("metric", "baseline_value", "current_value", "delta", "threshold"):
+        assert key in alert, f"Alert missing key: {key}"

--- a/tests/unit/test_trend_service.py
+++ b/tests/unit/test_trend_service.py
@@ -1,0 +1,372 @@
+"""Unit tests for src/services/trend_service.py.
+
+Tests cover:
+- JSON path: bucketing, suite filter, date window, all-fail, empty history
+- ValueError for invalid days argument
+- DB path: adapter called, results mapped to bucket dicts
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.services.trend_service import VALID_DAYS, get_trend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CUTOFF_DAYS = 30
+# Use a fixed reference date well within any 30-day window so tests are
+# deterministic regardless of when they run (2026-03-31 is "today" in the
+# project, so 2026-03-15 is comfortably inside a 30-day window).
+_RECENT_DATE = "2026-03-30"
+_OLD_DATE = "2026-01-01"   # always outside any supported window
+
+
+def _make_entry(
+    suite_name: str = "MySuite",
+    date_str: str = _RECENT_DATE,
+    status: str = "PASS",
+    quality_score: float | None = None,
+) -> dict:
+    """Return a run_history.json-shaped dict with an explicit UTC date.
+
+    Args:
+        suite_name: Suite name for the entry.
+        date_str: ISO date string (YYYY-MM-DD) for the run timestamp.
+        status: Run status — ``"PASS"``, ``"FAIL"``, or ``"PARTIAL"``.
+        quality_score: Optional quality score value.
+
+    Returns:
+        A dict matching the run_history.json entry schema.
+    """
+    entry = {
+        "run_id": "test-id",
+        "suite_name": suite_name,
+        "environment": "test",
+        "timestamp": f"{date_str}T12:00:00.000000Z",
+        "status": status,
+        "pass_count": 1 if status == "PASS" else 0,
+        "fail_count": 0 if status == "PASS" else 1,
+        "total_count": 1,
+    }
+    if quality_score is not None:
+        entry["quality_score"] = quality_score
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# JSON path tests
+# ---------------------------------------------------------------------------
+
+class TestGetTrendFromJson:
+    """Tests for _get_trend_from_json via get_trend (no DB_ADAPTER set)."""
+
+    def test_three_entries_on_different_days_produce_three_buckets(self, monkeypatch):
+        """3 entries on distinct days → 3 sorted buckets with correct counts."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-28", status="PASS"),
+            _make_entry(date_str="2026-03-29", status="FAIL"),
+            _make_entry(date_str="2026-03-30", status="PASS"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 3
+        # Sorted ascending by date
+        dates = [b["date"] for b in result]
+        assert dates == sorted(dates)
+        # Spot-check first bucket (oldest)
+        assert result[0]["date"] == "2026-03-28"
+        assert result[0]["total_runs"] == 1
+        assert result[0]["pass_runs"] == 1
+        assert result[0]["fail_runs"] == 0
+        # Second bucket
+        assert result[1]["pass_runs"] == 0
+        assert result[1]["fail_runs"] == 1
+
+    def test_suite_filter_returns_only_matching_entries(self, monkeypatch):
+        """suite='Alpha' filters out entries for other suites."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(suite_name="Alpha", date_str="2026-03-30", status="PASS"),
+            _make_entry(suite_name="Beta",  date_str="2026-03-30", status="PASS"),
+            _make_entry(suite_name="Alpha", date_str="2026-03-29", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(suite="Alpha", days=30)
+
+        total = sum(b["total_runs"] for b in result)
+        assert total == 2  # Only Alpha entries counted
+
+    def test_30_day_window_excludes_older_entries(self, monkeypatch):
+        """Entries older than the requested window are excluded."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-15", status="PASS"),   # inside 30-day window
+            _make_entry(date_str=_OLD_DATE,    status="PASS"),   # outside
+            _make_entry(date_str="2026-01-15", status="FAIL"),   # outside
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        total = sum(b["total_runs"] for b in result)
+        assert total == 1
+
+    def test_all_fail_runs_produces_pass_rate_zero(self, monkeypatch):
+        """When all runs fail, pass_rate is 0.0 and pass_runs is 0."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        bucket = result[0]
+        assert bucket["pass_runs"] == 0
+        assert bucket["fail_runs"] == 2
+        assert bucket["pass_rate"] == 0.0
+
+    def test_empty_history_returns_empty_list(self, monkeypatch):
+        """Empty run history produces an empty result list."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        with patch("src.services.trend_service._load_history", return_value=[]):
+            result = get_trend(days=30)
+
+        assert result == []
+
+    def test_pass_rate_calculated_correctly(self, monkeypatch):
+        """pass_rate = pass_runs / total_runs * 100, rounded to 2 dp."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        # 1 pass, 1 fail on same day → 50.0%
+        history = [
+            _make_entry(date_str="2026-03-30", status="PASS"),
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["pass_rate"] == 50.0
+
+    def test_quality_score_averaged_per_bucket(self, monkeypatch):
+        """avg_quality_score is the mean of quality_score across bucket entries."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-30", status="PASS", quality_score=80.0),
+            _make_entry(date_str="2026-03-30", status="PASS", quality_score=90.0),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["avg_quality_score"] == 85.0
+
+    def test_missing_quality_score_produces_none(self, monkeypatch):
+        """avg_quality_score is None when no entries have a quality_score."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [_make_entry(date_str="2026-03-30", status="PASS")]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert result[0]["avg_quality_score"] is None
+
+    def test_multiple_entries_same_day_aggregated_into_one_bucket(self, monkeypatch):
+        """Multiple runs on the same day are merged into a single bucket."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-30", status="PASS"),
+            _make_entry(date_str="2026-03-30", status="PASS"),
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["total_runs"] == 3
+        assert result[0]["pass_runs"] == 2
+        assert result[0]["fail_runs"] == 1
+
+    def test_result_bucket_has_required_keys(self, monkeypatch):
+        """Each bucket dict contains all required keys."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        required_keys = {"date", "total_runs", "pass_runs", "fail_runs",
+                         "avg_quality_score", "pass_rate"}
+        history = [_make_entry(date_str="2026-03-30")]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert required_keys.issubset(result[0].keys())
+
+    def test_partial_status_counted_as_fail(self, monkeypatch):
+        """PARTIAL status (not PASS) is counted in fail_runs."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [_make_entry(date_str="2026-03-30", status="PARTIAL")]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert result[0]["fail_runs"] == 1
+        assert result[0]["pass_runs"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Invalid days argument
+# ---------------------------------------------------------------------------
+
+class TestGetTrendInvalidDays:
+    """Tests for ValueError on invalid days argument."""
+
+    @pytest.mark.parametrize("bad_days", [0, 1, 15, 29, 31, 60, 365, -7])
+    def test_invalid_days_raises_value_error(self, bad_days):
+        """days not in VALID_DAYS raises ValueError."""
+        with pytest.raises(ValueError, match="days must be one of"):
+            get_trend(days=bad_days)
+
+    @pytest.mark.parametrize("good_days", VALID_DAYS)
+    def test_valid_days_does_not_raise(self, good_days, monkeypatch):
+        """Valid days values do not raise ValueError."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        with patch("src.services.trend_service._load_history", return_value=[]):
+            result = get_trend(days=good_days)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# DB path tests
+# ---------------------------------------------------------------------------
+
+class TestGetTrendFromDb:
+    """Tests for _get_trend_from_db via get_trend when DB_ADAPTER is set."""
+
+    def _make_mock_adapter(self, df: pd.DataFrame) -> MagicMock:
+        """Return a mock DatabaseAdapter that returns *df* from execute_query."""
+        mock_adapter = MagicMock()
+        mock_adapter.__enter__ = MagicMock(return_value=mock_adapter)
+        mock_adapter.__exit__ = MagicMock(return_value=False)
+        mock_adapter.execute_query = MagicMock(return_value=df)
+        return mock_adapter
+
+    def _single_row_df(
+        self,
+        date: datetime = datetime(2026, 3, 30),
+        total: int = 5,
+        pass_r: int = 4,
+        fail_r: int = 1,
+        avg_qs: float | None = 88.5,
+    ) -> pd.DataFrame:
+        """Return a single-row DataFrame matching the DB query result shape."""
+        return pd.DataFrame([{
+            "run_date": date,
+            "total_runs": total,
+            "pass_runs": pass_r,
+            "fail_runs": fail_r,
+            "avg_quality_score": avg_qs,
+        }])
+
+    def test_db_adapter_execute_query_is_called(self, monkeypatch):
+        """When DB_ADAPTER is set, get_database_adapter is imported and used."""
+        monkeypatch.setenv("DB_ADAPTER", "oracle")
+
+        mock_adapter = self._make_mock_adapter(self._single_row_df())
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        mock_adapter.execute_query.assert_called_once()
+        assert len(result) == 1
+
+    def test_db_result_mapped_to_bucket_dicts(self, monkeypatch):
+        """DB rows are correctly mapped to bucket dicts with all required fields."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        df = self._single_row_df(
+            date=datetime(2026, 3, 30), total=10, pass_r=8, fail_r=2, avg_qs=92.5
+        )
+        mock_adapter = self._make_mock_adapter(df)
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        assert len(result) == 1
+        bucket = result[0]
+        assert bucket["date"] == "2026-03-30"
+        assert bucket["total_runs"] == 10
+        assert bucket["pass_runs"] == 8
+        assert bucket["fail_runs"] == 2
+        assert bucket["avg_quality_score"] == 92.5
+        assert bucket["pass_rate"] == 80.0
+
+    def test_db_pass_rate_zero_when_no_runs(self, monkeypatch):
+        """pass_rate is 0.0 when total_runs is 0 (guard against ZeroDivisionError)."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        df = self._single_row_df(
+            date=datetime(2026, 3, 30), total=0, pass_r=0, fail_r=0, avg_qs=None
+        )
+        mock_adapter = self._make_mock_adapter(df)
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        assert result[0]["pass_rate"] == 0.0
+        assert result[0]["avg_quality_score"] is None
+
+    def test_db_suite_filter_passed_to_sql(self, monkeypatch):
+        """Suite name is forwarded as a SQL bind param when suite arg is provided."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        mock_adapter = self._make_mock_adapter(pd.DataFrame())
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                get_trend(suite="MySuite", days=7)
+
+        call_args = mock_adapter.execute_query.call_args
+        # Second positional arg is the params dict
+        params = call_args[0][1]
+        assert params.get("suite") == "MySuite"
+
+    def test_db_failure_falls_back_to_json(self, monkeypatch):
+        """When the DB adapter raises, get_trend falls back to the JSON path."""
+        monkeypatch.setenv("DB_ADAPTER", "oracle")
+
+        history = [_make_entry(date_str="2026-03-30", status="PASS")]
+
+        with patch(
+            "src.services.trend_service.get_database_adapter",
+            side_effect=RuntimeError("ORA-12170"),
+        ):
+            with patch("src.services.trend_service._load_history", return_value=history):
+                result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["total_runs"] == 1
+
+    def test_db_empty_result_returns_empty_list(self, monkeypatch):
+        """Empty DB result returns []."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        mock_adapter = self._make_mock_adapter(pd.DataFrame())
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        assert result == []


### PR DESCRIPTION
## Summary

- Adds `src/services/trend_service.py` with `get_trend(suite, days)` that aggregates run history into daily pass/fail/quality-score buckets
- Supports JSON path (reads `reports/run_history.json`) with automatic fallback when DB raises
- Supports DB path via `DatabaseAdapter.execute_query()` when `DB_ADAPTER` env var is set — GROUP BY date with suite filter pushed to SQL
- Guards invalid `days` values with `ValueError` (only `7, 14, 30, 90` are valid via `VALID_DAYS` constant)
- 29 unit tests covering: bucketing, suite filter, date window cutoff, all-fail, empty history, invalid days, DB adapter call verification, DB result mapping, DB-to-JSON fallback

## Test plan

- [x] `pytest tests/unit/test_trend_service.py -v` — 29/29 pass
- [x] `pytest tests/unit/ --cov=src --cov-report=term-missing -q` — 1497 tests pass, 80.71% coverage (no regressions)
- [x] JSON path: bucket structure, suite filter, date window, pass_rate, avg_quality_score
- [x] DB path: execute_query called, suite param forwarded, results mapped, fallback on error
- [x] ValueError raised for any days value not in (7, 14, 30, 90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)