### PR TITLE
fix(e2e): update stale E2E assertions after rebrand and wizard

### DIFF
--- a/tests/e2e/test_e2e_cross_tab.py
+++ b/tests/e2e/test_e2e_cross_tab.py
@@ -62,7 +62,8 @@ class TestCrossTab:
         """App header should be visible on all tabs."""
         header = ui_page.locator("header")
         assert header.is_visible()
-        assert "CM3" in header.text_content()
+        header_text = header.text_content()
+        assert any(word in header_text for word in ["CM3", "Valdo", "valdo"])
 
         # Check on different tabs
         for tab_id in ["tab-runs", "tab-mapping", "tab-tester"]:

--- a/tests/e2e/test_e2e_quick_test_validate.py
+++ b/tests/e2e/test_e2e_quick_test_validate.py
@@ -35,7 +35,7 @@ class TestQuickTestValidate:
 
     def test_validate_button_exists(self, ui_page):
         """Validate button should be present and clickable."""
-        btn = ui_page.locator("button:has-text('Validate')")
+        btn = ui_page.locator("#btnValidate")
         assert btn.is_visible()
 
     def test_validate_button_disabled_without_file(self, ui_page):


### PR DESCRIPTION
## Summary
- `test_header_always_visible`: header now reads "Valdo v2.0" not "CM3" — accepts either brand name
- `test_validate_button_exists`: uses `#btnValidate` ID to avoid strict-mode failure caused by second Validate button added by multi-record wizard (PR #271)

## Test plan
- [ ] Both previously failing E2E tests now pass
- [ ] Full E2E suite: 46/46 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)