### PR TITLE
chore: add pkanduri1 as default reviewer via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
+# All PRs require review from pkanduri1.
 # Configuration files require team review before merging.
 # See docs/CHANGE_MANAGEMENT.md for the full approval workflow.
+
+*                    @pkanduri1
 
 config/mappings/     @buddy-k23
 config/rules/        @buddy-k23


### PR DESCRIPTION
Adds `@pkanduri1` as a required reviewer for all files (`*` glob) so every future PR automatically requests their review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)