### PR TITLE
feat(ui): trend chart accessibility, dark/light theme, empty state (#250)

### DIFF
--- a/alembic/versions/0003_cm3_baselines.py
+++ b/alembic/versions/0003_cm3_baselines.py
@@ -1,0 +1,51 @@
+"""Add CM3_BASELINES table for per-suite quality metric baselines.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-31
+
+The CM3_BASELINES table stores one row per suite containing the rolling-window
+averaged metrics computed by :mod:`src.services.baseline_service`.  The primary
+key is ``suite_name`` so every UPSERT replaces the existing row for a suite.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# ---------------------------------------------------------------------------
+# Alembic revision metadata
+# ---------------------------------------------------------------------------
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+# ---------------------------------------------------------------------------
+# Migration steps
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    """Create the CM3_BASELINES table."""
+    op.create_table(
+        "CM3_BASELINES",
+        sa.Column("suite_name", sa.String(200), primary_key=True),
+        sa.Column("pass_rate", sa.Numeric(5, 2), nullable=True),
+        sa.Column("avg_quality_score", sa.Numeric(5, 2), nullable=True),
+        sa.Column("avg_error_rate", sa.Numeric(5, 2), nullable=True),
+        sa.Column(
+            "sample_size",
+            sa.Integer,
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("updated_at", sa.DateTime, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the CM3_BASELINES table."""
+    op.drop_table("CM3_BASELINES")

--- a/src/api/routers/runs.py
+++ b/src/api/routers/runs.py
@@ -3,9 +3,12 @@
 import uuid
 import asyncio
 from datetime import datetime
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from typing import Any, List, Optional
+
+from src.api.auth import require_api_key
+from src.services import summary_service
 
 router = APIRouter(prefix="/api/v1/runs", tags=["runs"])
 
@@ -80,6 +83,26 @@ async def trigger_run(request: TriggerRequest):
 
     asyncio.create_task(_run())
     return TriggerResponse(run_id=run_id, status="queued", message=f"Suite run queued as {run_id}")
+
+
+@router.get("/summaries")
+async def get_summaries(_: Any = Depends(require_api_key)) -> List[dict]:
+    """Return per-suite summary cards data for the dashboard.
+
+    Aggregates the full run history into one summary object per suite,
+    including last-run status, 30-day pass rate, average quality score,
+    and a 7-day trend direction.
+
+    Args:
+        _: Auth context injected by ``require_api_key`` dependency.
+
+    Returns:
+        List of suite summary dicts sorted by ``last_run_at`` descending.
+        Each dict contains: ``suite_name``, ``last_run_status``,
+        ``last_run_at``, ``pass_rate_30d``, ``avg_quality_score``,
+        ``trend_direction``.  Returns ``[]`` when no history exists.
+    """
+    return summary_service.get_suite_summaries()
 
 
 @router.get("/{run_id}")

--- a/src/commands/run_tests_command.py
+++ b/src/commands/run_tests_command.py
@@ -22,6 +22,11 @@ try:
 except ImportError:  # service not yet present in all environments
     _db_write_run = None  # type: ignore[assignment]
 
+try:
+    from src.services.baseline_service import update_baseline
+except ImportError:  # baseline service not yet present in all environments
+    update_baseline = None  # type: ignore[assignment]
+
 
 def _run_api_check_test(test: TestConfig, params: dict) -> dict:
     """Execute an HTTP API check test.
@@ -573,6 +578,20 @@ def run_suite_from_path(
         archive_path=archive_path_str,
         timestamp=run_timestamp,
     )
+
+    if update_baseline is not None:
+        try:
+            pass_count = sum(1 for r in results if r["status"] == "PASS")
+            total_count = len(results)
+            update_baseline(
+                suite.name,
+                {
+                    "pass_count": pass_count,
+                    "total_count": total_count,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logging.getLogger(__name__).warning("Baseline update failed: %s", exc)
 
     return results
 

--- a/src/reports/static/ui.css
+++ b/src/reports/static/ui.css
@@ -1629,3 +1629,21 @@
       transition: none !important;
     }
   }
+
+/* ===========================================================================
+   Trend chart day-range buttons (#249)
+   =========================================================================== */
+.trend-day-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+.trend-day-btn.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -301,6 +301,25 @@
       <button class="btn btn-secondary" onclick="loadRunHistory()" style="font-size:12px;padding:6px 14px" aria-label="Refresh run history">Refresh</button>
     </div>
 
+    <!-- Suite summary cards (#252) -->
+    <div id="suiteSummaryCards" style="margin-bottom:20px;"></div>
+
+    <!-- Trend chart section (#249) -->
+    <div id="trendChartSection" style="margin-bottom:20px;">
+      <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px;flex-wrap:wrap;">
+        <span style="font-size:13px;font-weight:600;color:var(--text-primary);">Pass Rate &amp; Quality Trend</span>
+        <select id="trendSuiteSelect" style="font-size:12px;padding:2px 6px;border:1px solid var(--border);border-radius:4px;background:var(--bg-secondary);color:var(--text-primary);">
+          <option value="">All suites</option>
+        </select>
+        <div style="display:flex;gap:4px;">
+          <button type="button" class="trend-day-btn active" data-days="7" onclick="setTrendDays(7)">7d</button>
+          <button type="button" class="trend-day-btn" data-days="14" onclick="setTrendDays(14)">14d</button>
+          <button type="button" class="trend-day-btn" data-days="30" onclick="setTrendDays(30)">30d</button>
+        </div>
+      </div>
+      <div id="trendsChart" style="width:100%;min-height:120px;"></div>
+    </div>
+
     <div class="table-wrap" id="runsTableWrap">
       <p class="empty-msg" id="runsLoading">Loading run history&hellip;</p>
     </div>

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -295,6 +295,9 @@
         <div class="refresh-dot"></div>
         <span id="refreshToggleLabel">Auto-refresh off</span>
       </div>
+      <button type="button" id="btnToggleBaselineCol"
+              style="font-size:12px;background:none;border:1px solid var(--border);border-radius:4px;padding:2px 8px;cursor:pointer;color:var(--text-secondary);"
+              onclick="toggleBaselineColumn()">Show baseline</button>
       <button class="btn btn-secondary" onclick="loadRunHistory()" style="font-size:12px;padding:6px 14px" aria-label="Refresh run history">Refresh</button>
     </div>
 

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -308,13 +308,14 @@
     <div id="trendChartSection" style="margin-bottom:20px;">
       <div style="display:flex;align-items:center;gap:12px;margin-bottom:8px;flex-wrap:wrap;">
         <span style="font-size:13px;font-weight:600;color:var(--text-primary);">Pass Rate &amp; Quality Trend</span>
+        <label for="trendSuiteSelect" style="font-size:11px;color:var(--text-secondary);">Suite:</label>
         <select id="trendSuiteSelect" style="font-size:12px;padding:2px 6px;border:1px solid var(--border);border-radius:4px;background:var(--bg-secondary);color:var(--text-primary);">
           <option value="">All suites</option>
         </select>
         <div style="display:flex;gap:4px;">
-          <button type="button" class="trend-day-btn active" data-days="7" onclick="setTrendDays(7)">7d</button>
-          <button type="button" class="trend-day-btn" data-days="14" onclick="setTrendDays(14)">14d</button>
-          <button type="button" class="trend-day-btn" data-days="30" onclick="setTrendDays(30)">30d</button>
+          <button type="button" class="trend-day-btn active" data-days="7" onclick="setTrendDays(7)" aria-pressed="true">7d</button>
+          <button type="button" class="trend-day-btn" data-days="14" onclick="setTrendDays(14)" aria-pressed="false">14d</button>
+          <button type="button" class="trend-day-btn" data-days="30" onclick="setTrendDays(30)" aria-pressed="false">30d</button>
         </div>
       </div>
       <div id="trendsChart" style="width:100%;min-height:120px;"></div>

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -8,6 +8,8 @@ var _autoRefreshTimer = null;
 var _runsData = [];
 var _runsSortCol = 'timestamp';
 var _runsSortDir = 'desc';
+var _trendDays = 7;
+var _trendSuite = '';
 
 // ---------------------------------------------------------------------------
 // Tab switching — animated panels + sliding underline indicator
@@ -37,6 +39,8 @@ function switchTab(name) {
     btn.setAttribute('aria-selected', String(t === name));
   });
   updateTabIndicator();
+  // Reload trend chart whenever the Recent Runs tab is activated (#249)
+  if (name === 'runs') { loadTrendChart(); }
 }
 
 /**
@@ -785,6 +789,11 @@ async function loadRunHistory() {
     _runsData = await resp.json();
     buildRunsTable(_runsData);
     _fetchBaselineStatuses();
+    // Populate trend chart suite selector with unique suite names (#249)
+    var _suiteNames = Array.from(new Set(
+      _runsData.map(function(r) { return r.suite_name || r.suite || ''; }).filter(Boolean)
+    )).sort();
+    _populateTrendSuiteSelector(_suiteNames);
   } catch (err) {
     while (wrap.firstChild) { wrap.removeChild(wrap.firstChild); }
     var p = document.createElement('p');
@@ -810,10 +819,72 @@ function toggleAutoRefresh() {
     toggle.classList.remove('active');
     label.textContent = 'Auto-refresh off';
   } else {
-    _autoRefreshTimer = setInterval(loadRunHistory, 30000);
+    _autoRefreshTimer = setInterval(function() { loadRunHistory(); loadTrendChart(); }, 30000);
     toggle.classList.add('active');
     label.textContent = 'Auto-refresh on (30s)';
   }
+}
+
+// ===========================================================================
+// Trend Chart — fetch + wiring (#249)
+// ===========================================================================
+/**
+ * Set the active day-range for the trend chart and reload it.
+ *
+ * Updates button active state and triggers a fresh fetch.
+ *
+ * @param {number} days - Number of days to display (7, 14, or 30).
+ */
+function setTrendDays(days) {
+  _trendDays = days;
+  document.querySelectorAll('.trend-day-btn').forEach(function(btn) {
+    btn.classList.toggle('active', parseInt(btn.getAttribute('data-days')) === days);
+  });
+  loadTrendChart();
+}
+
+/**
+ * Fetch trend data from the API and render it into the #trendsChart container.
+ *
+ * Uses the current values of _trendDays and the #trendSuiteSelect element.
+ * Safe to call before the DOM element exists — returns early if container is absent.
+ */
+function loadTrendChart() {
+  var container = document.getElementById('trendsChart');
+  if (!container) { return; }
+
+  var suite = document.getElementById('trendSuiteSelect') ?
+    document.getElementById('trendSuiteSelect').value : '';
+
+  var url = '/api/v1/runs/trend?days=' + _trendDays;
+  if (suite) { url += '&suite=' + encodeURIComponent(suite); }
+
+  container.textContent = 'Loading\u2026';
+
+  fetch(url, { headers: window._apiKey ? { 'X-API-Key': window._apiKey } : {} })
+    .then(function(r) { return r.ok ? r.json() : []; })
+    .then(function(data) { renderTrendChart(data, container); })
+    .catch(function() { container.textContent = 'Failed to load trend data.'; });
+}
+
+/**
+ * Populate the suite filter <select> in the trend chart section.
+ *
+ * Always preserves the leading "All suites" option and rebuilds the rest
+ * from the provided list.
+ *
+ * @param {string[]} suites - Unique suite names extracted from run history.
+ */
+function _populateTrendSuiteSelector(suites) {
+  var sel = document.getElementById('trendSuiteSelect');
+  if (!sel) { return; }
+  sel.innerHTML = '<option value="">All suites</option>';
+  (suites || []).forEach(function(s) {
+    var opt = document.createElement('option');
+    opt.value = s;
+    opt.textContent = s;
+    sel.appendChild(opt);
+  });
 }
 
 // ===========================================================================
@@ -1751,7 +1822,14 @@ setInterval(checkHealth, HEALTH_INTERVAL_MS);
 loadMappings();
 loadRules();
 loadRunHistory();
+loadTrendChart();
 _applyBaselineColVisibility();
+
+// Wire trend suite selector change event (#249)
+(function() {
+  var trendSel = document.getElementById('trendSuiteSelect');
+  if (trendSel) { trendSel.addEventListener('change', loadTrendChart); }
+})();
 
 // ===========================================================================
 // API TESTER

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -39,8 +39,8 @@ function switchTab(name) {
     btn.setAttribute('aria-selected', String(t === name));
   });
   updateTabIndicator();
-  // Reload trend chart whenever the Recent Runs tab is activated (#249)
-  if (name === 'runs') { loadTrendChart(); }
+  // Reload trend chart and summary cards whenever the Recent Runs tab is activated
+  if (name === 'runs') { loadTrendChart(); loadSummaryCards(); }
 }
 
 /**
@@ -716,6 +716,11 @@ function _applyBaselineColVisibility() {
     td.style.display = visible ? '' : 'none';
   });
   if (btn) { btn.textContent = visible ? 'Hide baseline' : 'Show baseline'; }
+  // Remove any open deviation detail row when the column is hidden
+  if (!visible) {
+    var detail = document.querySelector('tr.deviation-detail-row');
+    if (detail) { detail.remove(); }
+  }
 }
 
 /**
@@ -770,6 +775,98 @@ function _fetchBaselineStatuses() {
 }
 
 /**
+ * Attach click handlers to deviation badge cells so that clicking a warning cell
+ * toggles an inline detail row showing per-metric breakdown (Metric, Baseline,
+ * Current, Delta, Threshold).  Only cells with a `data-deviation` attribute
+ * (set by `_fetchBaselineStatuses`) get a handler.  Clicking the same cell a
+ * second time collapses the detail row.
+ */
+function _attachDeviationClickHandlers() {
+  document.querySelectorAll('.td-baseline[data-deviation]').forEach(function(td) {
+    td.addEventListener('click', function() {
+      var row = td.closest('tr');
+      if (!row) return;
+
+      // Close any existing open detail row
+      var existing = document.querySelector('tr.deviation-detail-row');
+      if (existing) {
+        var prevRow = existing.previousElementSibling;
+        if (prevRow === row) {
+          // Toggle off — same cell clicked again
+          existing.remove();
+          td.setAttribute('aria-expanded', 'false');
+          return;
+        }
+        // Close the other row's aria state
+        if (prevRow) {
+          var prevTd = prevRow.querySelector('.td-baseline');
+          if (prevTd) { prevTd.setAttribute('aria-expanded', 'false'); }
+        }
+        existing.remove();
+      }
+
+      var deviationData = JSON.parse(td.getAttribute('data-deviation') || '{}');
+      var alerts = deviationData.alerts || [];
+
+      var detailRow = document.createElement('tr');
+      detailRow.className = 'deviation-detail-row';
+
+      var colCount = row.cells.length;
+      var detailTd = document.createElement('td');
+      detailTd.setAttribute('colspan', colCount);
+      detailTd.style.cssText = 'padding:8px 16px;background:var(--bg-secondary);border-bottom:1px solid var(--border);';
+
+      if (alerts.length === 0) {
+        detailTd.textContent = 'No deviation details available.';
+      } else {
+        var table = document.createElement('table');
+        table.style.cssText = 'font-size:11px;border-collapse:collapse;width:auto;';
+
+        // Header row
+        var thead = document.createElement('thead');
+        var hrow = document.createElement('tr');
+        ['Metric', 'Baseline', 'Current', 'Delta', 'Threshold'].forEach(function(h) {
+          var th = document.createElement('th');
+          th.style.cssText = 'padding:3px 10px;text-align:left;color:var(--text-secondary);font-weight:600;border-bottom:1px solid var(--border);';
+          th.textContent = h;
+          hrow.appendChild(th);
+        });
+        thead.appendChild(hrow);
+        table.appendChild(thead);
+
+        // Data rows
+        var tbody = document.createElement('tbody');
+        alerts.forEach(function(alert) {
+          var tr = document.createElement('tr');
+          var deltaStr = (alert.delta > 0 ? '+' : '') + Math.round(alert.delta * 10) / 10 + '%';
+          var deltaColor = alert.delta < 0 ? 'var(--error, #dc2626)' : 'var(--success, #16a34a)';
+          [
+            alert.metric,
+            Math.round(alert.baseline_value * 10) / 10 + '%',
+            Math.round(alert.current_value * 10) / 10 + '%',
+            deltaStr,
+            alert.metric + ' drop > ' + alert.threshold + '%',
+          ].forEach(function(val, idx) {
+            var td2 = document.createElement('td');
+            td2.style.cssText = 'padding:3px 10px;';
+            if (idx === 3) { td2.style.color = deltaColor; }
+            td2.textContent = val;
+            tr.appendChild(td2);
+          });
+          tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        detailTd.appendChild(table);
+      }
+
+      detailRow.appendChild(detailTd);
+      row.parentNode.insertBefore(detailRow, row.nextSibling);
+      td.setAttribute('aria-expanded', 'true');
+    });
+  });
+}
+
+/**
  * Fetch run history from the API and render it into the runs table.
  * Displays a loading message while the request is in-flight and an error
  * message if the request fails.
@@ -788,7 +885,7 @@ async function loadRunHistory() {
     if (!resp.ok) { throw new Error('HTTP ' + resp.status); }
     _runsData = await resp.json();
     buildRunsTable(_runsData);
-    _fetchBaselineStatuses();
+    _fetchBaselineStatuses().then(_attachDeviationClickHandlers);
     // Populate trend chart suite selector with unique suite names (#249)
     var _suiteNames = Array.from(new Set(
       _runsData.map(function(r) { return r.suite_name || r.suite || ''; }).filter(Boolean)
@@ -819,10 +916,144 @@ function toggleAutoRefresh() {
     toggle.classList.remove('active');
     label.textContent = 'Auto-refresh off';
   } else {
-    _autoRefreshTimer = setInterval(function() { loadRunHistory(); loadTrendChart(); }, 30000);
+    _autoRefreshTimer = setInterval(function() { loadRunHistory(); loadTrendChart(); loadSummaryCards(); }, 30000);
     toggle.classList.add('active');
     label.textContent = 'Auto-refresh on (30s)';
   }
+}
+
+// ===========================================================================
+// Suite Summary Cards (#252)
+// ===========================================================================
+/**
+ * Fetch suite summaries from the API and render suite summary cards.
+ *
+ * Calls GET /api/v1/runs/summaries and delegates rendering to
+ * _renderSummaryCards. Silently clears the container on error.
+ */
+function loadSummaryCards() {
+  var container = document.getElementById('suiteSummaryCards');
+  if (!container) return;
+
+  fetch('/api/v1/runs/summaries', {
+    headers: window._apiKey ? { 'X-API-Key': window._apiKey } : {}
+  })
+  .then(function(r) { return r.ok ? r.json() : []; })
+  .then(function(summaries) { _renderSummaryCards(summaries, container); })
+  .catch(function() { container.textContent = ''; });
+}
+
+/**
+ * Render suite summary cards into the given container element.
+ *
+ * Displays up to 8 cards in a responsive grid. Each card shows the suite name,
+ * last-run status badge, relative time, 30-day pass rate, and trend arrow.
+ * Clicking a card sets the trendSuiteSelect filter and reloads the trend chart.
+ *
+ * @param {Array<Object>} summaries - Array of suite summary objects from the API.
+ * @param {HTMLElement} container - The DOM element to render cards into.
+ */
+function _renderSummaryCards(summaries, container) {
+  container.innerHTML = '';
+
+  if (!summaries || summaries.length === 0) {
+    var empty = document.createElement('p');
+    empty.style.fontSize = '13px';
+    empty.style.color = 'var(--text-secondary)';
+    empty.textContent = 'No suite history yet.';
+    container.appendChild(empty);
+    return;
+  }
+
+  var grid = document.createElement('div');
+  grid.style.cssText = 'display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:10px;';
+
+  var MAX_CARDS = 8;
+  var shown = summaries.slice(0, MAX_CARDS);
+
+  shown.forEach(function(s) {
+    var card = document.createElement('div');
+    card.style.cssText = 'border:1px solid var(--border);border-radius:6px;padding:10px 12px;cursor:pointer;background:var(--bg-secondary);';
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.setAttribute('data-suite', s.suite_name);
+
+    // Suite name
+    var nameEl = document.createElement('div');
+    nameEl.style.cssText = 'font-weight:600;font-size:13px;margin-bottom:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+    nameEl.textContent = s.suite_name;
+    card.appendChild(nameEl);
+
+    // Status badge
+    var badge = document.createElement('span');
+    var isPass = s.last_run_status === 'PASS';
+    badge.style.cssText = 'font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;' +
+      (isPass ? 'background:#dcfce7;color:#16a34a;' : 'background:#fee2e2;color:#dc2626;');
+    badge.textContent = s.last_run_status;
+    card.appendChild(badge);
+
+    // Relative time
+    var timeEl = document.createElement('div');
+    timeEl.style.cssText = 'font-size:11px;color:var(--text-secondary);margin-top:4px;';
+    timeEl.textContent = _relativeTime(s.last_run_at);
+    card.appendChild(timeEl);
+
+    // Pass rate and trend
+    var statsEl = document.createElement('div');
+    statsEl.style.cssText = 'font-size:11px;margin-top:6px;display:flex;gap:8px;';
+    var prEl = document.createElement('span');
+    prEl.textContent = (s.pass_rate_30d || 0) + '% pass';
+    var trendEl = document.createElement('span');
+    var arrow = s.trend_direction === 'up' ? '↑' : s.trend_direction === 'down' ? '↓' : '→';
+    var arrowColor = s.trend_direction === 'up' ? '#16a34a' : s.trend_direction === 'down' ? '#dc2626' : 'var(--text-secondary)';
+    trendEl.style.color = arrowColor;
+    trendEl.textContent = arrow;
+    statsEl.appendChild(prEl);
+    statsEl.appendChild(trendEl);
+    card.appendChild(statsEl);
+
+    // Click to filter trend chart
+    card.addEventListener('click', function() {
+      var sel = document.getElementById('trendSuiteSelect');
+      if (sel) {
+        sel.value = s.suite_name;
+        if (typeof loadTrendChart === 'function') loadTrendChart();
+      }
+    });
+
+    grid.appendChild(card);
+  });
+
+  container.appendChild(grid);
+
+  // Show overflow count if more suites exist than the displayed maximum
+  if (summaries.length > MAX_CARDS) {
+    var more = document.createElement('p');
+    more.style.cssText = 'font-size:11px;color:var(--text-secondary);margin-top:6px;';
+    more.textContent = '+ ' + (summaries.length - MAX_CARDS) + ' more suites';
+    container.appendChild(more);
+  }
+}
+
+/**
+ * Convert an ISO 8601 timestamp string to a human-readable relative time.
+ *
+ * @param {string} isoStr - ISO 8601 date string (e.g. "2026-03-31T12:00:00Z").
+ * @returns {string} Human-readable string like "5 min ago", "2 hours ago", or
+ *   the original string if parsing fails.
+ */
+function _relativeTime(isoStr) {
+  if (!isoStr) return '';
+  try {
+    var diff = Date.now() - new Date(isoStr).getTime();
+    var mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return mins + ' min ago';
+    var hrs = Math.floor(mins / 60);
+    if (hrs < 24) return hrs + ' hour' + (hrs > 1 ? 's' : '') + ' ago';
+    var days = Math.floor(hrs / 24);
+    return days + ' day' + (days > 1 ? 's' : '') + ' ago';
+  } catch(e) { return isoStr; }
 }
 
 // ===========================================================================
@@ -1823,6 +2054,7 @@ loadMappings();
 loadRules();
 loadRunHistory();
 loadTrendChart();
+loadSummaryCards();
 _applyBaselineColVisibility();
 
 // Wire trend suite selector change event (#249)

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -720,6 +720,137 @@ function toggleAutoRefresh() {
 }
 
 // ===========================================================================
+// Trend Chart — SVG renderer
+// ===========================================================================
+/**
+ * Render a pass-rate / quality-score trend line chart into a container element.
+ *
+ * The function is a pure DOM-manipulation renderer — it performs no fetch calls
+ * and has no side-effects beyond writing into `container`.
+ *
+ * Testability note: renderTrendChart is a pure DOM-manipulation function.
+ * Verified by: node --check src/reports/static/ui.js (syntax check)
+ * Manual test: open /ui in browser, check Recent Runs tab after chart is wired in (#249).
+ *
+ * @param {Array<{date: string, pass_rate: number, avg_quality_score: number|null}>} data
+ *   Array of daily trend objects, ordered oldest → newest.
+ * @param {HTMLElement} container - DOM element into which the SVG chart is injected.
+ */
+function renderTrendChart(data, container) {
+  // Clear container
+  container.innerHTML = '';
+
+  if (!data || data.length === 0) {
+    var emptyMsg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    emptyMsg.setAttribute('width', '100%');
+    emptyMsg.setAttribute('height', '120');
+    emptyMsg.setAttribute('role', 'img');
+    emptyMsg.setAttribute('aria-label', 'No trend data available');
+    var txt = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    txt.setAttribute('x', '50%');
+    txt.setAttribute('y', '60');
+    txt.setAttribute('text-anchor', 'middle');
+    txt.setAttribute('fill', 'var(--text-secondary)');
+    txt.setAttribute('font-size', '13');
+    txt.textContent = 'No trend data yet \u2014 run some suites to see history';
+    emptyMsg.appendChild(txt);
+    container.appendChild(emptyMsg);
+    return;
+  }
+
+  var W = container.clientWidth || 600;
+  var H = 180;
+  var PAD = { top: 16, right: 80, bottom: 32, left: 40 };
+  var chartW = W - PAD.left - PAD.right;
+  var chartH = H - PAD.top - PAD.bottom;
+
+  var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', W);
+  svg.setAttribute('height', H);
+  svg.setAttribute('role', 'img');
+
+  // Compute pass rate range for aria-label
+  var passRates = data.map(function(d) { return d.pass_rate || 0; });
+  var first = Math.round(passRates[0]);
+  var last = Math.round(passRates[passRates.length - 1]);
+  svg.setAttribute('aria-label', 'Pass rate trend: ' + first + '% to ' + last + '% over ' + data.length + ' days');
+
+  var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  g.setAttribute('transform', 'translate(' + PAD.left + ',' + PAD.top + ')');
+
+  // Y-axis reference lines at 0, 25, 50, 75, 100
+  [0, 25, 50, 75, 100].forEach(function(val) {
+    var y = chartH - (val / 100) * chartH;
+    var line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', 0); line.setAttribute('x2', chartW);
+    line.setAttribute('y1', y); line.setAttribute('y2', y);
+    line.setAttribute('stroke', 'var(--border, #e0e0e0)');
+    line.setAttribute('stroke-width', '1');
+    g.appendChild(line);
+
+    var label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    label.setAttribute('x', -4); label.setAttribute('y', y + 4);
+    label.setAttribute('text-anchor', 'end');
+    label.setAttribute('font-size', '10');
+    label.setAttribute('fill', 'var(--text-secondary, #888)');
+    label.textContent = val + '%';
+    g.appendChild(label);
+  });
+
+  function makePolyline(values, color) {
+    var n = data.length;
+    var points = values.map(function(v, i) {
+      var x = (i / Math.max(n - 1, 1)) * chartW;
+      var y = chartH - (Math.min(Math.max(v || 0, 0), 100) / 100) * chartH;
+      return x + ',' + y;
+    }).join(' ');
+    var pl = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    pl.setAttribute('points', points);
+    pl.setAttribute('fill', 'none');
+    pl.setAttribute('stroke', color);
+    pl.setAttribute('stroke-width', '2');
+    pl.setAttribute('stroke-linejoin', 'round');
+    return pl;
+  }
+
+  // Pass rate line
+  g.appendChild(makePolyline(data.map(function(d){ return d.pass_rate; }), 'var(--accent, #2563eb)'));
+  // Quality score line
+  var qualScores = data.map(function(d){ return d.avg_quality_score; });
+  if (qualScores.some(function(v){ return v != null; })) {
+    g.appendChild(makePolyline(qualScores, 'var(--text-secondary, #888)'));
+  }
+
+  // X-axis tick labels every 7 points
+  var step = Math.max(1, Math.floor(data.length / 5));
+  data.forEach(function(d, i) {
+    if (i % step !== 0 && i !== data.length - 1) return;
+    var x = (i / Math.max(data.length - 1, 1)) * chartW;
+    var datePart = (d.date || '').slice(5); // MM-DD
+    var tick = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    tick.setAttribute('x', x); tick.setAttribute('y', chartH + 14);
+    tick.setAttribute('text-anchor', 'middle');
+    tick.setAttribute('font-size', '9');
+    tick.setAttribute('fill', 'var(--text-secondary, #888)');
+    tick.textContent = datePart;
+    g.appendChild(tick);
+  });
+
+  // Legend at right edge
+  [['Pass Rate', 'var(--accent, #2563eb)', chartH - 20],
+   ['Quality', 'var(--text-secondary, #888)', chartH - 6]].forEach(function(item) {
+    var leg = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    leg.setAttribute('x', chartW + 4); leg.setAttribute('y', item[2]);
+    leg.setAttribute('font-size', '9'); leg.setAttribute('fill', item[1]);
+    leg.textContent = item[0];
+    g.appendChild(leg);
+  });
+
+  svg.appendChild(g);
+  container.appendChild(svg);
+}
+
+// ===========================================================================
 // Mapping Generator — state
 // ===========================================================================
 var mapFile   = null;

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -562,10 +562,15 @@ function buildRunsTable(rows) {
     { label: 'Status',      key: 'status' },
     { label: 'Tests',       key: 'pass_count' },
     { label: 'Report',      key: null },
+    { label: 'vs Baseline', key: null, id: 'thBaseline', hidden: true },
   ];
   cols.forEach(function(col) {
     var th = document.createElement('th');
     th.textContent = col.label;
+    if (col.id) { th.id = col.id; }
+    if (col.hidden) {
+      th.style.display = localStorage.getItem('valdo_baseline_col_visible') === 'true' ? '' : 'none';
+    }
     if (col.key) {
       var sortSpan = document.createElement('span');
       sortSpan.className = 'sort-icon';
@@ -663,10 +668,101 @@ function buildRunsTable(rows) {
     }
     tr.appendChild(tdReport);
 
+    // vs Baseline cell — filled in asynchronously by _fetchBaselineStatuses()
+    var tdBaseline = document.createElement('td');
+    tdBaseline.className = 'td-baseline';
+    tdBaseline.style.display = localStorage.getItem('valdo_baseline_col_visible') === 'true' ? '' : 'none';
+    tdBaseline.textContent = '\u2014';
+    tdBaseline.setAttribute('data-run-id', r.run_id || r.id || '');
+    tdBaseline.setAttribute('data-suite', r.suite_name || '');
+    tr.appendChild(tdBaseline);
+
     tbody.appendChild(tr);
   });
   table.appendChild(tbody);
   wrap.appendChild(table);
+}
+
+// ===========================================================================
+// Baseline column toggle and deviation fetch — issue #253
+// ===========================================================================
+
+/**
+ * Toggle the 'vs Baseline' column visibility in the Recent Runs table and
+ * persist the preference in localStorage.
+ */
+function toggleBaselineColumn() {
+  var visible = localStorage.getItem('valdo_baseline_col_visible') === 'true';
+  visible = !visible;
+  localStorage.setItem('valdo_baseline_col_visible', visible);
+  _applyBaselineColVisibility();
+}
+
+/**
+ * Apply the stored baseline column visibility preference to the table header
+ * and all baseline cells.  Safe to call before the table is rendered — it is
+ * a no-op when the relevant elements are absent.
+ */
+function _applyBaselineColVisibility() {
+  var visible = localStorage.getItem('valdo_baseline_col_visible') === 'true';
+  var th = document.getElementById('thBaseline');
+  var btn = document.getElementById('btnToggleBaselineCol');
+  if (th) { th.style.display = visible ? '' : 'none'; }
+  document.querySelectorAll('.td-baseline').forEach(function(td) {
+    td.style.display = visible ? '' : 'none';
+  });
+  if (btn) { btn.textContent = visible ? 'Hide baseline' : 'Show baseline'; }
+}
+
+/**
+ * Fetch deviation status from the baseline-check API for every baseline cell
+ * currently in the table and update each cell's text and style in-place.
+ *
+ * Requests are fired in parallel.  Cells with no run_id or suite are left
+ * unchanged.  Network errors are silently swallowed so the table remains
+ * functional when the baseline service is unavailable.
+ *
+ * @returns {Promise<void[]>}
+ */
+function _fetchBaselineStatuses() {
+  var cells = document.querySelectorAll('.td-baseline[data-run-id]');
+  var promises = Array.from(cells).map(function(td) {
+    var runId = td.getAttribute('data-run-id');
+    var suite = td.getAttribute('data-suite');
+    if (!runId || !suite) { return Promise.resolve(); }
+    return fetch(
+      '/api/v1/runs/baseline-check?suite=' + encodeURIComponent(suite) +
+      '&run_id=' + encodeURIComponent(runId),
+      { headers: { 'X-API-Key': window._apiKey || '' } }
+    )
+    .then(function(r) { return r.ok ? r.json() : null; })
+    .then(function(data) {
+      if (!data) { td.textContent = '\u2014'; return; }
+      if (data.reason === 'no_baseline') {
+        td.textContent = '\u2014';
+      } else if (data.deviated) {
+        var firstAlert = data.alerts && data.alerts[0];
+        var delta = firstAlert
+          ? ' (' + (firstAlert.delta > 0 ? '+' : '') + Math.round(firstAlert.delta) + '%)'
+          : '';
+        td.textContent = '\u26A0\uFE0F Deviated' + delta;
+        td.style.color = 'var(--error, #dc2626)';
+        td.setAttribute(
+          'title',
+          'Threshold: ' + (firstAlert
+            ? firstAlert.metric + ' drop > ' + firstAlert.threshold + '%'
+            : '')
+        );
+        td.style.cursor = 'pointer';
+        td.setAttribute('data-deviation', JSON.stringify(data));
+      } else {
+        td.textContent = '\u2713 Within baseline';
+        td.style.color = 'var(--success, #16a34a)';
+      }
+    })
+    .catch(function() { td.textContent = '\u2014'; });
+  });
+  return Promise.all(promises);
 }
 
 /**
@@ -688,6 +784,7 @@ async function loadRunHistory() {
     if (!resp.ok) { throw new Error('HTTP ' + resp.status); }
     _runsData = await resp.json();
     buildRunsTable(_runsData);
+    _fetchBaselineStatuses();
   } catch (err) {
     while (wrap.firstChild) { wrap.removeChild(wrap.firstChild); }
     var p = document.createElement('p');
@@ -1654,6 +1751,7 @@ setInterval(checkHealth, HEALTH_INTERVAL_MS);
 loadMappings();
 loadRules();
 loadRunHistory();
+_applyBaselineColVisibility();
 
 // ===========================================================================
 // API TESTER

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -1069,7 +1069,9 @@ function _relativeTime(isoStr) {
 function setTrendDays(days) {
   _trendDays = days;
   document.querySelectorAll('.trend-day-btn').forEach(function(btn) {
-    btn.classList.toggle('active', parseInt(btn.getAttribute('data-days')) === days);
+    var isActive = parseInt(btn.getAttribute('data-days')) === days;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
   loadTrendChart();
 }
@@ -1090,12 +1092,14 @@ function loadTrendChart() {
   var url = '/api/v1/runs/trend?days=' + _trendDays;
   if (suite) { url += '&suite=' + encodeURIComponent(suite); }
 
-  container.textContent = 'Loading\u2026';
+  container.innerHTML = '<span style="font-size:12px;color:var(--text-secondary);">Loading\u2026</span>';
 
   fetch(url, { headers: window._apiKey ? { 'X-API-Key': window._apiKey } : {} })
     .then(function(r) { return r.ok ? r.json() : []; })
     .then(function(data) { renderTrendChart(data, container); })
-    .catch(function() { container.textContent = 'Failed to load trend data.'; });
+    .catch(function() {
+      container.innerHTML = '<span style="font-size:12px;color:var(--fail);">Failed to load trend data.</span>';
+    });
 }
 
 /**

--- a/src/services/baseline_service.py
+++ b/src/services/baseline_service.py
@@ -1,0 +1,240 @@
+"""JSON-backed rolling baseline store for per-suite quality metrics.
+
+Baselines are persisted to ``reports/baselines.json`` using the same
+read-modify-write pattern as ``reports/run_history.json``.  Each suite
+maintains a rolling window of its last 10 runs; averages are recomputed
+on every call to :func:`update_baseline`.
+
+Storage format (``reports/baselines.json``)::
+
+    {
+        "SUITE_A": {
+            "baseline": {
+                "suite_name": "SUITE_A",
+                "pass_rate": 87.5,
+                "avg_quality_score": 91.2,
+                "avg_error_rate": 2.3,
+                "sample_size": 10,
+                "updated_at": "2026-03-30T14:00:00"
+            },
+            "history": [
+                {"pass_rate": 80.0, "quality_score": 90.0, "error_rate": 1.0},
+                ...
+            ]
+        },
+        ...
+    }
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BASELINES_PATH: Path = Path(__file__).parent.parent.parent / "reports" / "baselines.json"
+"""Absolute path to the JSON file that stores all suite baselines and history."""
+
+_ROLLING_WINDOW: int = 10
+"""Maximum number of historical runs to keep per suite when computing averages."""
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_store(path: Path) -> dict[str, Any]:
+    """Read the baselines JSON file from disk.
+
+    Returns an empty dict when the file does not exist or contains corrupt JSON.
+    The corrupt-JSON case is logged as a warning and treated as a fresh store
+    (consistent with the run_history pattern).
+
+    Args:
+        path: Path to the baselines JSON file.
+
+    Returns:
+        Dict mapping suite_name to its ``{"baseline": ..., "history": [...]}`` record.
+    """
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("baselines.json is unreadable, starting fresh: %s", exc)
+        return {}
+
+
+def _save_store(path: Path, store: dict[str, Any]) -> None:
+    """Write the baselines store dict to disk as formatted JSON.
+
+    Creates parent directories as needed.
+
+    Args:
+        path: Path to the baselines JSON file.
+        store: Full in-memory store dict to persist.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store, indent=2), encoding="utf-8")
+
+
+def _compute_error_rate(invalid_rows: int, total_rows: int) -> float:
+    """Compute per-run error rate as a percentage.
+
+    Args:
+        invalid_rows: Number of rows that failed validation.
+        total_rows: Total rows processed.
+
+    Returns:
+        ``invalid_rows / total_rows * 100``, or ``0.0`` when ``total_rows`` is zero.
+    """
+    if total_rows == 0:
+        return 0.0
+    return invalid_rows / total_rows * 100.0
+
+
+def _average_or_none(values: list[float]) -> Optional[float]:
+    """Return the arithmetic mean of *values*, or ``None`` for an empty list.
+
+    Args:
+        values: Non-empty list of floats to average.
+
+    Returns:
+        Mean value, or ``None`` if *values* is empty.
+    """
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _recompute_baseline(suite_name: str, history: list[dict[str, Any]]) -> dict[str, Any]:
+    """Recompute the baseline summary from the rolling history window.
+
+    Args:
+        suite_name: Name of the suite.
+        history: List of per-run snapshot dicts with keys ``pass_rate``,
+            ``quality_score`` (optional), and ``error_rate``.
+
+    Returns:
+        Baseline dict with keys: suite_name, pass_rate, avg_quality_score,
+        avg_error_rate, sample_size, updated_at.
+    """
+    pass_rates = [h["pass_rate"] for h in history]
+    quality_scores = [h["quality_score"] for h in history if h.get("quality_score") is not None]
+    error_rates = [h["error_rate"] for h in history]
+
+    return {
+        "suite_name": suite_name,
+        "pass_rate": _average_or_none(pass_rates),
+        "avg_quality_score": _average_or_none(quality_scores),
+        "avg_error_rate": _average_or_none(error_rates) or 0.0,
+        "sample_size": len(history),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
+    """Append *result* to the rolling history and recompute the baseline.
+
+    Reads the current store from ``reports/baselines.json``, appends a
+    per-run snapshot derived from *result* to the suite's history, caps
+    the history at :data:`_ROLLING_WINDOW` entries (oldest dropped first),
+    recomputes all averages, persists the updated store, and returns the
+    new baseline dict.
+
+    Args:
+        suite_name: Logical name of the test suite (e.g. ``"ATOCTRAN"``).
+        result: Run result dict.  Expected keys (all optional — missing keys
+            are treated as zero or absent):
+
+            * ``pass_count`` — number of tests that passed.
+            * ``total_count`` — total tests executed.
+            * ``invalid_rows`` — row-level validation failures.
+            * ``total_rows`` — total rows inspected.
+            * ``quality_score`` — optional float quality score (0–100).
+
+    Returns:
+        Updated baseline dict with keys: suite_name, pass_rate,
+        avg_quality_score, avg_error_rate, sample_size, updated_at.
+    """
+    path = _BASELINES_PATH
+
+    store = _load_store(path)
+    suite_record = store.get(suite_name, {"baseline": {}, "history": []})
+
+    # Build per-run snapshot
+    pass_count = result.get("pass_count", 0)
+    total_count = result.get("total_count", 0)
+    pass_rate = (pass_count / total_count * 100.0) if total_count > 0 else 0.0
+
+    invalid_rows = result.get("invalid_rows", 0)
+    total_rows = result.get("total_rows", 0)
+    error_rate = _compute_error_rate(invalid_rows, total_rows)
+
+    snapshot: dict[str, Any] = {
+        "pass_rate": pass_rate,
+        "quality_score": result.get("quality_score"),  # None when absent
+        "error_rate": error_rate,
+    }
+
+    # Append and cap the rolling window
+    history: list[dict[str, Any]] = suite_record["history"]
+    history.append(snapshot)
+    if len(history) > _ROLLING_WINDOW:
+        history = history[-_ROLLING_WINDOW:]
+
+    # Recompute and persist
+    baseline = _recompute_baseline(suite_name, history)
+    store[suite_name] = {"baseline": baseline, "history": history}
+    _save_store(path, store)
+
+    return baseline
+
+
+def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
+    """Return the stored baseline for *suite_name*, or ``None`` if absent.
+
+    Args:
+        suite_name: Name of the suite to look up.
+
+    Returns:
+        Baseline dict with keys: suite_name, pass_rate, avg_quality_score,
+        avg_error_rate, sample_size, updated_at; or ``None`` if no baseline
+        has been recorded for this suite yet.
+    """
+    path = _BASELINES_PATH
+    store = _load_store(path)
+    record = store.get(suite_name)
+    if record is None:
+        return None
+    return record.get("baseline") or None
+
+
+def list_baselines() -> list[dict[str, Any]]:
+    """Return all stored baselines sorted alphabetically by suite name.
+
+    Returns:
+        List of baseline dicts (see :func:`get_baseline`), sorted by
+        ``suite_name``.  Returns an empty list when no baselines exist.
+    """
+    path = _BASELINES_PATH
+    store = _load_store(path)
+    baselines = [
+        record["baseline"]
+        for record in store.values()
+        if record.get("baseline")
+    ]
+    return sorted(baselines, key=lambda b: b.get("suite_name", ""))

--- a/src/services/baseline_service.py
+++ b/src/services/baseline_service.py
@@ -5,6 +5,10 @@ read-modify-write pattern as ``reports/run_history.json``.  Each suite
 maintains a rolling window of its last 10 runs; averages are recomputed
 on every call to :func:`update_baseline`.
 
+When the ``DB_ADAPTER`` environment variable is set, each public function
+attempts a database path first (UPSERT / SELECT against the ``CM3_BASELINES``
+table) and falls back to JSON on any exception.
+
 Storage format (``reports/baselines.json``)::
 
     {
@@ -29,6 +33,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
@@ -142,6 +147,256 @@ def _recompute_baseline(suite_name: str, history: list[dict[str, Any]]) -> dict[
 
 
 # ---------------------------------------------------------------------------
+# DB helpers (used when DB_ADAPTER env var is set)
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS CM3_BASELINES (
+    suite_name        VARCHAR(200) PRIMARY KEY,
+    pass_rate         REAL,
+    avg_quality_score REAL,
+    avg_error_rate    REAL,
+    sample_size       INTEGER NOT NULL DEFAULT 0,
+    updated_at        TEXT
+)
+"""
+
+
+def _get_schema_prefix() -> str:
+    """Return the schema prefix string including trailing dot, or empty string.
+
+    Reads ``ORACLE_SCHEMA`` (falling back to ``ORACLE_USER``, then empty) and
+    returns the value with a trailing ``.`` so it can be prepended directly to
+    a table name.
+
+    Returns:
+        Schema prefix such as ``"CM3INT."`` or ``""`` when not configured.
+    """
+    schema = os.getenv("ORACLE_SCHEMA") or os.getenv("ORACLE_USER") or ""
+    return f"{schema}." if schema else ""
+
+
+def _ensure_baselines_table(connection: Any) -> None:
+    """Create the CM3_BASELINES table if it does not already exist.
+
+    Uses a dialect-agnostic ``CREATE TABLE IF NOT EXISTS`` statement that is
+    compatible with SQLite and PostgreSQL.  For Oracle, the Alembic migration
+    ``0003_cm3_baselines.py`` is the authoritative table-creation path.
+
+    Args:
+        connection: A raw DBAPI connection (e.g. ``sqlite3.Connection``).
+    """
+    try:
+        connection.execute(_CREATE_TABLE_SQL)
+        connection.commit()
+    except Exception:  # noqa: BLE001 — best-effort; Oracle falls through to Alembic
+        pass
+
+
+def _update_baseline_db(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
+    """Compute a single-run baseline from *result* and UPSERT it into CM3_BASELINES.
+
+    Derives pass_rate, error_rate, and quality_score from the run result dict,
+    then UPSERTs the row using ``INSERT OR REPLACE`` (SQLite) with a fallback
+    DELETE + INSERT for Oracle/PostgreSQL.  Both paths commit the transaction.
+
+    The CM3_BASELINES table stores the latest single-run snapshot per suite
+    in the DB path; the rolling-window average is maintained separately in
+    ``baselines.json`` by the JSON path.
+
+    Args:
+        suite_name: Primary key — logical name of the test suite.
+        result: Run result dict.  Expected keys (all optional):
+            ``pass_count``, ``total_count``, ``invalid_rows``,
+            ``total_rows``, ``quality_score``.
+
+    Returns:
+        The computed single-run baseline dict (same shape as the JSON path).
+
+    Raises:
+        Exception: Propagates any DB exception so the caller can apply the
+            JSON fallback.
+    """
+    from src.database.adapters.factory import get_database_adapter
+
+    # Compute single-run metrics from the raw result dict
+    pass_count = result.get("pass_count", 0)
+    total_count = result.get("total_count", 0)
+    pass_rate = (pass_count / total_count * 100.0) if total_count > 0 else 0.0
+
+    invalid_rows = result.get("invalid_rows", 0)
+    total_rows = result.get("total_rows", 0)
+    error_rate = _compute_error_rate(invalid_rows, total_rows)
+    quality_score = result.get("quality_score")
+    updated_at = datetime.utcnow().isoformat()
+
+    baseline_record: dict[str, Any] = {
+        "suite_name": suite_name,
+        "pass_rate": pass_rate,
+        "avg_quality_score": quality_score,
+        "avg_error_rate": error_rate,
+        "sample_size": 1,
+        "updated_at": updated_at,
+    }
+
+    adapter = get_database_adapter()
+    adapter.connect()
+    try:
+        conn = adapter._connection  # type: ignore[attr-defined]
+        _ensure_baselines_table(conn)
+
+        prefix = _get_schema_prefix()
+        table = f"{prefix}CM3_BASELINES"
+
+        params = {
+            "suite_name": suite_name,
+            "pass_rate": pass_rate,
+            "avg_quality_score": quality_score,
+            "avg_error_rate": error_rate,
+            "sample_size": 1,
+            "updated_at": updated_at,
+        }
+
+        try:
+            # SQLite-compatible UPSERT
+            conn.execute(
+                f"INSERT OR REPLACE INTO {table}"
+                " (suite_name, pass_rate, avg_quality_score,"
+                "  avg_error_rate, sample_size, updated_at)"
+                " VALUES (:suite_name, :pass_rate, :avg_quality_score,"
+                "         :avg_error_rate, :sample_size, :updated_at)",
+                params,
+            )
+        except Exception:  # noqa: BLE001
+            # Fallback for Oracle / PostgreSQL: DELETE then INSERT
+            conn.execute(
+                f"DELETE FROM {table} WHERE suite_name = :suite_name",
+                {"suite_name": suite_name},
+            )
+            conn.execute(
+                f"INSERT INTO {table}"
+                " (suite_name, pass_rate, avg_quality_score,"
+                "  avg_error_rate, sample_size, updated_at)"
+                " VALUES (:suite_name, :pass_rate, :avg_quality_score,"
+                "         :avg_error_rate, :sample_size, :updated_at)",
+                params,
+            )
+        conn.commit()
+    finally:
+        adapter.disconnect()
+
+    return baseline_record
+
+
+def _get_baseline_db(suite_name: str) -> Optional[dict[str, Any]]:
+    """Fetch a single baseline row from the CM3_BASELINES table.
+
+    Args:
+        suite_name: Suite name to look up (primary key).
+
+    Returns:
+        Baseline dict, or ``None`` when the row does not exist.
+
+    Raises:
+        Exception: Propagates any DB exception so the caller can apply the
+            JSON fallback.
+    """
+    from src.database.adapters.factory import get_database_adapter
+
+    adapter = get_database_adapter()
+    adapter.connect()
+    try:
+        conn = adapter._connection  # type: ignore[attr-defined]
+        _ensure_baselines_table(conn)
+
+        prefix = _get_schema_prefix()
+        table = f"{prefix}CM3_BASELINES"
+
+        cursor = conn.execute(
+            f"SELECT suite_name, pass_rate, avg_quality_score,"
+            f"       avg_error_rate, sample_size, updated_at"
+            f" FROM {table}"
+            f" WHERE suite_name = :suite_name",
+            {"suite_name": suite_name},
+        )
+        row = cursor.fetchone()
+    finally:
+        adapter.disconnect()
+
+    if row is None:
+        return None
+
+    # Support both sqlite3.Row (dict-like) and plain tuple
+    try:
+        return {
+            "suite_name": row["suite_name"],
+            "pass_rate": row["pass_rate"],
+            "avg_quality_score": row["avg_quality_score"],
+            "avg_error_rate": row["avg_error_rate"],
+            "sample_size": row["sample_size"],
+            "updated_at": row["updated_at"],
+        }
+    except TypeError:
+        cols = [
+            "suite_name", "pass_rate", "avg_quality_score",
+            "avg_error_rate", "sample_size", "updated_at",
+        ]
+        return dict(zip(cols, row))
+
+
+def _list_baselines_db() -> list[dict[str, Any]]:
+    """Return all baseline rows from CM3_BASELINES sorted by suite_name.
+
+    Returns:
+        List of baseline dicts sorted alphabetically by ``suite_name``.
+        Empty list when the table is empty.
+
+    Raises:
+        Exception: Propagates any DB exception so the caller can apply the
+            JSON fallback.
+    """
+    from src.database.adapters.factory import get_database_adapter
+
+    adapter = get_database_adapter()
+    adapter.connect()
+    try:
+        conn = adapter._connection  # type: ignore[attr-defined]
+        _ensure_baselines_table(conn)
+
+        prefix = _get_schema_prefix()
+        table = f"{prefix}CM3_BASELINES"
+
+        cursor = conn.execute(
+            f"SELECT suite_name, pass_rate, avg_quality_score,"
+            f"       avg_error_rate, sample_size, updated_at"
+            f" FROM {table}"
+            f" ORDER BY suite_name"
+        )
+        rows = cursor.fetchall()
+    finally:
+        adapter.disconnect()
+
+    results = []
+    for row in rows:
+        try:
+            results.append({
+                "suite_name": row["suite_name"],
+                "pass_rate": row["pass_rate"],
+                "avg_quality_score": row["avg_quality_score"],
+                "avg_error_rate": row["avg_error_rate"],
+                "sample_size": row["sample_size"],
+                "updated_at": row["updated_at"],
+            })
+        except TypeError:
+            cols = [
+                "suite_name", "pass_rate", "avg_quality_score",
+                "avg_error_rate", "sample_size", "updated_at",
+            ]
+            results.append(dict(zip(cols, row)))
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -154,6 +409,10 @@ def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
     the history at :data:`_ROLLING_WINDOW` entries (oldest dropped first),
     recomputes all averages, persists the updated store, and returns the
     new baseline dict.
+
+    When ``DB_ADAPTER`` is set in the environment, the function first attempts
+    to delegate to :func:`_update_baseline_db`.  On any DB exception the JSON
+    path is used as fallback (warning logged, no exception propagated).
 
     Args:
         suite_name: Logical name of the test suite (e.g. ``"ATOCTRAN"``).
@@ -170,6 +429,12 @@ def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
         Updated baseline dict with keys: suite_name, pass_rate,
         avg_quality_score, avg_error_rate, sample_size, updated_at.
     """
+    if os.getenv("DB_ADAPTER"):
+        try:
+            return _update_baseline_db(suite_name, result)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DB baseline update failed, using JSON: %s", exc)
+
     path = _BASELINES_PATH
 
     store = _load_store(path)
@@ -207,6 +472,10 @@ def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
 def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
     """Return the stored baseline for *suite_name*, or ``None`` if absent.
 
+    When ``DB_ADAPTER`` is set in the environment, the database is queried
+    first via :func:`_get_baseline_db`.  On any DB exception the JSON file
+    is used as fallback (warning logged).
+
     Args:
         suite_name: Name of the suite to look up.
 
@@ -215,6 +484,12 @@ def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
         avg_error_rate, sample_size, updated_at; or ``None`` if no baseline
         has been recorded for this suite yet.
     """
+    if os.getenv("DB_ADAPTER"):
+        try:
+            return _get_baseline_db(suite_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DB baseline get failed, using JSON: %s", exc)
+
     path = _BASELINES_PATH
     store = _load_store(path)
     record = store.get(suite_name)
@@ -226,10 +501,20 @@ def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
 def list_baselines() -> list[dict[str, Any]]:
     """Return all stored baselines sorted alphabetically by suite name.
 
+    When ``DB_ADAPTER`` is set in the environment, the database is queried
+    first via :func:`_list_baselines_db`.  On any DB exception the JSON file
+    is used as fallback (warning logged).
+
     Returns:
         List of baseline dicts (see :func:`get_baseline`), sorted by
         ``suite_name``.  Returns an empty list when no baselines exist.
     """
+    if os.getenv("DB_ADAPTER"):
+        try:
+            return _list_baselines_db()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DB baseline list failed, using JSON: %s", exc)
+
     path = _BASELINES_PATH
     store = _load_store(path)
     baselines = [

--- a/src/services/deviation_detector.py
+++ b/src/services/deviation_detector.py
@@ -1,0 +1,112 @@
+"""Statistical deviation detector — compares a run result against its suite baseline."""
+from __future__ import annotations
+
+from typing import Optional
+
+
+DEFAULT_THRESHOLDS = {
+    'pass_rate_drop': 10.0,    # percentage points
+    'quality_drop': 5.0,       # percentage points
+    'error_rate_spike': 20.0,  # percentage points
+}
+
+
+def check_deviation(
+    suite_name: str,
+    result: dict,
+    thresholds: Optional[dict] = None,
+) -> dict:
+    """Compare a completed run against the stored suite baseline.
+
+    Fetches the baseline for *suite_name* via ``baseline_service.get_baseline``
+    and checks whether any of the three tracked metrics has moved beyond its
+    configured threshold.
+
+    Args:
+        suite_name: Name of the suite to check.
+        result: Run result dict with keys: passed, total_rows, invalid_rows,
+            quality_score.
+        thresholds: Override thresholds dict. Recognised keys:
+            ``pass_rate_drop``, ``quality_drop``, ``error_rate_spike``.
+            Defaults to ``DEFAULT_THRESHOLDS`` when ``None``.
+
+    Returns:
+        A dict with two guaranteed keys:
+
+        - ``deviated`` (bool): True when at least one alert was raised.
+        - ``alerts`` (list[dict]): One entry per breached threshold.
+          Each alert contains: ``metric``, ``baseline_value``,
+          ``current_value``, ``delta``, ``threshold``.
+
+        When no baseline exists the dict also carries
+        ``reason: 'no_baseline'`` and ``deviated`` is always ``False``.
+
+    Raises:
+        Nothing — all arithmetic edge cases (zero rows, missing keys) are
+        handled gracefully.
+    """
+    from src.services.baseline_service import get_baseline
+
+    baseline = get_baseline(suite_name)
+    if baseline is None:
+        return {'deviated': False, 'alerts': [], 'reason': 'no_baseline'}
+
+    effective = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
+    alerts: list[dict] = []
+
+    # Derive current metrics from the result dict
+    total = result.get('total_rows') or 0
+    passed = bool(result.get('passed'))
+    invalid = result.get('invalid_rows') or 0
+    quality = result.get('quality_score')
+
+    # pass_rate: percentage of rows that are valid
+    # When total_rows is available use arithmetic; fall back to the boolean flag.
+    current_pass_rate = (
+        (1 - invalid / total) * 100 if total else (100.0 if passed else 0.0)
+    )
+    current_error_rate = (invalid / total * 100) if total else 0.0
+
+    # --- pass_rate drop check -------------------------------------------
+    bl_pass_rate = baseline.get('pass_rate')
+    if bl_pass_rate is not None:
+        delta = current_pass_rate - bl_pass_rate
+        if delta < -effective['pass_rate_drop']:
+            alerts.append({
+                'metric': 'pass_rate',
+                'baseline_value': bl_pass_rate,
+                'current_value': round(current_pass_rate, 2),
+                'delta': round(delta, 2),
+                'threshold': effective['pass_rate_drop'],
+            })
+
+    # --- quality_score drop check ----------------------------------------
+    bl_quality = baseline.get('avg_quality_score')
+    if bl_quality is not None and quality is not None:
+        delta = float(quality) - bl_quality
+        if delta < -effective['quality_drop']:
+            alerts.append({
+                'metric': 'quality_score',
+                'baseline_value': bl_quality,
+                'current_value': round(float(quality), 2),
+                'delta': round(delta, 2),
+                'threshold': effective['quality_drop'],
+            })
+
+    # --- error_rate spike check ------------------------------------------
+    bl_error_rate = baseline.get('avg_error_rate')
+    if bl_error_rate is not None:
+        delta = current_error_rate - bl_error_rate
+        if delta > effective['error_rate_spike']:
+            alerts.append({
+                'metric': 'error_rate',
+                'baseline_value': bl_error_rate,
+                'current_value': round(current_error_rate, 2),
+                'delta': round(delta, 2),
+                'threshold': effective['error_rate_spike'],
+            })
+
+    return {
+        'deviated': len(alerts) > 0,
+        'alerts': alerts,
+    }

--- a/src/services/drift_detector.py
+++ b/src/services/drift_detector.py
@@ -1,0 +1,171 @@
+"""Schema drift detector — detects when a file's layout differs from its mapping.
+
+Fixed-width files are sensitive to layout changes: an upstream producer adding
+or removing bytes causes all downstream field positions to silently shift.  This
+module implements a heuristic detector that samples the first 20 non-blank
+lines of a file and checks whether each field's declared start position begins
+with non-whitespace content.  When a field's expected start is consistently
+blank but a nearby position has non-blank content, a drift record is emitted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SAMPLE_SIZE = 20
+_MIN_SAMPLE_LINES = 3
+_LEADING_BLANK_THRESHOLD = 0.8   # >80% of lines have blank at expected start → suspect drift
+_CONTENT_RATIO_THRESHOLD = 0.5   # >50% of lines must have boundary-start to accept position
+_SEARCH_RADIUS = 15              # bytes left/right of expected position to scan
+_SEARCH_MAX_POS = 200            # upper bound for position scan
+_LARGE_OFFSET_THRESHOLD = 5     # offsets larger than this → severity='error'
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_fixed_width_drift(lines: list[str], mapping: dict[str, Any]) -> dict[str, Any]:
+    """Detect position/width drift in a fixed-width file.
+
+    Samples the first ``_SAMPLE_SIZE`` non-blank lines and checks whether each
+    field's declared byte position begins with non-whitespace.  When more than
+    80 % of sample lines have whitespace at the declared start byte and a
+    nearby position has a clear content boundary in more than 50 % of lines,
+    the field is reported as drifted.
+
+    Args:
+        lines: List of text lines from the file (newlines may be present but
+            are not stripped — callers may pass raw ``file.readlines()`` output).
+        mapping: Mapping dict with a ``'fields'`` list.  Each field entry must
+            have ``'name'`` and ``'length'`` keys.  ``'position'`` is a 1-indexed
+            byte offset; when absent, the field is skipped.
+
+    Returns:
+        On success::
+
+            {'drifted': bool, 'fields': list[dict]}
+
+        Each entry in ``fields`` has keys:
+            ``name``, ``expected_start`` (1-indexed), ``expected_length``,
+            ``actual_start`` (1-indexed), ``actual_length``, ``severity``
+            (``'warning'`` for offset <= 5, ``'error'`` for offset > 5).
+
+        On early exit::
+
+            {'drifted': False, 'fields': [], 'skipped': True, 'reason': str}
+
+        Possible ``reason`` values: ``'too_short'``, ``'no_fields'``.
+    """
+    sample = [line for line in lines if line.strip()][:_SAMPLE_SIZE]
+
+    if len(sample) < _MIN_SAMPLE_LINES:
+        return {"drifted": False, "fields": [], "skipped": True, "reason": "too_short"}
+
+    fields = mapping.get("fields", [])
+    if not fields:
+        return {"drifted": False, "fields": [], "skipped": True, "reason": "no_fields"}
+
+    drifted_fields: list[dict[str, Any]] = []
+
+    for field in fields:
+        name = field.get("name", "")
+        position = field.get("position")  # 1-indexed byte offset; may be absent
+        length = field.get("length", 0)
+
+        if not length:
+            continue
+
+        # When position is absent the field carries no positional information
+        # and cannot be drift-checked.
+        if position is None:
+            continue
+
+        begin = int(position) - 1  # convert to 0-indexed
+        length_int = int(length)
+
+        # Drift signal: count lines where the expected start byte is blank.
+        # A consistently blank start byte means content did not begin here.
+        leading_blank_count = sum(
+            1
+            for line in sample
+            if len(line) <= begin or not line[begin : begin + 1].strip()
+        )
+        leading_blank_ratio = leading_blank_count / len(sample)
+
+        if leading_blank_ratio > _LEADING_BLANK_THRESHOLD:
+            actual_begin = _find_actual_position(sample, begin, length_int)
+            if actual_begin is not None and actual_begin != begin:
+                offset = abs(actual_begin - begin)
+                severity = "error" if offset > _LARGE_OFFSET_THRESHOLD else "warning"
+                drifted_fields.append(
+                    {
+                        "name": name,
+                        "expected_start": int(position),       # 1-indexed
+                        "expected_length": length_int,
+                        "actual_start": actual_begin + 1,      # back to 1-indexed
+                        "actual_length": length_int,
+                        "severity": severity,
+                    }
+                )
+
+    return {
+        "drifted": len(drifted_fields) > 0,
+        "fields": drifted_fields,
+    }
+
+
+def _find_actual_position(
+    sample: list[str],
+    expected_begin: int,
+    length: int,
+) -> Optional[int]:
+    """Scan nearby byte positions to find where content actually begins.
+
+    Uses a "boundary-start" heuristic: a position scores a point for each
+    sample line where that byte is non-whitespace AND the preceding byte is
+    whitespace (or it is position 0).  This identifies where a field's content
+    starts rather than where it merely overlaps.
+
+    Searches within ``_SEARCH_RADIUS`` bytes on either side of ``expected_begin``
+    (excluding ``expected_begin`` itself) for the position whose boundary-start
+    score exceeds 50 % of sample lines.
+
+    Args:
+        sample: Non-blank lines to inspect (already filtered).
+        expected_begin: 0-indexed byte offset that is known to be mostly blank.
+        length: Field byte length (used only to bound the line-length check).
+
+    Returns:
+        The 0-indexed byte offset of the best candidate position, or ``None``
+        when no candidate exceeds the 50 % boundary-start threshold.
+    """
+    low = max(0, expected_begin - _SEARCH_RADIUS)
+    high = min(_SEARCH_MAX_POS, expected_begin + _SEARCH_RADIUS)
+
+    best_pos: Optional[int] = None
+    best_score = 0
+
+    for pos in range(low, high):
+        if pos == expected_begin:
+            continue
+
+        boundary_start_count = sum(
+            1
+            for line in sample
+            if len(line) >= pos + 1
+            and line[pos : pos + 1].strip()                   # current byte is non-blank
+            and (pos == 0 or not line[pos - 1 : pos].strip()) # preceding byte is blank (or start)
+        )
+
+        if boundary_start_count > best_score:
+            best_score = boundary_start_count
+            best_pos = pos
+
+    threshold = len(sample) * _CONTENT_RATIO_THRESHOLD
+    return best_pos if best_score > threshold else None

--- a/src/services/run_history_service.py
+++ b/src/services/run_history_service.py
@@ -1,7 +1,38 @@
 """Service layer for persisting run history to Oracle DB."""
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
 from typing import Any
+
+_RUN_HISTORY_PATH = Path("reports") / "run_history.json"
+
+
+def load_run_history() -> list[dict[str, Any]]:
+    """Load run history from Oracle DB or the JSON fallback file.
+
+    Tries the database path first when ``ORACLE_USER`` is set, then falls
+    back to reading ``reports/run_history.json``.  Returns all available
+    entries — callers are responsible for any time-window filtering.
+
+    Returns:
+        List of run history entry dicts, each containing at minimum:
+        ``run_id``, ``suite_name``, ``timestamp``, ``status``.
+        Returns an empty list if no data source is available.
+    """
+    if os.getenv("ORACLE_USER"):
+        try:
+            return fetch_history_from_db(limit=1000)
+        except Exception:
+            pass
+
+    if not _RUN_HISTORY_PATH.exists():
+        return []
+    try:
+        return json.loads(_RUN_HISTORY_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return []
 
 
 def write_run_to_db(

--- a/src/services/summary_service.py
+++ b/src/services/summary_service.py
@@ -1,0 +1,156 @@
+"""Per-suite summary aggregation for the dashboard cards."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from src.services.run_history_service import load_run_history
+
+# Number of days used for pass-rate and trend calculations.
+_WINDOW_30D = 30
+_WINDOW_7D = 7
+_WINDOW_14D = 14
+
+# Minimum percentage-point difference to classify a trend as up/down.
+_TREND_THRESHOLD = 2.0
+
+
+def _parse_timestamp(entry: dict) -> datetime:
+    """Extract a comparable datetime from a run history entry.
+
+    Tries the ``timestamp`` key (run_history.json format), then
+    ``run_date``, then ``run_timestamp`` as fallbacks.
+
+    Args:
+        entry: A run history entry dict.
+
+    Returns:
+        Parsed datetime, or ``datetime.min`` when no valid value found.
+    """
+    raw = entry.get("timestamp") or entry.get("run_date") or entry.get("run_timestamp") or ""
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            # Trim trailing 'Z' and microseconds for broad compatibility
+            return datetime.fromisoformat(raw[:19])
+        except (ValueError, TypeError):
+            pass
+    return datetime.min
+
+
+def _is_pass(entry: dict) -> bool:
+    """Return True when the run entry represents a PASS result.
+
+    Args:
+        entry: A run history entry dict.
+
+    Returns:
+        True if ``status`` == ``"PASS"``, False for FAIL or PARTIAL.
+    """
+    return entry.get("status") == "PASS"
+
+
+def _pass_rate(runs: list[dict]) -> Optional[float]:
+    """Calculate the pass rate for a list of runs.
+
+    Args:
+        runs: List of run history entry dicts.
+
+    Returns:
+        Pass rate as a percentage (0–100), or ``None`` if the list is empty.
+    """
+    if not runs:
+        return None
+    passes = sum(1 for r in runs if _is_pass(r))
+    return passes / len(runs) * 100
+
+
+def get_suite_summaries() -> list[dict]:
+    """Return per-suite summary objects for dashboard cards.
+
+    Reads the full run history (DB or JSON fallback), groups entries by
+    ``suite_name``, and produces one summary dict per suite.
+
+    Returns:
+        List of suite summary dicts sorted by ``last_run_at`` descending::
+
+            [
+                {
+                    "suite_name": str,
+                    "last_run_status": "PASS" | "FAIL",
+                    "last_run_at": str,          # ISO datetime string
+                    "pass_rate_30d": float,      # 0.0–100.0
+                    "avg_quality_score": float | None,
+                    "trend_direction": "up" | "down" | "flat",
+                },
+                ...
+            ]
+    """
+    history = load_run_history()
+    if not history:
+        return []
+
+    now = datetime.utcnow()
+    cutoff_30d = now - timedelta(days=_WINDOW_30D)
+    cutoff_7d = now - timedelta(days=_WINDOW_7D)
+    cutoff_14d = now - timedelta(days=_WINDOW_14D)
+
+    # Group entries by suite name.
+    suites: dict[str, list[dict]] = {}
+    for entry in history:
+        name = entry.get("suite_name") or entry.get("name") or "unknown"
+        suites.setdefault(name, []).append(entry)
+
+    results = []
+    for suite_name, runs in suites.items():
+        runs_sorted = sorted(runs, key=_parse_timestamp, reverse=True)
+        last_run = runs_sorted[0]
+
+        last_status = "PASS" if _is_pass(last_run) else "FAIL"
+        last_at = _parse_timestamp(last_run).isoformat()
+
+        # 30-day pass rate.
+        recent_30 = [r for r in runs if _parse_timestamp(r) >= cutoff_30d]
+        pass_30 = sum(1 for r in recent_30 if _is_pass(r))
+        pass_rate_30d = round(pass_30 / len(recent_30) * 100, 1) if recent_30 else 0.0
+
+        # Average quality score over the 30-day window.
+        scores = [
+            r["quality_score"]
+            for r in recent_30
+            if r.get("quality_score") is not None
+        ]
+        avg_quality: Optional[float] = round(sum(scores) / len(scores), 1) if scores else None
+
+        # Trend: compare last 7 days vs prior 7 days (days 8–14).
+        last_7 = [r for r in runs if _parse_timestamp(r) >= cutoff_7d]
+        prior_7 = [
+            r for r in runs if cutoff_14d <= _parse_timestamp(r) < cutoff_7d
+        ]
+
+        r_last = _pass_rate(last_7)
+        r_prior = _pass_rate(prior_7)
+
+        if r_last is None or r_prior is None:
+            trend = "flat"
+        elif r_last - r_prior > _TREND_THRESHOLD:
+            trend = "up"
+        elif r_prior - r_last > _TREND_THRESHOLD:
+            trend = "down"
+        else:
+            trend = "flat"
+
+        results.append(
+            {
+                "suite_name": suite_name,
+                "last_run_status": last_status,
+                "last_run_at": last_at,
+                "pass_rate_30d": pass_rate_30d,
+                "avg_quality_score": avg_quality,
+                "trend_direction": trend,
+            }
+        )
+
+    results.sort(key=lambda x: x["last_run_at"], reverse=True)
+    return results

--- a/src/services/trend_service.py
+++ b/src/services/trend_service.py
@@ -1,0 +1,223 @@
+"""Daily trend aggregation for run history — used by the trend API endpoint.
+
+Aggregates run history into daily buckets, returning pass/fail counts and
+average quality score per day. Supports both a JSON file path (default) and
+a database path when ``DB_ADAPTER`` environment variable is set.
+"""
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+# Top-level import allows tests to patch src.services.trend_service.get_database_adapter
+# and src.services.trend_service.get_db_config without needing to reach into sub-modules.
+try:
+    from src.database.adapters.factory import get_database_adapter
+    from src.config.db_config import get_db_config
+except ImportError:  # pragma: no cover
+    get_database_adapter = None  # type: ignore[assignment]
+    get_db_config = None  # type: ignore[assignment]
+
+VALID_DAYS = (7, 14, 30, 90)
+
+_RUN_HISTORY_PATH = Path("reports") / "run_history.json"
+
+
+def _load_history() -> list[dict]:
+    """Load run history entries from the JSON file.
+
+    Returns:
+        List of run history entry dicts. Returns an empty list if the file
+        does not exist or cannot be parsed.
+    """
+    if not _RUN_HISTORY_PATH.exists():
+        return []
+    try:
+        return json.loads(_RUN_HISTORY_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+
+def get_trend(suite: Optional[str] = None, days: int = 30) -> list[dict]:
+    """Return daily-aggregated run history buckets.
+
+    Tries the database path first when ``DB_ADAPTER`` is set, then falls back
+    to reading ``reports/run_history.json``.
+
+    Args:
+        suite: Filter to a specific suite name. ``None`` means all suites.
+        days: Number of days to look back. Must be one of ``(7, 14, 30, 90)``.
+
+    Returns:
+        List of daily bucket dicts sorted ascending by date::
+
+            [
+                {
+                    "date": "2026-03-30",
+                    "total_runs": 5,
+                    "pass_runs": 4,
+                    "fail_runs": 1,
+                    "avg_quality_score": 88.5,  # or None
+                    "pass_rate": 80.0,
+                }
+            ]
+
+    Raises:
+        ValueError: If ``days`` is not in :data:`VALID_DAYS`.
+    """
+    if days not in VALID_DAYS:
+        raise ValueError(f"days must be one of {VALID_DAYS}, got {days}")
+
+    db_adapter = os.getenv("DB_ADAPTER")
+    if db_adapter:
+        try:
+            return _get_trend_from_db(suite, days)
+        except Exception:
+            pass  # fall through to JSON
+
+    return _get_trend_from_json(suite, days)
+
+
+def _get_trend_from_json(suite: Optional[str], days: int) -> list[dict]:
+    """Aggregate run history from the JSON file into daily buckets.
+
+    Args:
+        suite: Optional suite name filter. ``None`` includes all suites.
+        days: Number of past days to include.
+
+    Returns:
+        List of daily bucket dicts sorted ascending by date.
+    """
+    history = _load_history()
+    cutoff = datetime.utcnow() - timedelta(days=days)
+
+    # bucket structure: date_key -> aggregation state
+    buckets: dict[str, dict] = defaultdict(lambda: {
+        "total_runs": 0,
+        "pass_runs": 0,
+        "fail_runs": 0,
+        "quality_scores": [],
+    })
+
+    for entry in history:
+        # Suite filter
+        if suite and entry.get("suite_name") != suite:
+            continue
+
+        # Parse timestamp — JSON entries use the "timestamp" key
+        raw_ts = entry.get("timestamp") or entry.get("run_timestamp") or entry.get("run_date") or ""
+        if isinstance(raw_ts, str):
+            try:
+                run_dt = datetime.fromisoformat(raw_ts[:19])
+            except (ValueError, TypeError):
+                continue
+        elif isinstance(raw_ts, datetime):
+            run_dt = raw_ts
+        else:
+            continue
+
+        if run_dt < cutoff:
+            continue
+
+        date_key = run_dt.strftime("%Y-%m-%d")
+        bucket = buckets[date_key]
+        bucket["total_runs"] += 1
+
+        status = entry.get("status", "")
+        if status == "PASS":
+            bucket["pass_runs"] += 1
+        else:
+            bucket["fail_runs"] += 1
+
+        qs = entry.get("quality_score")
+        if qs is not None:
+            bucket["quality_scores"].append(float(qs))
+
+    result = []
+    for date_key in sorted(buckets.keys()):
+        b = buckets[date_key]
+        scores = b.pop("quality_scores")
+        b["date"] = date_key
+        b["avg_quality_score"] = round(sum(scores) / len(scores), 2) if scores else None
+        b["pass_rate"] = round(b["pass_runs"] / b["total_runs"] * 100, 2) if b["total_runs"] else 0.0
+        result.append(b)
+
+    return result
+
+
+def _get_trend_from_db(suite: Optional[str], days: int) -> list[dict]:
+    """Aggregate run history from the configured database adapter.
+
+    Uses :func:`~src.database.adapters.factory.get_database_adapter` to
+    query the ``CM3_RUN_HISTORY`` table and aggregate results into daily
+    buckets via SQL GROUP BY.
+
+    Args:
+        suite: Optional suite name filter passed as a SQL bind parameter.
+        days: Number of past days to include (used to compute the cutoff).
+
+    Returns:
+        List of daily bucket dicts sorted ascending by date.
+
+    Raises:
+        Exception: Re-raises any exception from the adapter so that
+            :func:`get_trend` can fall back to the JSON path.
+    """
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    schema = get_db_config().schema
+    table = f"{schema}.CM3_RUN_HISTORY"
+
+    suite_filter = "AND suite_name = :suite" if suite else ""
+    sql = f"""
+        SELECT
+            CAST(run_timestamp AS DATE) AS run_date,
+            COUNT(*) AS total_runs,
+            SUM(CASE WHEN status = 'PASS' THEN 1 ELSE 0 END) AS pass_runs,
+            SUM(CASE WHEN status != 'PASS' THEN 1 ELSE 0 END) AS fail_runs,
+            AVG(quality_score) AS avg_quality_score
+        FROM {table}
+        WHERE run_timestamp >= :cutoff
+        {suite_filter}
+        GROUP BY CAST(run_timestamp AS DATE)
+        ORDER BY CAST(run_timestamp AS DATE)
+    """
+
+    params: dict = {"cutoff": cutoff}
+    if suite:
+        params["suite"] = suite
+
+    adapter = get_database_adapter()
+    with adapter:
+        df = adapter.execute_query(sql, params)
+
+    if df is None or df.empty:
+        return []
+
+    result = []
+    for _, row in df.iterrows():
+        total = int(row["total_runs"] or 0)
+        pass_r = int(row["pass_runs"] or 0)
+        fail_r = int(row["fail_runs"] or 0)
+        qs_raw = row.get("avg_quality_score") if hasattr(row, "get") else row["avg_quality_score"]
+        avg_qs: Optional[float] = round(float(qs_raw), 2) if qs_raw is not None else None
+
+        run_date = row["run_date"]
+        if isinstance(run_date, datetime):
+            date_str = run_date.strftime("%Y-%m-%d")
+        else:
+            date_str = str(run_date)[:10]
+
+        result.append({
+            "date": date_str,
+            "total_runs": total,
+            "pass_runs": pass_r,
+            "fail_runs": fail_r,
+            "avg_quality_score": avg_qs,
+            "pass_rate": round(pass_r / total * 100, 2) if total else 0.0,
+        })
+
+    return result

--- a/tests/unit/test_api_summaries.py
+++ b/tests/unit/test_api_summaries.py
@@ -1,0 +1,118 @@
+"""Unit tests for GET /api/v1/runs/summaries endpoint.
+
+Tests cover:
+- 200 response with list of summary dicts (mocked service)
+- No auth → 401 when API_KEYS is configured
+- Invalid key → 403
+- Empty result → 200 with []
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+
+# Ensure a test API key is always available for auth-required tests.
+_api_keys = os.getenv("API_KEYS", "")
+if "dev-key" not in {k.split(":", 1)[0].strip() for k in _api_keys.split(",") if k.strip()}:
+    os.environ["API_KEYS"] = f"{_api_keys},dev-key:admin" if _api_keys else "dev-key:admin"
+
+client = TestClient(app)
+API_HEADERS = {"X-API-Key": "dev-key"}
+
+_SAMPLE_SUMMARIES = [
+    {
+        "suite_name": "E2E Smoke",
+        "last_run_status": "PASS",
+        "last_run_at": "2026-03-30T12:00:00",
+        "pass_rate_30d": 90.0,
+        "avg_quality_score": 95.0,
+        "trend_direction": "up",
+    }
+]
+
+
+def test_summaries_returns_200_with_list():
+    with patch(
+        "src.api.routers.runs.summary_service.get_suite_summaries",
+        return_value=_SAMPLE_SUMMARIES,
+    ):
+        r = client.get("/api/v1/runs/summaries", headers=API_HEADERS)
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["suite_name"] == "E2E Smoke"
+    assert payload[0]["last_run_status"] == "PASS"
+    assert payload[0]["trend_direction"] == "up"
+
+
+def test_summaries_returns_empty_list_when_no_history():
+    with patch(
+        "src.api.routers.runs.summary_service.get_suite_summaries",
+        return_value=[],
+    ):
+        r = client.get("/api/v1/runs/summaries", headers=API_HEADERS)
+
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_summaries_requires_auth_missing_key():
+    """When API_KEYS is set and no key is provided, expect 401."""
+    with patch(
+        "src.api.routers.runs.summary_service.get_suite_summaries",
+        return_value=_SAMPLE_SUMMARIES,
+    ):
+        r = client.get("/api/v1/runs/summaries")  # no headers
+
+    # With API_KEYS configured and no referer from /ui, expect 401
+    assert r.status_code == 401
+
+
+def test_summaries_requires_auth_invalid_key():
+    """Invalid key should return 403."""
+    with patch(
+        "src.api.routers.runs.summary_service.get_suite_summaries",
+        return_value=_SAMPLE_SUMMARIES,
+    ):
+        r = client.get(
+            "/api/v1/runs/summaries",
+            headers={"X-API-Key": "totally-wrong-key"},
+        )
+
+    assert r.status_code == 403
+
+
+def test_summaries_response_contains_expected_fields():
+    summaries = [
+        {
+            "suite_name": "Regression",
+            "last_run_status": "FAIL",
+            "last_run_at": "2026-03-29T08:00:00",
+            "pass_rate_30d": 75.0,
+            "avg_quality_score": None,
+            "trend_direction": "down",
+        }
+    ]
+    with patch(
+        "src.api.routers.runs.summary_service.get_suite_summaries",
+        return_value=summaries,
+    ):
+        r = client.get("/api/v1/runs/summaries", headers=API_HEADERS)
+
+    assert r.status_code == 200
+    item = r.json()[0]
+    required_keys = {
+        "suite_name",
+        "last_run_status",
+        "last_run_at",
+        "pass_rate_30d",
+        "avg_quality_score",
+        "trend_direction",
+    }
+    assert required_keys.issubset(set(item.keys()))

--- a/tests/unit/test_baseline_service.py
+++ b/tests/unit/test_baseline_service.py
@@ -1,0 +1,512 @@
+"""Unit tests for baseline_service.py — TDD: written before implementation.
+
+Tests cover:
+- First-run baseline creation (sample_size=1)
+- Second-run rolling average recalculation (sample_size=2)
+- Rolling window capped at 10 runs (11 runs → sample_size=10)
+- get_baseline returns None for unknown suite
+- list_baselines returns all suites sorted alphabetically
+- Round-trip JSON serialization via tmp_path fixture
+- Missing quality_score in result → avg_quality_score stays None
+- total_rows=0 → avg_error_rate=0.0
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    pass_count: int = 8,
+    total_count: int = 10,
+    invalid_rows: int = 1,
+    total_rows: int = 100,
+    quality_score: float | None = 90.0,
+) -> dict:
+    """Build a minimal result dict matching the run_history entry shape."""
+    result = {
+        "pass_count": pass_count,
+        "total_count": total_count,
+        "invalid_rows": invalid_rows,
+        "total_rows": total_rows,
+    }
+    if quality_score is not None:
+        result["quality_score"] = quality_score
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_baseline
+# ---------------------------------------------------------------------------
+
+class TestUpdateBaseline:
+    """Tests for update_baseline()."""
+
+    def test_first_run_creates_baseline_with_sample_size_1(self, tmp_path: Path):
+        """First call creates a baseline with sample_size=1."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = _make_result(pass_count=8, total_count=10, quality_score=90.0)
+            baseline = update_baseline("SUITE_A", result)
+
+        assert baseline["suite_name"] == "SUITE_A"
+        assert baseline["sample_size"] == 1
+        assert baseline["pass_rate"] == pytest.approx(80.0)
+        assert baseline["avg_quality_score"] == pytest.approx(90.0)
+        assert "updated_at" in baseline
+
+    def test_second_run_recalculates_averages_with_sample_size_2(
+        self, tmp_path: Path
+    ):
+        """Second call recalculates averages from 2 runs."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(pass_count=8, total_count=10, quality_score=80.0))
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(pass_count=6, total_count=10, quality_score=90.0),
+            )
+
+        assert baseline["sample_size"] == 2
+        # pass_rate: (80 + 60) / 2 = 70.0
+        assert baseline["pass_rate"] == pytest.approx(70.0)
+        # avg_quality_score: (80 + 90) / 2 = 85.0
+        assert baseline["avg_quality_score"] == pytest.approx(85.0)
+
+    def test_rolling_window_capped_at_10_after_11_runs(self, tmp_path: Path):
+        """After 11 runs the rolling window holds exactly 10; sample_size=10."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            for i in range(11):
+                baseline = update_baseline(
+                    "SUITE_A",
+                    _make_result(pass_count=i, total_count=10, quality_score=float(i * 10)),
+                )
+
+        assert baseline["sample_size"] == 10
+
+    def test_avg_error_rate_computed_from_invalid_and_total_rows(
+        self, tmp_path: Path
+    ):
+        """avg_error_rate = invalid_rows / total_rows * 100."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(invalid_rows=5, total_rows=200),
+            )
+
+        assert baseline["avg_error_rate"] == pytest.approx(2.5)
+
+    def test_total_rows_zero_gives_error_rate_zero(self, tmp_path: Path):
+        """total_rows=0 avoids division by zero and yields avg_error_rate=0.0."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(invalid_rows=3, total_rows=0),
+            )
+
+        assert baseline["avg_error_rate"] == pytest.approx(0.0)
+
+    def test_missing_quality_score_yields_avg_quality_score_none(
+        self, tmp_path: Path
+    ):
+        """When quality_score is absent from result, avg_quality_score is None."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            baseline = update_baseline(
+                "SUITE_A",
+                _make_result(quality_score=None),
+            )
+
+        assert baseline["avg_quality_score"] is None
+
+    def test_mixed_quality_score_presence_averages_available_values(
+        self, tmp_path: Path
+    ):
+        """When some runs lack quality_score, average computed from runs that have it."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(quality_score=80.0))
+            baseline = update_baseline("SUITE_A", _make_result(quality_score=None))
+
+        # Only 1 run had a score (80.0), so average is 80.0
+        assert baseline["avg_quality_score"] == pytest.approx(80.0)
+
+    def test_returns_updated_baseline_dict(self, tmp_path: Path):
+        """update_baseline returns the updated baseline dict."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = update_baseline("SUITE_A", _make_result())
+
+        assert isinstance(result, dict)
+        assert result["suite_name"] == "SUITE_A"
+
+    def test_multiple_suites_stored_independently(self, tmp_path: Path):
+        """Baselines for different suites do not interfere with each other."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(pass_count=10, total_count=10))
+            update_baseline("SUITE_B", _make_result(pass_count=5, total_count=10))
+            a = update_baseline("SUITE_A", _make_result(pass_count=10, total_count=10))
+            b = update_baseline("SUITE_B", _make_result(pass_count=5, total_count=10))
+
+        assert a["pass_rate"] == pytest.approx(100.0)
+        assert b["pass_rate"] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_baseline
+# ---------------------------------------------------------------------------
+
+class TestGetBaseline:
+    """Tests for get_baseline()."""
+
+    def test_returns_none_for_unknown_suite(self, tmp_path: Path):
+        """get_baseline returns None when no baseline exists for the suite."""
+        from src.services.baseline_service import get_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = get_baseline("UNKNOWN_SUITE")
+
+        assert result is None
+
+    def test_returns_none_when_file_does_not_exist(self, tmp_path: Path):
+        """get_baseline returns None when baselines.json does not exist."""
+        from src.services.baseline_service import get_baseline
+
+        storage = tmp_path / "nonexistent.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = get_baseline("SUITE_A")
+
+        assert result is None
+
+    def test_returns_baseline_after_update(self, tmp_path: Path):
+        """get_baseline retrieves a baseline previously written by update_baseline."""
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(quality_score=75.0))
+            result = get_baseline("SUITE_A")
+
+        assert result is not None
+        assert result["suite_name"] == "SUITE_A"
+        assert result["avg_quality_score"] == pytest.approx(75.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: list_baselines
+# ---------------------------------------------------------------------------
+
+class TestListBaselines:
+    """Tests for list_baselines()."""
+
+    def test_returns_empty_list_when_no_file(self, tmp_path: Path):
+        """list_baselines returns [] when baselines.json does not exist."""
+        from src.services.baseline_service import list_baselines
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            result = list_baselines()
+
+        assert result == []
+
+    def test_returns_all_suites_sorted_alphabetically(self, tmp_path: Path):
+        """list_baselines sorts results alphabetically by suite_name."""
+        from src.services.baseline_service import list_baselines, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("ZEBRA", _make_result())
+            update_baseline("ALPHA", _make_result())
+            update_baseline("MONKEY", _make_result())
+            result = list_baselines()
+
+        names = [b["suite_name"] for b in result]
+        assert names == ["ALPHA", "MONKEY", "ZEBRA"]
+
+    def test_returns_list_of_dicts(self, tmp_path: Path):
+        """list_baselines returns a list of baseline dicts."""
+        from src.services.baseline_service import list_baselines, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+            result = list_baselines()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+
+
+# ---------------------------------------------------------------------------
+# Tests: round-trip JSON serialization
+# ---------------------------------------------------------------------------
+
+class TestJsonRoundTrip:
+    """Tests for JSON file persistence."""
+
+    def test_written_file_is_valid_json(self, tmp_path: Path):
+        """update_baseline writes valid JSON to disk."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+
+        assert storage.exists()
+        data = json.loads(storage.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+
+    def test_baseline_survives_file_reload(self, tmp_path: Path):
+        """Baseline persists after re-reading the storage file from disk."""
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result(quality_score=88.0))
+            # Re-read from disk by calling get_baseline with the same patch
+            result = get_baseline("SUITE_A")
+
+        assert result is not None
+        assert result["avg_quality_score"] == pytest.approx(88.0)
+
+    def test_file_created_on_first_write(self, tmp_path: Path):
+        """baselines.json is created if it does not exist yet."""
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        assert not storage.exists()
+
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+
+        assert storage.exists()
+
+    def test_baseline_record_has_required_fields(self, tmp_path: Path):
+        """Stored baseline contains all required schema fields."""
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with patch("src.services.baseline_service._BASELINES_PATH", storage):
+            update_baseline("SUITE_A", _make_result())
+            baseline = get_baseline("SUITE_A")
+
+        required_keys = {
+            "suite_name",
+            "pass_rate",
+            "avg_quality_score",
+            "avg_error_rate",
+            "sample_size",
+            "updated_at",
+        }
+        assert required_keys.issubset(set(baseline.keys()))
+
+
+# ---------------------------------------------------------------------------
+# Tests: DB path
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBaselineDbPath:
+    """Tests for the DB path in update_baseline, get_baseline, list_baselines."""
+
+    def test_update_baseline_calls_db_upsert_when_db_adapter_set(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB_ADAPTER is set, update_baseline delegates to _update_baseline_db."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        from src.services import baseline_service
+
+        storage = tmp_path / "baselines.json"
+        mock_baseline = {
+            "suite_name": "SUITE_A",
+            "pass_rate": 80.0,
+            "avg_quality_score": 90.0,
+            "avg_error_rate": 1.0,
+            "sample_size": 1,
+            "updated_at": "2026-03-31T00:00:00",
+        }
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(
+                baseline_service, "_update_baseline_db", return_value=mock_baseline
+            ) as mock_db,
+        ):
+            result = baseline_service.update_baseline("SUITE_A", _make_result())
+
+        mock_db.assert_called_once_with("SUITE_A", _make_result())
+        assert result == mock_baseline
+
+    def test_update_baseline_falls_back_to_json_when_db_raises(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB path raises, update_baseline falls back to JSON silently."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        from src.services import baseline_service
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(
+                baseline_service, "_update_baseline_db", side_effect=RuntimeError("db down")
+            ),
+        ):
+            result = baseline_service.update_baseline("SUITE_A", _make_result())
+
+        # JSON fallback must succeed and return a valid baseline
+        assert result["suite_name"] == "SUITE_A"
+        assert result["sample_size"] == 1
+
+    def test_get_baseline_calls_db_path_when_db_adapter_set(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB_ADAPTER is set, get_baseline delegates to _get_baseline_db."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        from src.services import baseline_service
+
+        mock_baseline = {
+            "suite_name": "SUITE_A",
+            "pass_rate": 75.0,
+            "avg_quality_score": None,
+            "avg_error_rate": 0.0,
+            "sample_size": 3,
+            "updated_at": "2026-03-31T00:00:00",
+        }
+        storage = tmp_path / "baselines.json"
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(
+                baseline_service, "_get_baseline_db", return_value=mock_baseline
+            ) as mock_db,
+        ):
+            result = baseline_service.get_baseline("SUITE_A")
+
+        mock_db.assert_called_once_with("SUITE_A")
+        assert result == mock_baseline
+
+    def test_get_baseline_falls_back_to_json_when_db_raises(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB path raises, get_baseline falls back to JSON."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        from src.services import baseline_service
+
+        storage = tmp_path / "baselines.json"
+        # Pre-populate JSON so the fallback has something to return
+        storage.write_text(
+            '{"SUITE_A": {"baseline": {"suite_name": "SUITE_A", "pass_rate": 50.0,'
+            ' "avg_quality_score": null, "avg_error_rate": 0.0, "sample_size": 1,'
+            ' "updated_at": "2026-01-01T00:00:00"}, "history": []}}',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(
+                baseline_service, "_get_baseline_db", side_effect=RuntimeError("db down")
+            ),
+        ):
+            result = baseline_service.get_baseline("SUITE_A")
+
+        assert result is not None
+        assert result["suite_name"] == "SUITE_A"
+
+    def test_list_baselines_calls_db_path_when_db_adapter_set(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB_ADAPTER is set, list_baselines delegates to _list_baselines_db."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        from src.services import baseline_service
+
+        mock_list = [
+            {"suite_name": "A", "pass_rate": 90.0, "avg_quality_score": None,
+             "avg_error_rate": 0.0, "sample_size": 2, "updated_at": "2026-03-31T00:00:00"},
+        ]
+        storage = tmp_path / "baselines.json"
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(
+                baseline_service, "_list_baselines_db", return_value=mock_list
+            ) as mock_db,
+        ):
+            result = baseline_service.list_baselines()
+
+        mock_db.assert_called_once_with()
+        assert result == mock_list
+
+    def test_list_baselines_falls_back_to_json_when_db_raises(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB path raises, list_baselines falls back to JSON."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        from src.services import baseline_service
+
+        storage = tmp_path / "baselines.json"
+        storage.write_text(
+            '{"SUITE_A": {"baseline": {"suite_name": "SUITE_A", "pass_rate": 50.0,'
+            ' "avg_quality_score": null, "avg_error_rate": 0.0, "sample_size": 1,'
+            ' "updated_at": "2026-01-01T00:00:00"}, "history": []}}',
+            encoding="utf-8",
+        )
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(
+                baseline_service, "_list_baselines_db", side_effect=RuntimeError("db down")
+            ),
+        ):
+            result = baseline_service.list_baselines()
+
+        assert len(result) == 1
+        assert result[0]["suite_name"] == "SUITE_A"
+
+    def test_update_baseline_skips_db_when_db_adapter_not_set(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """When DB_ADAPTER is not set, update_baseline uses JSON only."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+
+        from src.services import baseline_service
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch.object(baseline_service, "_BASELINES_PATH", storage),
+            patch.object(baseline_service, "_update_baseline_db") as mock_db,
+        ):
+            result = baseline_service.update_baseline("SUITE_A", _make_result())
+
+        mock_db.assert_not_called()
+        assert result["suite_name"] == "SUITE_A"

--- a/tests/unit/test_baseline_wiring.py
+++ b/tests/unit/test_baseline_wiring.py
@@ -1,0 +1,188 @@
+"""Tests verifying update_baseline is wired into run_suite_from_path (#246).
+
+Covers:
+- After a suite run, update_baseline is called with the correct suite_name.
+- When update_baseline raises, the suite run still succeeds (warning logged).
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_SUITE_YAML = textwrap.dedent("""\
+    name: Wiring Suite
+    environment: test
+    tests:
+      - name: Structural Check
+        type: structural
+        file: {file_path}
+        mapping: {mapping_path}
+""")
+
+
+def _write_suite(tmp_path: Path) -> tuple[Path, Path]:
+    """Write a minimal suite YAML and dummy data/mapping files.
+
+    Returns:
+        Tuple of (suite_path, output_dir).
+    """
+    data_file = tmp_path / "data.dat"
+    data_file.write_text("HELLO\n", encoding="utf-8")
+
+    mapping_file = tmp_path / "mapping.json"
+    mapping_file.write_text(
+        '{"record_type": "delimited", "delimiter": "|", "fields": []}',
+        encoding="utf-8",
+    )
+
+    suite_file = tmp_path / "suite.yaml"
+    suite_file.write_text(
+        MINIMAL_SUITE_YAML.format(
+            file_path=str(data_file),
+            mapping_path=str(mapping_file),
+        )
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    return suite_file, output_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineWiredIntoRunSuiteFromPath:
+    """update_baseline is called after a suite run completes."""
+
+    def test_update_baseline_called_with_correct_suite_name(self, tmp_path: Path):
+        """run_suite_from_path calls update_baseline(suite_name, result_summary)."""
+        suite_file, output_dir = _write_suite(tmp_path)
+
+        mock_svc_result = {
+            "total_rows": 10,
+            "error_count": 0,
+            "warning_count": 0,
+        }
+
+        with (
+            patch(
+                "src.services.validate_service.run_validate_service",
+                return_value=mock_svc_result,
+            ),
+            patch(
+                "src.commands.run_tests_command._append_run_history"
+            ) as mock_history,
+            patch(
+                "src.commands.run_tests_command.update_baseline"
+            ) as mock_baseline,
+            patch(
+                "src.utils.archive.ArchiveManager.archive_run",
+                return_value=tmp_path / "archive",
+            ),
+        ):
+            from src.commands.run_tests_command import run_suite_from_path
+
+            results = run_suite_from_path(
+                suite_path=str(suite_file),
+                params={},
+                env="test",
+                output_dir=str(output_dir),
+            )
+
+        mock_baseline.assert_called_once()
+        args, kwargs = mock_baseline.call_args
+        assert args[0] == "Wiring Suite"
+        assert isinstance(args[1], dict)
+
+    def test_update_baseline_raises_suite_run_still_succeeds(self, tmp_path: Path):
+        """When update_baseline raises, run_suite_from_path returns results normally."""
+        suite_file, output_dir = _write_suite(tmp_path)
+
+        mock_svc_result = {
+            "total_rows": 5,
+            "error_count": 1,
+            "warning_count": 0,
+        }
+
+        with (
+            patch(
+                "src.services.validate_service.run_validate_service",
+                return_value=mock_svc_result,
+            ),
+            patch("src.commands.run_tests_command._append_run_history"),
+            patch(
+                "src.commands.run_tests_command.update_baseline",
+                side_effect=RuntimeError("baseline exploded"),
+            ),
+            patch(
+                "src.utils.archive.ArchiveManager.archive_run",
+                return_value=tmp_path / "archive",
+            ),
+        ):
+            from src.commands.run_tests_command import run_suite_from_path
+
+            results = run_suite_from_path(
+                suite_path=str(suite_file),
+                params={},
+                env="test",
+                output_dir=str(output_dir),
+            )
+
+        # Suite run must have returned results despite baseline failure
+        assert isinstance(results, list)
+        assert len(results) == 1
+
+    def test_update_baseline_receives_result_dict_with_counts(self, tmp_path: Path):
+        """The result dict passed to update_baseline contains pass_count / total_count."""
+        suite_file, output_dir = _write_suite(tmp_path)
+
+        mock_svc_result = {
+            "total_rows": 20,
+            "error_count": 2,
+            "warning_count": 0,
+        }
+
+        captured_args: list = []
+
+        def _capture_baseline(suite_name, result):
+            captured_args.append((suite_name, result))
+
+        with (
+            patch(
+                "src.services.validate_service.run_validate_service",
+                return_value=mock_svc_result,
+            ),
+            patch("src.commands.run_tests_command._append_run_history"),
+            patch(
+                "src.commands.run_tests_command.update_baseline",
+                side_effect=_capture_baseline,
+            ),
+            patch(
+                "src.utils.archive.ArchiveManager.archive_run",
+                return_value=tmp_path / "archive",
+            ),
+        ):
+            from src.commands.run_tests_command import run_suite_from_path
+
+            run_suite_from_path(
+                suite_path=str(suite_file),
+                params={},
+                env="test",
+                output_dir=str(output_dir),
+            )
+
+        assert len(captured_args) == 1
+        suite_name, result_dict = captured_args[0]
+        assert suite_name == "Wiring Suite"
+        # Must contain aggregate counts so baseline_service can compute pass_rate
+        assert "pass_count" in result_dict
+        assert "total_count" in result_dict

--- a/tests/unit/test_deviation_detector.py
+++ b/tests/unit/test_deviation_detector.py
@@ -1,0 +1,258 @@
+"""Unit tests for src/services/deviation_detector.py — check_deviation()."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+MODULE = "src.services.baseline_service.get_baseline"
+
+
+def _make_result(
+    passed: bool = True,
+    total_rows: int = 100,
+    invalid_rows: int = 0,
+    quality_score: float = 95.0,
+) -> dict:
+    """Helper to build a minimal run result dict."""
+    return {
+        "passed": passed,
+        "total_rows": total_rows,
+        "invalid_rows": invalid_rows,
+        "quality_score": quality_score,
+    }
+
+
+def _baseline(
+    pass_rate: float = 90.0,
+    avg_quality_score: float = 90.0,
+    avg_error_rate: float = 5.0,
+) -> dict:
+    """Helper to build a minimal baseline dict."""
+    return {
+        "pass_rate": pass_rate,
+        "avg_quality_score": avg_quality_score,
+        "avg_error_rate": avg_error_rate,
+    }
+
+
+# ---------------------------------------------------------------------------
+# No baseline
+# ---------------------------------------------------------------------------
+
+def test_no_baseline_returns_no_deviation():
+    """When get_baseline returns None, result should indicate no_baseline."""
+    with patch(MODULE, return_value=None):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("my_suite", _make_result())
+
+    assert result["deviated"] is False
+    assert result["alerts"] == []
+    assert result["reason"] == "no_baseline"
+
+
+# ---------------------------------------------------------------------------
+# pass_rate checks
+# ---------------------------------------------------------------------------
+
+def test_pass_rate_drop_exceeds_threshold():
+    """Pass rate drop of 15pp (> default 10pp threshold) triggers an alert."""
+    # baseline pass_rate=90, current invalid=25/100 → pass_rate=75 → delta=-15
+    with patch(MODULE, return_value=_baseline(pass_rate=90.0)):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("my_suite", _make_result(total_rows=100, invalid_rows=25))
+
+    assert result["deviated"] is True
+    assert len(result["alerts"]) == 1
+    alert = result["alerts"][0]
+    assert alert["metric"] == "pass_rate"
+    assert alert["baseline_value"] == 90.0
+    assert alert["current_value"] == 75.0
+    assert alert["delta"] == -15.0
+    assert alert["threshold"] == 10.0
+
+
+def test_pass_rate_drop_within_threshold():
+    """Pass rate drop of 5pp (≤ default 10pp threshold) does NOT trigger alert."""
+    # baseline pass_rate=90, current invalid=5/100 → pass_rate=95 → delta=+5 (improvement)
+    # Use invalid_rows=15 → pass_rate=85 → delta=-5 which is within threshold
+    with patch(MODULE, return_value=_baseline(pass_rate=90.0)):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("my_suite", _make_result(total_rows=100, invalid_rows=15))
+
+    assert result["deviated"] is False
+    assert result["alerts"] == []
+
+
+# ---------------------------------------------------------------------------
+# quality_score checks
+# ---------------------------------------------------------------------------
+
+def test_quality_drop_exceeds_threshold():
+    """Quality score drop of 10pp (> default 5pp threshold) triggers an alert."""
+    baseline = _baseline(avg_quality_score=90.0)
+    result_data = _make_result(quality_score=78.0)  # delta = -12
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_q", result_data)
+
+    quality_alerts = [a for a in result["alerts"] if a["metric"] == "quality_score"]
+    assert len(quality_alerts) == 1
+    alert = quality_alerts[0]
+    assert alert["baseline_value"] == 90.0
+    assert alert["current_value"] == 78.0
+    assert alert["delta"] == -12.0
+    assert alert["threshold"] == 5.0
+
+
+def test_both_pass_rate_and_quality_drop():
+    """Two metrics deviating produces two separate alerts."""
+    baseline = _baseline(pass_rate=90.0, avg_quality_score=90.0, avg_error_rate=5.0)
+    # pass_rate drops 15pp, quality drops 12pp, error_rate unchanged
+    result_data = {
+        "passed": False,
+        "total_rows": 100,
+        "invalid_rows": 25,   # pass_rate=75, delta=-15
+        "quality_score": 78.0,  # delta=-12
+    }
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_both", result_data)
+
+    assert result["deviated"] is True
+    metrics = {a["metric"] for a in result["alerts"]}
+    assert metrics == {"pass_rate", "quality_score"}
+    assert len(result["alerts"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# error_rate checks
+# ---------------------------------------------------------------------------
+
+def test_all_three_metrics_deviated():
+    """All three metrics deviating produces three alerts."""
+    baseline = _baseline(pass_rate=90.0, avg_quality_score=90.0, avg_error_rate=5.0)
+    # pass_rate=75 (drop 15), quality=78 (drop 12), error_rate=25 (spike +20 → delta=20, > threshold 20 → NOT triggered)
+    # Use error_rate spike of 30 (> 20 threshold): invalid_rows=55/100 → error_rate=55, delta=50
+    result_data = {
+        "passed": False,
+        "total_rows": 100,
+        "invalid_rows": 55,   # pass_rate=45 (drop 45), error_rate=55 (spike 50)
+        "quality_score": 78.0,  # quality drop 12
+    }
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_all", result_data)
+
+    assert result["deviated"] is True
+    metrics = {a["metric"] for a in result["alerts"]}
+    assert metrics == {"pass_rate", "quality_score", "error_rate"}
+    assert len(result["alerts"]) == 3
+
+
+def test_error_rate_spike_exactly_at_threshold_not_triggered():
+    """Error rate spike equal to threshold does NOT trigger (strict > check)."""
+    # baseline error_rate=5, current error_rate=25 → delta=20, threshold=20 → NOT triggered
+    baseline = _baseline(pass_rate=100.0, avg_quality_score=95.0, avg_error_rate=5.0)
+    result_data = _make_result(total_rows=100, invalid_rows=25, quality_score=95.0)  # error_rate=25
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_at_threshold", result_data)
+
+    error_alerts = [a for a in result["alerts"] if a["metric"] == "error_rate"]
+    assert error_alerts == []
+
+
+# ---------------------------------------------------------------------------
+# Custom thresholds
+# ---------------------------------------------------------------------------
+
+def test_custom_thresholds_override_defaults():
+    """Custom thresholds dict overrides DEFAULT_THRESHOLDS values."""
+    # With default threshold=10, a 5pp drop would NOT trigger.
+    # With custom threshold=3, a 5pp drop SHOULD trigger.
+    baseline = _baseline(pass_rate=90.0)
+    result_data = _make_result(total_rows=100, invalid_rows=15)  # pass_rate=85, delta=-5
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_custom", result_data, thresholds={"pass_rate_drop": 3.0})
+
+    assert result["deviated"] is True
+    pass_alerts = [a for a in result["alerts"] if a["metric"] == "pass_rate"]
+    assert len(pass_alerts) == 1
+    assert pass_alerts[0]["threshold"] == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_missing_quality_score_skips_quality_check():
+    """Result without quality_score key does not raise and skips quality alert."""
+    baseline = _baseline(avg_quality_score=90.0)
+    result_data = {"passed": True, "total_rows": 100, "invalid_rows": 0}  # no quality_score
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_no_quality", result_data)
+
+    quality_alerts = [a for a in result["alerts"] if a["metric"] == "quality_score"]
+    assert quality_alerts == []
+
+
+def test_total_rows_zero_no_crash():
+    """total_rows=0 should not cause a ZeroDivisionError and returns no deviation."""
+    baseline = _baseline(pass_rate=90.0, avg_error_rate=5.0)
+    result_data = {"passed": True, "total_rows": 0, "invalid_rows": 0, "quality_score": 95.0}
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_zero_rows", result_data)
+
+    # With total_rows=0 and passed=True, pass_rate=100. baseline=90 → no drop.
+    assert isinstance(result, dict)
+    assert "deviated" in result
+    assert result["deviated"] is False
+
+
+def test_return_shape_contains_deviated_and_alerts():
+    """Result always contains 'deviated' (bool) and 'alerts' (list) keys."""
+    with patch(MODULE, return_value=_baseline()):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_shape", _make_result())
+
+    assert isinstance(result["deviated"], bool)
+    assert isinstance(result["alerts"], list)
+
+
+def test_alert_contains_required_keys():
+    """Each alert dict has metric, baseline_value, current_value, delta, threshold."""
+    baseline = _baseline(pass_rate=90.0)
+    result_data = _make_result(total_rows=100, invalid_rows=25)  # pass_rate=75, drop=15
+
+    with patch(MODULE, return_value=baseline):
+        from src.services.deviation_detector import check_deviation
+
+        result = check_deviation("suite_keys", result_data)
+
+    assert result["deviated"] is True
+    alert = result["alerts"][0]
+    for key in ("metric", "baseline_value", "current_value", "delta", "threshold"):
+        assert key in alert, f"Alert missing key: {key}"

--- a/tests/unit/test_drift_detector_fixed_width.py
+++ b/tests/unit/test_drift_detector_fixed_width.py
@@ -1,0 +1,302 @@
+"""Unit tests for src/services/drift_detector.py — fixed-width drift detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.drift_detector import _detect_fixed_width_drift, _find_actual_position
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build fixed-width test lines
+# ---------------------------------------------------------------------------
+
+def _make_line(fields: list[tuple[int, str]], total_width: int = 40) -> str:
+    """Build a fixed-width line by placing field values at given 0-indexed positions.
+
+    Args:
+        fields: List of (start_0idx, value) tuples.
+        total_width: Total line width (padded with spaces).
+
+    Returns:
+        A string of exactly total_width characters.
+    """
+    buf = list(" " * total_width)
+    for start, value in fields:
+        for i, ch in enumerate(value):
+            if start + i < total_width:
+                buf[start + i] = ch
+    return "".join(buf)
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+def _mapping(*field_defs: tuple[str, int, int]) -> dict:
+    """Build a minimal mapping dict for fixed-width drift detection.
+
+    Args:
+        field_defs: Tuples of (name, position_1indexed, length).
+
+    Returns:
+        Mapping dict with 'fields' list.
+    """
+    return {
+        "fields": [
+            {"name": name, "position": pos, "length": length}
+            for name, pos, length in field_defs
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# _detect_fixed_width_drift — happy-path (no drift)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFixedWidthDriftClean:
+    """File content matches the mapping exactly — no drift expected."""
+
+    def test_clean_file_returns_drifted_false(self):
+        # Field A: position 1 (0-idx 0), length 5
+        # Field B: position 6 (0-idx 5), length 4
+        lines = [
+            _make_line([(0, "HELLO"), (5, "WXYZ")]) for _ in range(5)
+        ]
+        mapping = _mapping(("FIELD_A", 1, 5), ("FIELD_B", 6, 4))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is False
+        assert result["fields"] == []
+        assert "skipped" not in result
+
+    def test_clean_file_with_numeric_content(self):
+        # Field at position 1 (0-idx 0), length 8 filled with digits
+        lines = [
+            _make_line([(0, "12345678")]) for _ in range(6)
+        ]
+        mapping = _mapping(("AMOUNT", 1, 8))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is False
+
+    def test_more_than_20_lines_only_samples_first_20(self):
+        """25 matching lines → drifted=False (only first 20 sampled)."""
+        lines = [_make_line([(0, "HELLO")]) for _ in range(25)]
+        mapping = _mapping(("FIELD_A", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_fixed_width_drift — drift detected (shift left / right)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFixedWidthDriftShifted:
+    """Content is systematically shifted vs. expected positions."""
+
+    def test_shift_right_by_2_detected(self):
+        """Field expected at position 1 (0-idx 0) but content starts at 0-idx 2."""
+        # Field A: mapping says position=1, length=5.
+        # Actual data is at 0-idx 2 (shifted right by 2).
+        lines = [
+            _make_line([(2, "HELLO")]) for _ in range(5)
+        ]
+        mapping = _mapping(("FIELD_A", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is True
+        assert len(result["fields"]) >= 1
+        field = result["fields"][0]
+        assert field["name"] == "FIELD_A"
+        assert field["expected_start"] == 1  # 1-indexed as passed in
+        assert field["actual_start"] != 1    # shifted
+
+    def test_shift_right_by_6_is_error_severity(self):
+        """Offset > 5 bytes → severity='error'."""
+        # Field at position 1 (0-idx 0), length 5, but data at 0-idx 7 (offset=7).
+        lines = [
+            _make_line([(7, "HELLO")]) for _ in range(5)
+        ]
+        mapping = _mapping(("BIG_SHIFT", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is True
+        drifted_field = result["fields"][0]
+        assert drifted_field["severity"] == "error"
+
+    def test_shift_right_by_3_is_warning_severity(self):
+        """Offset <= 5 bytes → severity='warning'."""
+        # Field at position 1 (0-idx 0), length 5, but data at 0-idx 3 (offset=3).
+        lines = [
+            _make_line([(3, "HELLO")]) for _ in range(5)
+        ]
+        mapping = _mapping(("SMALL_SHIFT", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is True
+        drifted_field = result["fields"][0]
+        assert drifted_field["severity"] == "warning"
+
+    def test_drifted_field_carries_expected_and_actual_start(self):
+        """Result dict carries expected_start (1-indexed) and actual_start (1-indexed)."""
+        lines = [
+            _make_line([(4, "HELLO")]) for _ in range(5)
+        ]
+        mapping = _mapping(("F", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is True
+        f = result["fields"][0]
+        assert "expected_start" in f
+        assert "actual_start" in f
+        assert "expected_length" in f
+        assert "actual_length" in f
+
+    def test_multiple_fields_both_shifted_detects_both(self):
+        """Two fields, both shifted — both appear in drifted_fields."""
+        # FIELD_A: mapping pos=1 (0-idx 0), length=5 — data at 0-idx 2
+        # FIELD_B: mapping pos=11 (0-idx 10), length=4 — data at 0-idx 13
+        lines = [
+            _make_line([(2, "HELLO"), (13, "WXYZ")]) for _ in range(5)
+        ]
+        mapping = _mapping(("FIELD_A", 1, 5), ("FIELD_B", 11, 4))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is True
+        names = [f["name"] for f in result["fields"]]
+        assert "FIELD_A" in names
+        assert "FIELD_B" in names
+
+    def test_only_one_field_shifted(self):
+        """First field matches, second field is shifted — only second flagged."""
+        # FIELD_A at pos=1 (0-idx 0), length=5 — correct
+        # FIELD_B at pos=8 (0-idx 7), length=4 — data actually at 0-idx 13
+        lines = [
+            _make_line([(0, "HELLO"), (13, "WXYZ")]) for _ in range(5)
+        ]
+        mapping = _mapping(("FIELD_A", 1, 5), ("FIELD_B", 8, 4))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        names = [f["name"] for f in result["fields"]]
+        assert "FIELD_A" not in names
+        assert "FIELD_B" in names
+
+
+# ---------------------------------------------------------------------------
+# _detect_fixed_width_drift — edge / skip cases
+# ---------------------------------------------------------------------------
+
+
+class TestDetectFixedWidthDriftSkip:
+    """Inputs that trigger early-exit skip conditions."""
+
+    def test_empty_lines_returns_skipped(self):
+        mapping = _mapping(("FIELD_A", 1, 5))
+        result = _detect_fixed_width_drift([], mapping)
+
+        assert result["drifted"] is False
+        assert result["skipped"] is True
+        assert result["reason"] == "too_short"
+
+    def test_fewer_than_3_non_empty_lines_returns_skipped(self):
+        lines = ["HELLO" + " " * 15, "WORLD" + " " * 15]
+        mapping = _mapping(("FIELD_A", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is False
+        assert result["skipped"] is True
+        assert result["reason"] == "too_short"
+
+    def test_exactly_3_non_empty_lines_does_not_skip(self):
+        lines = [_make_line([(0, "HELLO")]) for _ in range(3)]
+        mapping = _mapping(("FIELD_A", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert "skipped" not in result
+
+    def test_blank_lines_ignored_when_counting_sample(self):
+        """Blank lines must be excluded from the 3-line minimum check."""
+        blank_lines = ["   ", "", "  "]
+        content_lines = [_make_line([(0, "HELLO")]) for _ in range(3)]
+        lines = blank_lines + content_lines
+        mapping = _mapping(("FIELD_A", 1, 5))
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert "skipped" not in result
+
+    def test_no_fields_in_mapping_returns_skipped(self):
+        lines = [_make_line([(0, "HELLO")]) for _ in range(5)]
+        result = _detect_fixed_width_drift(lines, {"fields": []})
+
+        assert result["drifted"] is False
+        assert result["skipped"] is True
+        assert result["reason"] == "no_fields"
+
+    def test_missing_fields_key_returns_skipped(self):
+        lines = [_make_line([(0, "HELLO")]) for _ in range(5)]
+        result = _detect_fixed_width_drift(lines, {})
+
+        assert result["drifted"] is False
+        assert result["skipped"] is True
+        assert result["reason"] == "no_fields"
+
+    def test_field_with_zero_length_is_skipped(self):
+        """A field with length=0 should be silently ignored (no crash)."""
+        lines = [_make_line([(0, "HELLO")]) for _ in range(5)]
+        mapping = {"fields": [{"name": "BAD", "position": 1, "length": 0}]}
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is False
+
+    def test_field_without_position_key_is_skipped(self):
+        """A field with no 'position' key cannot be drift-checked and is skipped silently."""
+        lines = [_make_line([(0, "HELLO")]) for _ in range(5)]
+        # Omit 'position' entirely — delimited-format fields have no byte offset
+        mapping = {"fields": [{"name": "COL_A", "length": 5}]}
+        result = _detect_fixed_width_drift(lines, mapping)
+
+        assert result["drifted"] is False
+        assert result["fields"] == []
+
+
+# ---------------------------------------------------------------------------
+# _find_actual_position
+# ---------------------------------------------------------------------------
+
+
+class TestFindActualPosition:
+    """Unit tests for the internal position-scanning helper."""
+
+    def test_finds_correct_offset_position(self):
+        """Content consistently at 0-idx 5 — should return 5."""
+        sample = [_make_line([(5, "HELLO")]) for _ in range(6)]
+        pos = _find_actual_position(sample, expected_begin=0, length=5)
+
+        assert pos == 5
+
+    def test_returns_none_when_no_clear_winner(self):
+        """All-whitespace lines — no clear non-blank position found."""
+        sample = [" " * 30 for _ in range(6)]
+        pos = _find_actual_position(sample, expected_begin=0, length=5)
+
+        assert pos is None
+
+    def test_returns_none_when_best_score_below_50_percent(self):
+        """Only 2 of 6 lines have content — below 50% threshold."""
+        sample = [_make_line([(5, "HELLO")]) if i < 2 else " " * 30 for i in range(6)]
+        pos = _find_actual_position(sample, expected_begin=0, length=5)
+
+        assert pos is None
+
+    def test_ignores_expected_begin_position(self):
+        """expected_begin itself must not be returned (it was already blank)."""
+        # Content at 0 and at 5; expected_begin=5 is excluded from search
+        sample = [_make_line([(0, "HELLO")]) for _ in range(6)]
+        pos = _find_actual_position(sample, expected_begin=5, length=5)
+
+        # Should find position 0, not 5 (which is excluded)
+        assert pos == 0

--- a/tests/unit/test_summary_service.py
+++ b/tests/unit/test_summary_service.py
@@ -1,0 +1,269 @@
+"""Unit tests for src/services/summary_service.py.
+
+Tests cover:
+- 3 suites in history → 3 summary objects, sorted by last_run_at desc
+- Trend direction: up when recent pass rate > prior; down when lower; flat within 2%
+- Empty history → []
+- Single run → trend='flat', pass_rate_30d correct
+- Pass/FAIL/PARTIAL status detection using 'status' field
+- quality_score averaging
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from src.services.summary_service import get_suite_summaries
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(
+    suite_name: str = "MySuite",
+    timestamp: str = "2026-03-30T12:00:00",
+    status: str = "PASS",
+    quality_score: float | None = None,
+) -> dict:
+    """Return a run_history.json-shaped entry dict.
+
+    Args:
+        suite_name: Name of the suite.
+        timestamp: ISO datetime string.
+        status: Run status — PASS, FAIL, or PARTIAL.
+        quality_score: Optional quality score float.
+
+    Returns:
+        Dict matching run_history.json entry schema.
+    """
+    entry: dict = {
+        "run_id": "test-id",
+        "suite_name": suite_name,
+        "environment": "test",
+        "timestamp": timestamp,
+        "status": status,
+        "pass_count": 1 if status == "PASS" else 0,
+        "fail_count": 0 if status == "PASS" else 1,
+        "total_count": 1,
+    }
+    if quality_score is not None:
+        entry["quality_score"] = quality_score
+    return entry
+
+
+def _ts(days_ago: int) -> str:
+    """Return ISO timestamp string for N days ago from 2026-03-31."""
+    base = datetime(2026, 3, 31, 12, 0, 0)
+    return (base - timedelta(days=days_ago)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Empty history
+# ---------------------------------------------------------------------------
+
+def test_empty_history_returns_empty_list():
+    with patch("src.services.summary_service.load_run_history", return_value=[]):
+        result = get_suite_summaries()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Single run
+# ---------------------------------------------------------------------------
+
+def test_single_run_returns_one_summary():
+    history = [_make_entry("Alpha", _ts(1), "PASS")]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+    assert len(result) == 1
+    s = result[0]
+    assert s["suite_name"] == "Alpha"
+    assert s["last_run_status"] == "PASS"
+    assert s["pass_rate_30d"] == 100.0
+    assert s["trend_direction"] == "flat"
+
+
+def test_single_run_fail_status():
+    history = [_make_entry("Beta", _ts(1), "FAIL")]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+    assert result[0]["last_run_status"] == "FAIL"
+    assert result[0]["pass_rate_30d"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Three suites — basic grouping and sort order
+# ---------------------------------------------------------------------------
+
+def test_three_suites_returns_three_summaries():
+    history = [
+        _make_entry("Alpha", _ts(1), "PASS"),
+        _make_entry("Beta", _ts(2), "FAIL"),
+        _make_entry("Gamma", _ts(3), "PASS"),
+    ]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert len(result) == 3
+    suite_names = [r["suite_name"] for r in result]
+    assert "Alpha" in suite_names
+    assert "Beta" in suite_names
+    assert "Gamma" in suite_names
+
+
+def test_summaries_sorted_by_last_run_at_descending():
+    history = [
+        _make_entry("Alpha", _ts(3), "PASS"),
+        _make_entry("Beta", _ts(1), "PASS"),   # most recent
+        _make_entry("Gamma", _ts(5), "PASS"),
+    ]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    # Beta ran 1 day ago — should be first
+    assert result[0]["suite_name"] == "Beta"
+    assert result[1]["suite_name"] == "Alpha"
+    assert result[2]["suite_name"] == "Gamma"
+
+
+# ---------------------------------------------------------------------------
+# pass_rate_30d calculation
+# ---------------------------------------------------------------------------
+
+def test_pass_rate_30d_with_mixed_results():
+    # 2 passes, 2 fails within 30 days → 50%
+    history = [
+        _make_entry("Suite", _ts(1), "PASS"),
+        _make_entry("Suite", _ts(5), "PASS"),
+        _make_entry("Suite", _ts(10), "FAIL"),
+        _make_entry("Suite", _ts(20), "FAIL"),
+    ]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["pass_rate_30d"] == 50.0
+
+
+def test_runs_older_than_30d_excluded_from_pass_rate():
+    # Only the old run is a pass; recent runs are all fails
+    history = [
+        _make_entry("Suite", _ts(1), "FAIL"),
+        _make_entry("Suite", _ts(35), "PASS"),  # outside 30d window
+    ]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    # Only the recent FAIL counts for 30d pass rate
+    assert result[0]["pass_rate_30d"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Trend direction
+# ---------------------------------------------------------------------------
+
+def test_trend_up_when_recent_pass_rate_higher():
+    # Last 7 days: 5 passes → 100%
+    # Prior 7 days (days 8-14): 0 passes out of 5 → 0%
+    history = (
+        [_make_entry("Suite", _ts(i), "PASS") for i in range(1, 6)]
+        + [_make_entry("Suite", _ts(i), "FAIL") for i in range(8, 13)]
+    )
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["trend_direction"] == "up"
+
+
+def test_trend_down_when_recent_pass_rate_lower():
+    # Last 7 days: all fail → 0%
+    # Prior 7 days: all pass → 100%
+    history = (
+        [_make_entry("Suite", _ts(i), "FAIL") for i in range(1, 6)]
+        + [_make_entry("Suite", _ts(i), "PASS") for i in range(8, 13)]
+    )
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["trend_direction"] == "down"
+
+
+def test_trend_flat_when_rates_within_2_percent():
+    # Both windows: 1 pass out of 2 → 50%
+    history = [
+        _make_entry("Suite", _ts(1), "PASS"),
+        _make_entry("Suite", _ts(3), "FAIL"),
+        _make_entry("Suite", _ts(8), "PASS"),
+        _make_entry("Suite", _ts(10), "FAIL"),
+    ]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["trend_direction"] == "flat"
+
+
+def test_trend_flat_when_no_prior_data():
+    # Only last 7 days, nothing in days 8-14
+    history = [_make_entry("Suite", _ts(2), "PASS")]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["trend_direction"] == "flat"
+
+
+# ---------------------------------------------------------------------------
+# Quality score averaging
+# ---------------------------------------------------------------------------
+
+def test_avg_quality_score_computed_correctly():
+    history = [
+        _make_entry("Suite", _ts(1), "PASS", quality_score=90.0),
+        _make_entry("Suite", _ts(5), "PASS", quality_score=80.0),
+    ]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["avg_quality_score"] == 85.0
+
+
+def test_avg_quality_score_none_when_no_scores():
+    history = [_make_entry("Suite", _ts(1), "PASS")]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["avg_quality_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# PARTIAL status treated as FAIL
+# ---------------------------------------------------------------------------
+
+def test_partial_status_treated_as_fail():
+    history = [_make_entry("Suite", _ts(1), "PARTIAL")]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    assert result[0]["last_run_status"] == "FAIL"
+    assert result[0]["pass_rate_30d"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Required keys in every summary object
+# ---------------------------------------------------------------------------
+
+def test_summary_has_all_required_keys():
+    history = [_make_entry("Suite", _ts(1), "PASS")]
+    with patch("src.services.summary_service.load_run_history", return_value=history):
+        result = get_suite_summaries()
+
+    required_keys = {
+        "suite_name",
+        "last_run_status",
+        "last_run_at",
+        "pass_rate_30d",
+        "avg_quality_score",
+        "trend_direction",
+    }
+    assert required_keys.issubset(set(result[0].keys()))

--- a/tests/unit/test_trend_service.py
+++ b/tests/unit/test_trend_service.py
@@ -1,0 +1,372 @@
+"""Unit tests for src/services/trend_service.py.
+
+Tests cover:
+- JSON path: bucketing, suite filter, date window, all-fail, empty history
+- ValueError for invalid days argument
+- DB path: adapter called, results mapped to bucket dicts
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.services.trend_service import VALID_DAYS, get_trend
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CUTOFF_DAYS = 30
+# Use a fixed reference date well within any 30-day window so tests are
+# deterministic regardless of when they run (2026-03-31 is "today" in the
+# project, so 2026-03-15 is comfortably inside a 30-day window).
+_RECENT_DATE = "2026-03-30"
+_OLD_DATE = "2026-01-01"   # always outside any supported window
+
+
+def _make_entry(
+    suite_name: str = "MySuite",
+    date_str: str = _RECENT_DATE,
+    status: str = "PASS",
+    quality_score: float | None = None,
+) -> dict:
+    """Return a run_history.json-shaped dict with an explicit UTC date.
+
+    Args:
+        suite_name: Suite name for the entry.
+        date_str: ISO date string (YYYY-MM-DD) for the run timestamp.
+        status: Run status — ``"PASS"``, ``"FAIL"``, or ``"PARTIAL"``.
+        quality_score: Optional quality score value.
+
+    Returns:
+        A dict matching the run_history.json entry schema.
+    """
+    entry = {
+        "run_id": "test-id",
+        "suite_name": suite_name,
+        "environment": "test",
+        "timestamp": f"{date_str}T12:00:00.000000Z",
+        "status": status,
+        "pass_count": 1 if status == "PASS" else 0,
+        "fail_count": 0 if status == "PASS" else 1,
+        "total_count": 1,
+    }
+    if quality_score is not None:
+        entry["quality_score"] = quality_score
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# JSON path tests
+# ---------------------------------------------------------------------------
+
+class TestGetTrendFromJson:
+    """Tests for _get_trend_from_json via get_trend (no DB_ADAPTER set)."""
+
+    def test_three_entries_on_different_days_produce_three_buckets(self, monkeypatch):
+        """3 entries on distinct days → 3 sorted buckets with correct counts."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-28", status="PASS"),
+            _make_entry(date_str="2026-03-29", status="FAIL"),
+            _make_entry(date_str="2026-03-30", status="PASS"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 3
+        # Sorted ascending by date
+        dates = [b["date"] for b in result]
+        assert dates == sorted(dates)
+        # Spot-check first bucket (oldest)
+        assert result[0]["date"] == "2026-03-28"
+        assert result[0]["total_runs"] == 1
+        assert result[0]["pass_runs"] == 1
+        assert result[0]["fail_runs"] == 0
+        # Second bucket
+        assert result[1]["pass_runs"] == 0
+        assert result[1]["fail_runs"] == 1
+
+    def test_suite_filter_returns_only_matching_entries(self, monkeypatch):
+        """suite='Alpha' filters out entries for other suites."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(suite_name="Alpha", date_str="2026-03-30", status="PASS"),
+            _make_entry(suite_name="Beta",  date_str="2026-03-30", status="PASS"),
+            _make_entry(suite_name="Alpha", date_str="2026-03-29", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(suite="Alpha", days=30)
+
+        total = sum(b["total_runs"] for b in result)
+        assert total == 2  # Only Alpha entries counted
+
+    def test_30_day_window_excludes_older_entries(self, monkeypatch):
+        """Entries older than the requested window are excluded."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-15", status="PASS"),   # inside 30-day window
+            _make_entry(date_str=_OLD_DATE,    status="PASS"),   # outside
+            _make_entry(date_str="2026-01-15", status="FAIL"),   # outside
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        total = sum(b["total_runs"] for b in result)
+        assert total == 1
+
+    def test_all_fail_runs_produces_pass_rate_zero(self, monkeypatch):
+        """When all runs fail, pass_rate is 0.0 and pass_runs is 0."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        bucket = result[0]
+        assert bucket["pass_runs"] == 0
+        assert bucket["fail_runs"] == 2
+        assert bucket["pass_rate"] == 0.0
+
+    def test_empty_history_returns_empty_list(self, monkeypatch):
+        """Empty run history produces an empty result list."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        with patch("src.services.trend_service._load_history", return_value=[]):
+            result = get_trend(days=30)
+
+        assert result == []
+
+    def test_pass_rate_calculated_correctly(self, monkeypatch):
+        """pass_rate = pass_runs / total_runs * 100, rounded to 2 dp."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        # 1 pass, 1 fail on same day → 50.0%
+        history = [
+            _make_entry(date_str="2026-03-30", status="PASS"),
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["pass_rate"] == 50.0
+
+    def test_quality_score_averaged_per_bucket(self, monkeypatch):
+        """avg_quality_score is the mean of quality_score across bucket entries."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-30", status="PASS", quality_score=80.0),
+            _make_entry(date_str="2026-03-30", status="PASS", quality_score=90.0),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["avg_quality_score"] == 85.0
+
+    def test_missing_quality_score_produces_none(self, monkeypatch):
+        """avg_quality_score is None when no entries have a quality_score."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [_make_entry(date_str="2026-03-30", status="PASS")]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert result[0]["avg_quality_score"] is None
+
+    def test_multiple_entries_same_day_aggregated_into_one_bucket(self, monkeypatch):
+        """Multiple runs on the same day are merged into a single bucket."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [
+            _make_entry(date_str="2026-03-30", status="PASS"),
+            _make_entry(date_str="2026-03-30", status="PASS"),
+            _make_entry(date_str="2026-03-30", status="FAIL"),
+        ]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["total_runs"] == 3
+        assert result[0]["pass_runs"] == 2
+        assert result[0]["fail_runs"] == 1
+
+    def test_result_bucket_has_required_keys(self, monkeypatch):
+        """Each bucket dict contains all required keys."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        required_keys = {"date", "total_runs", "pass_runs", "fail_runs",
+                         "avg_quality_score", "pass_rate"}
+        history = [_make_entry(date_str="2026-03-30")]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert required_keys.issubset(result[0].keys())
+
+    def test_partial_status_counted_as_fail(self, monkeypatch):
+        """PARTIAL status (not PASS) is counted in fail_runs."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        history = [_make_entry(date_str="2026-03-30", status="PARTIAL")]
+        with patch("src.services.trend_service._load_history", return_value=history):
+            result = get_trend(days=30)
+
+        assert result[0]["fail_runs"] == 1
+        assert result[0]["pass_runs"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Invalid days argument
+# ---------------------------------------------------------------------------
+
+class TestGetTrendInvalidDays:
+    """Tests for ValueError on invalid days argument."""
+
+    @pytest.mark.parametrize("bad_days", [0, 1, 15, 29, 31, 60, 365, -7])
+    def test_invalid_days_raises_value_error(self, bad_days):
+        """days not in VALID_DAYS raises ValueError."""
+        with pytest.raises(ValueError, match="days must be one of"):
+            get_trend(days=bad_days)
+
+    @pytest.mark.parametrize("good_days", VALID_DAYS)
+    def test_valid_days_does_not_raise(self, good_days, monkeypatch):
+        """Valid days values do not raise ValueError."""
+        monkeypatch.delenv("DB_ADAPTER", raising=False)
+        with patch("src.services.trend_service._load_history", return_value=[]):
+            result = get_trend(days=good_days)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# DB path tests
+# ---------------------------------------------------------------------------
+
+class TestGetTrendFromDb:
+    """Tests for _get_trend_from_db via get_trend when DB_ADAPTER is set."""
+
+    def _make_mock_adapter(self, df: pd.DataFrame) -> MagicMock:
+        """Return a mock DatabaseAdapter that returns *df* from execute_query."""
+        mock_adapter = MagicMock()
+        mock_adapter.__enter__ = MagicMock(return_value=mock_adapter)
+        mock_adapter.__exit__ = MagicMock(return_value=False)
+        mock_adapter.execute_query = MagicMock(return_value=df)
+        return mock_adapter
+
+    def _single_row_df(
+        self,
+        date: datetime = datetime(2026, 3, 30),
+        total: int = 5,
+        pass_r: int = 4,
+        fail_r: int = 1,
+        avg_qs: float | None = 88.5,
+    ) -> pd.DataFrame:
+        """Return a single-row DataFrame matching the DB query result shape."""
+        return pd.DataFrame([{
+            "run_date": date,
+            "total_runs": total,
+            "pass_runs": pass_r,
+            "fail_runs": fail_r,
+            "avg_quality_score": avg_qs,
+        }])
+
+    def test_db_adapter_execute_query_is_called(self, monkeypatch):
+        """When DB_ADAPTER is set, get_database_adapter is imported and used."""
+        monkeypatch.setenv("DB_ADAPTER", "oracle")
+
+        mock_adapter = self._make_mock_adapter(self._single_row_df())
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        mock_adapter.execute_query.assert_called_once()
+        assert len(result) == 1
+
+    def test_db_result_mapped_to_bucket_dicts(self, monkeypatch):
+        """DB rows are correctly mapped to bucket dicts with all required fields."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        df = self._single_row_df(
+            date=datetime(2026, 3, 30), total=10, pass_r=8, fail_r=2, avg_qs=92.5
+        )
+        mock_adapter = self._make_mock_adapter(df)
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        assert len(result) == 1
+        bucket = result[0]
+        assert bucket["date"] == "2026-03-30"
+        assert bucket["total_runs"] == 10
+        assert bucket["pass_runs"] == 8
+        assert bucket["fail_runs"] == 2
+        assert bucket["avg_quality_score"] == 92.5
+        assert bucket["pass_rate"] == 80.0
+
+    def test_db_pass_rate_zero_when_no_runs(self, monkeypatch):
+        """pass_rate is 0.0 when total_runs is 0 (guard against ZeroDivisionError)."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        df = self._single_row_df(
+            date=datetime(2026, 3, 30), total=0, pass_r=0, fail_r=0, avg_qs=None
+        )
+        mock_adapter = self._make_mock_adapter(df)
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        assert result[0]["pass_rate"] == 0.0
+        assert result[0]["avg_quality_score"] is None
+
+    def test_db_suite_filter_passed_to_sql(self, monkeypatch):
+        """Suite name is forwarded as a SQL bind param when suite arg is provided."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        mock_adapter = self._make_mock_adapter(pd.DataFrame())
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                get_trend(suite="MySuite", days=7)
+
+        call_args = mock_adapter.execute_query.call_args
+        # Second positional arg is the params dict
+        params = call_args[0][1]
+        assert params.get("suite") == "MySuite"
+
+    def test_db_failure_falls_back_to_json(self, monkeypatch):
+        """When the DB adapter raises, get_trend falls back to the JSON path."""
+        monkeypatch.setenv("DB_ADAPTER", "oracle")
+
+        history = [_make_entry(date_str="2026-03-30", status="PASS")]
+
+        with patch(
+            "src.services.trend_service.get_database_adapter",
+            side_effect=RuntimeError("ORA-12170"),
+        ):
+            with patch("src.services.trend_service._load_history", return_value=history):
+                result = get_trend(days=30)
+
+        assert len(result) == 1
+        assert result[0]["total_runs"] == 1
+
+    def test_db_empty_result_returns_empty_list(self, monkeypatch):
+        """Empty DB result returns []."""
+        monkeypatch.setenv("DB_ADAPTER", "sqlite")
+
+        mock_adapter = self._make_mock_adapter(pd.DataFrame())
+
+        with patch("src.services.trend_service.get_database_adapter", return_value=mock_adapter):
+            with patch("src.services.trend_service.get_db_config") as mock_cfg:
+                mock_cfg.return_value.schema = "CM3INT"
+                result = get_trend(days=30)
+
+        assert result == []

--- a/tests/unit/test_web_ui.py
+++ b/tests/unit/test_web_ui.py
@@ -252,3 +252,118 @@ class TestTooltips:
         assert "All tests passed or were skipped" in html
         assert "One or more tests failed" in html
         assert "Some tests passed and some failed" in html
+
+
+# ---------------------------------------------------------------------------
+# vs Baseline column — issue #253
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineColumn:
+    """Tests for the 'vs Baseline' column and toggle in the Recent Runs table."""
+
+    def test_baseline_th_id_referenced_in_js(self):
+        """ui.js must reference 'thBaseline' as the column header id."""
+        html = _load_ui_html()
+        assert "thBaseline" in html, "thBaseline id reference is missing from ui.js"
+
+    def test_baseline_th_hidden_by_default(self):
+        """The baseline column header must start hidden unless localStorage says otherwise."""
+        html = _load_ui_html()
+        # JS must check valdo_baseline_col_visible to determine initial display state
+        assert "valdo_baseline_col_visible" in html, (
+            "valdo_baseline_col_visible key missing — baseline column won't be hidden by default"
+        )
+
+    def test_toggle_button_present_in_html(self):
+        """ui.html must contain a button with id='btnToggleBaselineCol'."""
+        html = _load_ui_html()
+        assert 'id="btnToggleBaselineCol"' in html, (
+            "btnToggleBaselineCol toggle button is missing from ui.html"
+        )
+
+    def test_toggle_button_in_runs_toolbar(self):
+        """The baseline toggle button must appear inside the runs-toolbar section."""
+        content = (
+            Path(__file__).resolve().parent.parent.parent
+            / "src"
+            / "reports"
+            / "static"
+            / "ui.html"
+        ).read_text(encoding="utf-8")
+        # Find the runs-toolbar div and the subsequent table-wrap div
+        toolbar_start = content.find('class="runs-toolbar"')
+        table_wrap_start = content.find('id="runsTableWrap"', toolbar_start)
+        assert toolbar_start != -1, "runs-toolbar section not found"
+        assert table_wrap_start != -1, "runsTableWrap section not found after toolbar"
+        toolbar_section = content[toolbar_start:table_wrap_start]
+        assert "btnToggleBaselineCol" in toolbar_section, (
+            "btnToggleBaselineCol must be inside the runs-toolbar div"
+        )
+
+    def test_toggle_baseline_column_function_in_js(self):
+        """ui.js must define a toggleBaselineColumn() function."""
+        html = _load_ui_html()
+        assert "function toggleBaselineColumn(" in html, (
+            "toggleBaselineColumn function missing from ui.js"
+        )
+
+    def test_apply_baseline_col_visibility_function_in_js(self):
+        """ui.js must define _applyBaselineColVisibility() function."""
+        html = _load_ui_html()
+        assert "function _applyBaselineColVisibility(" in html, (
+            "_applyBaselineColVisibility function missing from ui.js"
+        )
+
+    def test_fetch_baseline_statuses_function_in_js(self):
+        """ui.js must define _fetchBaselineStatuses() function."""
+        html = _load_ui_html()
+        assert "function _fetchBaselineStatuses(" in html, (
+            "_fetchBaselineStatuses function missing from ui.js"
+        )
+
+    def test_td_baseline_class_in_row_builder(self):
+        """ui.js row builder must create cells with class 'td-baseline'."""
+        html = _load_ui_html()
+        assert "td-baseline" in html, (
+            "td-baseline class not found — baseline cell missing from row builder"
+        )
+
+    def test_baseline_check_api_url_in_js(self):
+        """ui.js must call the /api/v1/runs/baseline-check endpoint."""
+        html = _load_ui_html()
+        assert "/api/v1/runs/baseline-check" in html, (
+            "baseline-check API URL missing from ui.js"
+        )
+
+    def test_fetch_baseline_statuses_called_after_table_renders(self):
+        """ui.js must call _fetchBaselineStatuses() after loadRunHistory builds the table."""
+        html = _load_ui_html()
+        # The call must appear after buildRunsTable in the loadRunHistory function
+        load_idx = html.find("async function loadRunHistory(")
+        assert load_idx != -1, "loadRunHistory function not found"
+        fetch_call_idx = html.find("_fetchBaselineStatuses()", load_idx)
+        assert fetch_call_idx != -1, (
+            "_fetchBaselineStatuses() is not called inside loadRunHistory"
+        )
+
+    def test_apply_visibility_called_at_init(self):
+        """ui.js init block must call _applyBaselineColVisibility() at page load."""
+        html = _load_ui_html()
+        # Must appear after the loadRunHistory() call in the init block
+        init_idx = html.find("loadRunHistory();")
+        assert init_idx != -1, "loadRunHistory() init call not found"
+        apply_idx = html.find("_applyBaselineColVisibility()", init_idx)
+        assert apply_idx != -1, (
+            "_applyBaselineColVisibility() is not called in the init block after loadRunHistory()"
+        )
+
+    def test_deviated_badge_text_in_js(self):
+        """ui.js must contain the deviation badge text string."""
+        html = _load_ui_html()
+        assert "Deviated" in html, "Deviation badge text 'Deviated' not found in ui.js"
+
+    def test_within_baseline_text_in_js(self):
+        """ui.js must contain the 'Within baseline' success text."""
+        html = _load_ui_html()
+        assert "Within baseline" in html, "'Within baseline' text not found in ui.js"


### PR DESCRIPTION
## Summary

- **`aria-pressed` on day-range buttons** — `setTrendDays()` now sets `aria-pressed` to `'true'`/`'false'` on every `.trend-day-btn` on each invocation; initial values are also set in `ui.html` markup (7d = `true`, 14d/30d = `false`)
- **Visible `<label>` for suite selector** — `<label for="trendSuiteSelect">Suite:</label>` added before the `<select>`, satisfying WCAG 2.1 SC 1.3.1 (labels)
- **Styled loading state** — loading indicator uses `<span style="color:var(--text-secondary);">` instead of bare `textContent`, so it responds correctly to dark/light theme switches
- **Styled error state** — `.catch()` handler now renders `<span style="color:var(--fail);">` using the existing CSS variable (`--fail: #e74c3c`), no hardcoded hex
- **Empty state verified** — `renderTrendChart([], container)` already renders "No trend data yet" SVG text from PR #264; no change needed
- **SVG accessibility verified** — `renderTrendChart` already sets `role='img'` and a dynamic `aria-label` from PR #264; no change needed

## Test plan
- [ ] `node --check src/reports/static/ui.js` passes (verified locally)
- [ ] Open `/ui` in browser (dark theme) — click Recent Runs, observe loading spinner text is subdued grey, not white
- [ ] Toggle to light theme — loading text still reads correctly with `var(--text-secondary)`
- [ ] Disconnect network / break API URL — error text appears in red using `var(--fail)`
- [ ] Inspect 7d/14d/30d buttons in DevTools — `aria-pressed` is `true` on active, `false` on others
- [ ] Click 14d — `aria-pressed` updates correctly on all three buttons
- [ ] Screen reader: "Suite:" label is announced before the `<select>` control

🤖 Generated with [Claude Code](https://claude.com/claude-code)