### PR TITLE
feat(service): baseline_service.py — JSON-backed rolling baseline store (#242)

### DIFF
--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -250,6 +250,10 @@ Services
    :members:
    :undoc-members:
 
+.. automodule:: src.services.baseline_service
+   :members:
+   :undoc-members:
+
 Contracts & Adapters
 --------------------
 

--- a/src/services/baseline_service.py
+++ b/src/services/baseline_service.py
@@ -1,0 +1,240 @@
+"""JSON-backed rolling baseline store for per-suite quality metrics.
+
+Baselines are persisted to ``reports/baselines.json`` using the same
+read-modify-write pattern as ``reports/run_history.json``.  Each suite
+maintains a rolling window of its last 10 runs; averages are recomputed
+on every call to :func:`update_baseline`.
+
+Storage format (``reports/baselines.json``)::
+
+    {
+        "SUITE_A": {
+            "baseline": {
+                "suite_name": "SUITE_A",
+                "pass_rate": 87.5,
+                "avg_quality_score": 91.2,
+                "avg_error_rate": 2.3,
+                "sample_size": 10,
+                "updated_at": "2026-03-30T14:00:00"
+            },
+            "history": [
+                {"pass_rate": 80.0, "quality_score": 90.0, "error_rate": 1.0},
+                ...
+            ]
+        },
+        ...
+    }
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BASELINES_PATH: Path = Path(__file__).parent.parent.parent / "reports" / "baselines.json"
+"""Absolute path to the JSON file that stores all suite baselines and history."""
+
+_ROLLING_WINDOW: int = 10
+"""Maximum number of historical runs to keep per suite when computing averages."""
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_store(path: Path) -> dict[str, Any]:
+    """Read the baselines JSON file from disk.
+
+    Returns an empty dict when the file does not exist or contains corrupt JSON.
+    The corrupt-JSON case is logged as a warning and treated as a fresh store
+    (consistent with the run_history pattern).
+
+    Args:
+        path: Path to the baselines JSON file.
+
+    Returns:
+        Dict mapping suite_name to its ``{"baseline": ..., "history": [...]}`` record.
+    """
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("baselines.json is unreadable, starting fresh: %s", exc)
+        return {}
+
+
+def _save_store(path: Path, store: dict[str, Any]) -> None:
+    """Write the baselines store dict to disk as formatted JSON.
+
+    Creates parent directories as needed.
+
+    Args:
+        path: Path to the baselines JSON file.
+        store: Full in-memory store dict to persist.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+
+
+def _compute_error_rate(invalid_rows: int, total_rows: int) -> float:
+    """Compute per-run error rate as a percentage.
+
+    Args:
+        invalid_rows: Number of rows that failed validation.
+        total_rows: Total rows processed.
+
+    Returns:
+        ``invalid_rows / total_rows * 100``, or ``0.0`` when ``total_rows`` is zero.
+    """
+    if total_rows == 0:
+        return 0.0
+    return invalid_rows / total_rows * 100.0
+
+
+def _average_or_none(values: list[float]) -> Optional[float]:
+    """Return the arithmetic mean of *values*, or ``None`` for an empty list.
+
+    Args:
+        values: Non-empty list of floats to average.
+
+    Returns:
+        Mean value, or ``None`` if *values* is empty.
+    """
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _recompute_baseline(suite_name: str, history: list[dict[str, Any]]) -> dict[str, Any]:
+    """Recompute the baseline summary from the rolling history window.
+
+    Args:
+        suite_name: Name of the suite.
+        history: List of per-run snapshot dicts with keys ``pass_rate``,
+            ``quality_score`` (optional), and ``error_rate``.
+
+    Returns:
+        Baseline dict with keys: suite_name, pass_rate, avg_quality_score,
+        avg_error_rate, sample_size, updated_at.
+    """
+    pass_rates = [h["pass_rate"] for h in history]
+    quality_scores = [h["quality_score"] for h in history if h.get("quality_score") is not None]
+    error_rates = [h["error_rate"] for h in history]
+
+    return {
+        "suite_name": suite_name,
+        "pass_rate": _average_or_none(pass_rates),
+        "avg_quality_score": _average_or_none(quality_scores),
+        "avg_error_rate": _average_or_none(error_rates) or 0.0,
+        "sample_size": len(history),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
+    """Append *result* to the rolling history and recompute the baseline.
+
+    Reads the current store from ``reports/baselines.json``, appends a
+    per-run snapshot derived from *result* to the suite's history, caps
+    the history at :data:`_ROLLING_WINDOW` entries (oldest dropped first),
+    recomputes all averages, persists the updated store, and returns the
+    new baseline dict.
+
+    Args:
+        suite_name: Logical name of the test suite (e.g. ``"ATOCTRAN"``).
+        result: Run result dict.  Expected keys (all optional — missing keys
+            are treated as zero or absent):
+
+            * ``pass_count`` — number of tests that passed.
+            * ``total_count`` — total tests executed.
+            * ``invalid_rows`` — row-level validation failures.
+            * ``total_rows`` — total rows inspected.
+            * ``quality_score`` — optional float quality score (0–100).
+
+    Returns:
+        Updated baseline dict with keys: suite_name, pass_rate,
+        avg_quality_score, avg_error_rate, sample_size, updated_at.
+    """
+    path = _BASELINES_PATH
+
+    store = _load_store(path)
+    suite_record = store.get(suite_name, {"baseline": {}, "history": []})
+
+    # Build per-run snapshot
+    pass_count = result.get("pass_count", 0)
+    total_count = result.get("total_count", 0)
+    pass_rate = (pass_count / total_count * 100.0) if total_count > 0 else 0.0
+
+    invalid_rows = result.get("invalid_rows", 0)
+    total_rows = result.get("total_rows", 0)
+    error_rate = _compute_error_rate(invalid_rows, total_rows)
+
+    snapshot: dict[str, Any] = {
+        "pass_rate": pass_rate,
+        "quality_score": result.get("quality_score"),  # None when absent
+        "error_rate": error_rate,
+    }
+
+    # Append and cap the rolling window
+    history: list[dict[str, Any]] = suite_record["history"]
+    history.append(snapshot)
+    if len(history) > _ROLLING_WINDOW:
+        history = history[-_ROLLING_WINDOW:]
+
+    # Recompute and persist
+    baseline = _recompute_baseline(suite_name, history)
+    store[suite_name] = {"baseline": baseline, "history": history}
+    _save_store(path, store)
+
+    return baseline
+
+
+def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
+    """Return the stored baseline for *suite_name*, or ``None`` if absent.
+
+    Args:
+        suite_name: Name of the suite to look up.
+
+    Returns:
+        Baseline dict with keys: suite_name, pass_rate, avg_quality_score,
+        avg_error_rate, sample_size, updated_at; or ``None`` if no baseline
+        has been recorded for this suite yet.
+    """
+    path = _BASELINES_PATH
+    store = _load_store(path)
+    record = store.get(suite_name)
+    if record is None:
+        return None
+    return record.get("baseline") or None
+
+
+def list_baselines() -> list[dict[str, Any]]:
+    """Return all stored baselines sorted alphabetically by suite name.
+
+    Returns:
+        List of baseline dicts (see :func:`get_baseline`), sorted by
+        ``suite_name``.  Returns an empty list when no baselines exist.
+    """
+    path = _BASELINES_PATH
+    store = _load_store(path)
+    baselines = [
+        record["baseline"]
+        for record in store.values()
+        if record.get("baseline")
+    ]
+    return sorted(baselines, key=lambda b: b.get("suite_name", ""))

--- a/tests/unit/test_baseline_service.py
+++ b/tests/unit/test_baseline_service.py
@@ -1,0 +1,331 @@
+"""Unit tests for baseline_service.py — TDD: written before implementation.
+
+Tests cover:
+- First-run baseline creation (sample_size=1)
+- Second-run rolling average recalculation (sample_size=2)
+- Rolling window capped at 10 runs (11 runs → sample_size=10)
+- get_baseline returns None for unknown suite
+- list_baselines returns all suites sorted alphabetically
+- Round-trip JSON serialization via tmp_path fixture
+- Missing quality_score in result → avg_quality_score stays None
+- total_rows=0 → avg_error_rate=0.0
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    pass_count: int = 8,
+    total_count: int = 10,
+    invalid_rows: int = 1,
+    total_rows: int = 100,
+    quality_score: float | None = 90.0,
+) -> dict:
+    """Build a minimal result dict matching the run_history entry shape."""
+    result = {
+        "pass_count": pass_count,
+        "total_count": total_count,
+        "invalid_rows": invalid_rows,
+        "total_rows": total_rows,
+    }
+    if quality_score is not None:
+        result["quality_score"] = quality_score
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_baseline
+# ---------------------------------------------------------------------------
+
+class TestUpdateBaseline:
+    """Tests for update_baseline()."""
+
+    def test_first_run_creates_baseline_with_sample_size_1(self, tmp_path: Path):
+        """First call creates a baseline with sample_size=1."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = _make_result(pass_count=8, total_count=10, quality_score=90.0)
+            baseline = update_baseline("SUITE_A", result)
+
+        assert baseline["suite_name"] == "SUITE_A"
+        assert baseline["sample_size"] == 1
+        assert baseline["pass_rate"] == pytest.approx(80.0)
+        assert baseline["avg_quality_score"] == pytest.approx(90.0)
+        assert "updated_at" in baseline
+
+    def test_second_run_recalculates_averages_with_sample_size_2(
+        self, tmp_path: Path
+    ):
+        """Second call recalculates averages from 2 runs."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(pass_count=8, total_count=10, quality_score=80.0))
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(pass_count=6, total_count=10, quality_score=90.0),
+            )
+
+        assert baseline["sample_size"] == 2
+        # pass_rate: (80 + 60) / 2 = 70.0
+        assert baseline["pass_rate"] == pytest.approx(70.0)
+        # avg_quality_score: (80 + 90) / 2 = 85.0
+        assert baseline["avg_quality_score"] == pytest.approx(85.0)
+
+    def test_rolling_window_capped_at_10_after_11_runs(self, tmp_path: Path):
+        """After 11 runs the rolling window holds exactly 10; sample_size=10."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            for i in range(11):
+                baseline = update_baseline(
+                    "SUITE_A",
+                    _make_result(pass_count=i, total_count=10, quality_score=float(i * 10)),
+                )
+
+        assert baseline["sample_size"] == 10
+
+    def test_avg_error_rate_computed_from_invalid_and_total_rows(
+        self, tmp_path: Path
+    ):
+        """avg_error_rate = invalid_rows / total_rows * 100."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(invalid_rows=5, total_rows=200),
+            )
+
+        assert baseline["avg_error_rate"] == pytest.approx(2.5)
+
+    def test_total_rows_zero_gives_error_rate_zero(self, tmp_path: Path):
+        """total_rows=0 avoids division by zero and yields avg_error_rate=0.0."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(invalid_rows=3, total_rows=0),
+            )
+
+        assert baseline["avg_error_rate"] == pytest.approx(0.0)
+
+    def test_missing_quality_score_yields_avg_quality_score_none(
+        self, tmp_path: Path
+    ):
+        """When quality_score is absent from result, avg_quality_score is None."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(quality_score=None),
+            )
+
+        assert baseline["avg_quality_score"] is None
+
+    def test_mixed_quality_score_presence_averages_available_values(
+        self, tmp_path: Path
+    ):
+        """When some runs lack quality_score, average computed from runs that have it."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(quality_score=80.0))
+            baseline = update_baseline("SUITE_A", _make_result(quality_score=None))
+
+        # Only 1 run had a score (80.0), so average is 80.0
+        assert baseline["avg_quality_score"] == pytest.approx(80.0)
+
+    def test_returns_updated_baseline_dict(self, tmp_path: Path):
+        """update_baseline returns the updated baseline dict."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = update_baseline("SUITE_A", _make_result())
+
+        assert isinstance(result, dict)
+        assert result["suite_name"] == "SUITE_A"
+
+    def test_multiple_suites_stored_independently(self, tmp_path: Path):
+        """Baselines for different suites do not interfere with each other."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(pass_count=10, total_count=10))
+            update_baseline("SUITE_B", _make_result(pass_count=5, total_count=10))
+            a = update_baseline("SUITE_A", _make_result(pass_count=10, total_count=10))
+            b = update_baseline("SUITE_B", _make_result(pass_count=5, total_count=10))
+
+        assert a["pass_rate"] == pytest.approx(100.0)
+        assert b["pass_rate"] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_baseline
+# ---------------------------------------------------------------------------
+
+class TestGetBaseline:
+    """Tests for get_baseline()."""
+
+    def test_returns_none_for_unknown_suite(self, tmp_path: Path):
+        """get_baseline returns None when no baseline exists for the suite."""
+        from src.services.baseline_service import get_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = get_baseline("UNKNOWN_SUITE")
+
+        assert result is None
+
+    def test_returns_none_when_file_does_not_exist(self, tmp_path: Path):
+        """get_baseline returns None when baselines.json does not exist."""
+        from src.services.baseline_service import get_baseline
+
+        storage = tmp_path / "nonexistent.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = get_baseline("SUITE_A")
+
+        assert result is None
+
+    def test_returns_baseline_after_update(self, tmp_path: Path):
+        """get_baseline retrieves a baseline previously written by update_baseline."""
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(quality_score=75.0))
+            result = get_baseline("SUITE_A")
+
+        assert result is not None
+        assert result["suite_name"] == "SUITE_A"
+        assert result["avg_quality_score"] == pytest.approx(75.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_baselines
+# ---------------------------------------------------------------------------
+
+class TestListBaselines:
+    """Tests for list_baselines()."""
+
+    def test_returns_empty_list_when_no_file(self, tmp_path: Path):
+        """list_baselines returns [] when baselines.json does not exist."""
+        from src.services.baseline_service import list_baselines
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = list_baselines()
+
+        assert result == []
+
+    def test_returns_all_suites_sorted_alphabetically(self, tmp_path: Path):
+        """list_baselines sorts results alphabetically by suite_name."""
+        from src.services.baseline_service import list_baselines, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("ZEBRA", _make_result())
+            update_baseline("ALPHA", _make_result())
+            update_baseline("MONKEY", _make_result())
+            result = list_baselines()
+
+        names = [b["suite_name"] for b in result]
+        assert names == ["ALPHA", "MONKEY", "ZEBRA"]
+
+    def test_returns_list_of_dicts(self, tmp_path: Path):
+        """list_baselines returns a list of baseline dicts."""
+        from src.services.baseline_service import list_baselines, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+            result = list_baselines()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+
+
+# ---------------------------------------------------------------------------
+# Tests: round-trip JSON serialization
+# ---------------------------------------------------------------------------
+
+class TestJsonRoundTrip:
+    """Tests for JSON file persistence."""
+
+    def test_written_file_is_valid_json(self, tmp_path: Path):
+        """update_baseline writes valid JSON to disk."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+
+        assert storage.exists()
+        data = json.loads(storage.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+
+    def test_baseline_survives_file_reload(self, tmp_path: Path):
+        """Baseline persists after re-reading the storage file from disk."""
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(quality_score=88.0))
+            # Re-read from disk by calling get_baseline with the same patch
+            result = get_baseline("SUITE_A")
+
+        assert result is not None
+        assert result["avg_quality_score"] == pytest.approx(88.0)
+
+    def test_file_created_on_first_write(self, tmp_path: Path):
+        """baselines.json is created if it does not exist yet."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        assert not storage.exists()
+
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+
+        assert storage.exists()
+
+    def test_baseline_record_has_required_fields(self, tmp_path: Path):
+        """Stored baseline contains all required schema fields."""
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+            baseline = get_baseline("SUITE_A")
+
+        required_keys = {
+            "suite_name",
+            "pass_rate",
+            "avg_quality_score",
+            "avg_error_rate",
+            "sample_size",
+            "updated_at",
+        }
+        assert required_keys.issubset(set(baseline.keys()))


### PR DESCRIPTION
## Summary

- Add `src/services/baseline_service.py` with three public functions: `update_baseline`, `get_baseline`, and `list_baselines`
- Persists per-suite quality baselines to `reports/baselines.json` using a rolling window of the last 10 runs
- Add `tests/unit/test_baseline_service.py` with 19 unit tests (TDD — tests written first, then implementation)
- Register new module in `docs/sphinx/modules.rst`

## Details

**Storage format** — `reports/baselines.json` maps suite names to a `{baseline, history}` record. The `history` list is capped at 10 entries (oldest dropped); averages recomputed on every `update_baseline` call.

**Edge cases handled:**
- `total_rows=0` → `avg_error_rate=0.0` (no division-by-zero)
- Missing `quality_score` in result → `avg_quality_score=None`
- Mixed presence of `quality_score` across runs → average of available values only
- Corrupt or missing `baselines.json` → start fresh with a warning log

**Architecture:** Pure service layer — no commands, routers, or DB imports. Uses `Path(__file__).parent` for the default storage path; tests redirect via `unittest.mock.patch` on `_BASELINES_PATH` with a `tmp_path` fixture.

## Test plan

- [x] 19 unit tests all pass: `python3 -m pytest tests/unit/test_baseline_service.py -v`
- [x] Full suite passes at 80.71% coverage: `python3 -m pytest tests/unit/ -q --tb=no`
- [x] Sphinx builds cleanly: `python3 -m sphinx -b html . _build/html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)