### PR TITLE
feat: failed rows export — service, API, CLI, UI (#227 #228 #229)

### DIFF
--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -329,6 +329,13 @@ comparison.
   need to see raw values for debugging.
 - **Elapsed time tile** -- After validation completes, an "Elapsed" metric card
   shows total processing time in seconds.
+- **Download Failed Rows** -- When validation finds errors, a "Download Failed
+  Rows" button appears below the metric cards.  Clicking it POSTs to
+  `POST /api/v1/files/export-errors` using the same file and mapping already
+  selected, and triggers a browser download of a file named
+  `errors_<original_filename>` containing only the rows that failed.  The
+  button is hidden when all rows are valid and is reset automatically when you
+  upload a new file.
 - **Report links** -- Download or view the generated HTML/JSON report directly
   from the results area.
 
@@ -506,6 +513,7 @@ valdo validate \
 | `--strict-fixed-width / --no-strict-fixed-width` | off | Strict fixed-width field checks |
 | `--strict-level` | `format` | Strict depth: `basic`, `format`, or `all` |
 | `--multi-record` | | Path to multi-record YAML config (for files with multiple record types) |
+| `--export-errors` | | Path to write failed rows to after validation completes |
 
 #### Common examples
 
@@ -556,6 +564,19 @@ valdo validate \
   -f output/ATOCTRAN.txt \
   --multi-record config/multi-record/atoctran_config.yaml
 ```
+
+**Export failed rows to a separate file:**
+
+```bash
+valdo validate \
+  --file data/batch/customers.txt \
+  --mapping config/mappings/customer_mapping.json \
+  --export-errors output/failed_rows.txt
+# Prints: Exported 23 failed rows to output/failed_rows.txt
+```
+
+For delimited files the output includes the header row so it can be opened
+directly in a spreadsheet or fed back into a re-validation run.
 
 See [Multi-Record-Type File Validation](#multi-record-type-file-validation)
 in the Configuration Reference for the full YAML format and cross-type rule
@@ -912,6 +933,25 @@ curl -X POST http://localhost:8000/api/v1/files/validate \
   "report_url": "/uploads/validate_customers.html"
 }
 ```
+
+#### POST /api/v1/files/export-errors
+
+Validate a file and return a downloadable file containing only the rows that
+failed validation.  Accepts the same `file`, `mapping_id`, and
+`multi_record_config` fields as `POST /api/v1/files/validate`.
+
+```bash
+curl -X POST http://localhost:8000/api/v1/files/export-errors \
+  -H "X-API-Key: key-dev-abc123" \
+  -F "file=@data/batch/customers.txt" \
+  -F "mapping_id=customer_mapping" \
+  --output errors_customers.txt
+```
+
+**Response:** A plain-text file download named `errors_<original_filename>`.
+For delimited files the header row is included so the output is self-describing.
+When there are no errors the response is empty (fixed-width) or header-only
+(delimited) with HTTP 200.
 
 #### POST /api/v1/files/compare
 

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -262,6 +262,10 @@ Services
    :members:
    :undoc-members:
 
+.. automodule:: src.services.error_extractor
+   :members:
+   :undoc-members:
+
 Contracts & Adapters
 --------------------
 

--- a/src/api/routers/files.py
+++ b/src/api/routers/files.py
@@ -7,7 +7,8 @@ import time
 from pathlib import Path
 import shutil
 
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Body
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Body, Depends
+from fastapi.responses import FileResponse
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
@@ -36,6 +37,8 @@ from src.services.retry_policy import execute_with_retries
 from src.services.metrics_registry import METRICS
 from src.utils.structured_logger import get_structured_logger, log_event
 from src.validators.threshold import ThresholdEvaluator
+from src.api.auth import require_api_key
+from src.services.error_extractor import extract_error_rows
 
 router = APIRouter()
 
@@ -632,6 +635,109 @@ async def db_compare(
         raise HTTPException(status_code=500, detail=f"DB extraction failed: {exc}")
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Error running db-compare: {exc}")
+
+    finally:
+        if upload_path.exists():
+            upload_path.unlink()
+
+
+@router.post("/export-errors")
+async def export_errors(
+    file: UploadFile = File(...),
+    mapping_id: str = Form(None),
+    multi_record_config: UploadFile = File(None),
+    _: str = Depends(require_api_key),
+):
+    """Run validation and return a file containing only the failed rows.
+
+    Validates the uploaded file against the provided mapping or multi-record
+    YAML config, then extracts all rows that produced validation errors into a
+    downloadable text file.  The response is always 200; when there are no
+    errors the returned file is effectively empty (fixed-width) or header-only
+    (delimited).
+
+    Args:
+        file: The batch data file to validate.
+        mapping_id: Mapping config identifier (JSON filename stem under
+            ``config/mappings/``).  Required unless ``multi_record_config``
+            is provided.
+        multi_record_config: Optional YAML file describing a multi-record
+            config.  When present, ``mapping_id`` is not required.
+
+    Returns:
+        A ``FileResponse`` with ``Content-Disposition: attachment`` and
+        filename ``errors_<original_filename>``.
+
+    Raises:
+        HTTPException: 422 if neither ``mapping_id`` nor
+            ``multi_record_config`` is supplied.
+        HTTPException: 404 if the ``mapping_id`` mapping file does not exist.
+        HTTPException: 500 on unexpected service errors.
+    """
+    if multi_record_config is None and not mapping_id:
+        raise HTTPException(
+            status_code=422,
+            detail="Either 'mapping_id' or 'multi_record_config' must be provided",
+        )
+
+    upload_path = UPLOADS_DIR / f"export_errors_{file.filename}"
+    error_output_path = UPLOADS_DIR / f"errors_{file.filename}"
+
+    with open(upload_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    try:
+        # --- Multi-record path ---
+        if multi_record_config is not None:
+            config_bytes = await multi_record_config.read()
+            config_yaml = config_bytes.decode("utf-8", errors="replace")
+            try:
+                result = run_multi_record_validate_service(
+                    file_path=str(upload_path),
+                    config_yaml=config_yaml,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+
+            # Convert cross-type violations to error format compatible with extractor.
+            cross_violations = result.get("cross_type_violations", [])
+            errors = [
+                {"row": v.get("row", 0), "message": v.get("message", "")}
+                for v in cross_violations
+                if v.get("severity") == "error"
+            ]
+            validation_result_dict = {"errors": errors}
+        else:
+            # --- Standard field-level validation path ---
+            mapping_file = MAPPINGS_DIR / f"{mapping_id}.json"
+            if not mapping_file.exists():
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Mapping '{mapping_id}' not found",
+                )
+
+            validation_result_dict = run_validate_service(
+                file=str(upload_path),
+                mapping=str(mapping_file),
+                use_chunked=_should_use_chunked(upload_path),
+            )
+
+        extract_error_rows(
+            file_path=str(upload_path),
+            validation_result=validation_result_dict,
+            output_path=str(error_output_path),
+        )
+
+        return FileResponse(
+            path=str(error_output_path),
+            filename=f"errors_{file.filename}",
+            media_type="text/plain",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Error exporting errors: {exc}")
 
     finally:
         if upload_path.exists():

--- a/src/commands/validate_command.py
+++ b/src/commands/validate_command.py
@@ -6,6 +6,21 @@ from pathlib import Path
 import click
 
 
+def _run_export_errors(file_path: str, result: dict, export_errors_path: str) -> None:
+    """Call error_extractor and print a summary line to stdout.
+
+    Args:
+        file_path: Path to the original data file.
+        result: Validation result dict containing an ``'errors'`` key.
+        export_errors_path: Destination path for the exported failed rows.
+    """
+    from src.services.error_extractor import extract_error_rows
+
+    export_result = extract_error_rows(file_path, result, export_errors_path)
+    n = export_result["exported_rows"]
+    click.echo(f"Exported {n} failed rows to {export_errors_path}")
+
+
 def _build_fixed_width_field_specs(fields):
     """Build (name, start, end) specs from mapping fields with validation."""
     field_specs = []
@@ -89,6 +104,7 @@ def run_validate_command(
     workers=1,
     logger=None,
     suppress_pii=True,
+    export_errors_path=None,
 ):
     """Validate a batch data file against a mapping and optional rules config.
 
@@ -114,6 +130,9 @@ def run_validate_command(
             logger.
         suppress_pii: When True, redact raw field values from HTML reports
             and CSV sidecars.
+        export_errors_path: Optional path to write failed rows to.  When
+            provided, :func:`~src.services.error_extractor.extract_error_rows`
+            is called after validation completes and a summary is printed.
     """
     from src.parsers.format_detector import FormatDetector
     from src.parsers.enhanced_validator import EnhancedFileValidator
@@ -229,6 +248,9 @@ def run_validate_command(
             else:
                 click.echo(click.style("\nUnsupported output type for chunked validation. Use .json or .html", fg='yellow'))
 
+        if export_errors_path:
+            _run_export_errors(file, result, export_errors_path)
+
         if not result['valid']:
             sys.exit(1)
         return
@@ -276,6 +298,9 @@ def run_validate_command(
             click.echo(f"\n✓ Validation HTML report generated: {output}")
         else:
             click.echo(click.style("\nUnsupported output type for validation. Use .json or .html", fg='yellow'))
+
+    if export_errors_path:
+        _run_export_errors(file, result, export_errors_path)
 
     if not result['valid']:
         sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -79,8 +79,10 @@ def parse(file, mapping, format, output, use_chunked, chunk_size):
               help='Redact raw field values from HTML reports (default: enabled)')
 @click.option('--multi-record', default=None, type=click.Path(exists=True),
               help='Multi-record YAML config for files with multiple record types')
+@click.option('--export-errors', default=None, type=click.Path(),
+              help='Write failed rows to this file after validation')
 def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
-             strict_fixed_width, strict_level, workers, suppress_pii, multi_record):
+             strict_fixed_width, strict_level, workers, suppress_pii, multi_record, export_errors):
     """Validate file format and content."""
     logger = setup_logger('valdo', log_to_file=False)
 
@@ -95,6 +97,7 @@ def validate(file, mapping, rules, output, detailed, use_chunked, chunk_size, pr
             file, mapping, rules, output, detailed, use_chunked, chunk_size, progress,
             strict_fixed_width, strict_level, workers, logger,
             suppress_pii=suppress_pii,
+            export_errors_path=export_errors,
         )
     except Exception as e:
         logger.error(f"Error validating file: {e}")

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -214,6 +214,20 @@
       </div>
     </div>
 
+    <!-- Download Failed Rows button (shown only when invalid_rows > 0) -->
+    <div id="exportErrorsRow" style="display:none;margin-top:12px;">
+      <button class="btn btn-secondary" id="btnDownloadErrors"
+              aria-label="Download rows that failed validation"
+              data-tooltip="Download a file containing only the rows that failed validation">
+        <svg aria-hidden="true" focusable="false" width="15" height="15" fill="none"
+             stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round"
+            d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M12 3v13.5m0 0l-4.5-4.5m4.5 4.5l4.5-4.5"/>
+        </svg>
+        Download Failed Rows
+      </button>
+    </div>
+
     <!-- Compare section: side-by-side cards -->
     <div id="compare-section">
       <div class="compare-cards">

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -178,7 +178,11 @@ setupDrop('dropZone2', 'secondary');
 document.getElementById('btnCloseReport').addEventListener('click', hideInlineReport);
 
 document.getElementById('fileInput').addEventListener('change', function() {
-  if (this.files.length) { setFile(this.files[0], 'primary'); }
+  if (this.files.length) {
+    setFile(this.files[0], 'primary');
+    // Hide export button whenever a new file is selected.
+    document.getElementById('exportErrorsRow').style.display = 'none';
+  }
 });
 document.getElementById('fileInput2').addEventListener('change', function() {
   if (this.files.length) { setFile(this.files[0], 'secondary'); }
@@ -432,6 +436,9 @@ document.getElementById('btnValidate').addEventListener('click', async function(
     document.getElementById('metricQuality').textContent = quality + '%';
     document.getElementById('quickMetrics').style.display = '';
 
+    // Show Download Failed Rows button when there are errors.
+    document.getElementById('exportErrorsRow').style.display = errors > 0 ? '' : 'none';
+
     var msg = 'Validated \u2014 ' + data.valid_rows + '/' + data.total_rows + ' rows valid'
       + (data.invalid_rows ? ' (' + data.invalid_rows + ' errors)' : '') + '.';
     if (data.report_url) {
@@ -445,6 +452,59 @@ document.getElementById('btnValidate').addEventListener('click', async function(
   } finally {
     setBtnLoading(btn, false);
     updateButtons();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Download Failed Rows
+// ---------------------------------------------------------------------------
+/**
+ * POST to /api/v1/files/export-errors with the same file + mapping/yaml used
+ * for the validate call, then trigger a browser file download from the response.
+ */
+document.getElementById('btnDownloadErrors').addEventListener('click', async function() {
+  if (!primaryFile) { setStatusText('No file selected.', 'error'); return; }
+
+  var mrYamlInput = document.getElementById('qtMrYamlInput');
+  var mrYamlFile = mrYamlInput && mrYamlInput.files[0] ? mrYamlInput.files[0] : null;
+  var mapping = document.getElementById('mappingSelect').value;
+  if (!mrYamlFile && !mapping) {
+    setStatusText('Please select a mapping or provide a multi-record YAML.', 'error');
+    return;
+  }
+
+  var btn = this;
+  setBtnLoading(btn, true);
+
+  try {
+    var fd = new FormData();
+    fd.append('file', primaryFile);
+    if (mrYamlFile) {
+      fd.append('multi_record_config', mrYamlFile);
+    } else {
+      fd.append('mapping_id', mapping);
+    }
+
+    var resp = await fetch('/api/v1/files/export-errors', { method: 'POST', body: fd });
+    if (!resp.ok) {
+      var errData = await resp.json().catch(function() { return { detail: resp.statusText }; });
+      throw new Error(errData.detail || resp.statusText);
+    }
+
+    // Trigger browser download from the response blob.
+    var blob = await resp.blob();
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'errors_' + primaryFile.name;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch (err) {
+    setStatusText('Error downloading failed rows: ' + err.message, 'error');
+  } finally {
+    setBtnLoading(btn, false);
   }
 });
 

--- a/src/services/error_extractor.py
+++ b/src/services/error_extractor.py
@@ -1,0 +1,118 @@
+"""Service for extracting failed rows from a validated batch file.
+
+Issue #227 — provides :func:`extract_error_rows` used by both the CLI
+``--export-errors`` flag and the ``POST /api/v1/files/export-errors`` endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+# Delimiters tried in priority order when auto-detecting file format.
+_DELIMITER_CANDIDATES: tuple[str, ...] = ("|", "\t", ",")
+
+
+def _detect_delimiter(file_path: str) -> str | None:
+    """Detect the field delimiter of a delimited file by inspecting the first line.
+
+    Tries pipe ``|``, tab ``\\t``, then comma ``,`` in that order.  Returns
+    ``None`` when none of the candidates are found (i.e. the file is treated as
+    fixed-width).
+
+    Args:
+        file_path: Path to the data file to inspect.
+
+    Returns:
+        The delimiter character string, or ``None`` for fixed-width files.
+    """
+    try:
+        with open(file_path, encoding="utf-8", errors="replace") as fh:
+            first_line = fh.readline()
+        for delim in _DELIMITER_CANDIDATES:
+            if delim in first_line:
+                return delim
+    except OSError:
+        pass
+    return None
+
+
+def extract_error_rows(
+    file_path: str,
+    validation_result: dict[str, Any],
+    output_path: str,
+) -> dict[str, Any]:
+    """Extract failed rows from the original file and write them to output_path.
+
+    Collects the unique set of 1-indexed row numbers referenced in
+    ``validation_result['errors']``, reads those lines from ``file_path``,
+    and writes them to ``output_path``.
+
+    For **delimited** files (pipe, tab, or comma-separated) the header row
+    (row 1) is always written first so the output file is self-describing.
+    For **fixed-width** files only the raw failed lines are written.
+
+    When there are no errors the output file is still created:
+    - Fixed-width: 0 bytes.
+    - Delimited: header row only.
+
+    Handles chunked validation results — errors from all chunks reference
+    absolute 1-indexed row numbers, so no special handling is needed here.
+
+    Args:
+        file_path: Path to the original batch file.
+        validation_result: Dict with an ``'errors'`` key; each error entry
+            must have a ``'row'`` field (1-indexed integer).  Missing or
+            ``None`` row values are silently skipped.
+        output_path: Path to write the extracted rows to.  Parent directory
+            is created automatically if it does not exist.
+
+    Returns:
+        Dict with keys:
+
+        - ``exported_rows`` (int): number of unique failed rows written.
+        - ``output_path`` (str): the value passed in as ``output_path``.
+
+    Raises:
+        OSError: If ``file_path`` cannot be read or ``output_path`` cannot
+            be written.
+    """
+    # Collect unique failed row numbers (1-indexed).
+    error_rows: set[int] = set()
+    for err in validation_result.get("errors", []):
+        row = err.get("row") if isinstance(err, dict) else None
+        if isinstance(row, int):
+            error_rows.add(row)
+
+    # Ensure parent directory exists.
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+    delimiter = _detect_delimiter(file_path)
+    is_delimited = delimiter is not None
+
+    # Read every line from the source file into memory (indexed from 1).
+    with open(file_path, encoding="utf-8", errors="replace") as fh:
+        all_lines: list[str] = fh.readlines()
+
+    # For delimited files, row 1 is the header.
+    header_line: str | None = all_lines[0].rstrip("\n") if (is_delimited and all_lines) else None
+
+    with open(output_path, "w", encoding="utf-8") as out_fh:
+        if is_delimited and header_line is not None:
+            # Always write the header for delimited files.
+            out_fh.write(header_line + "\n")
+
+        if not error_rows:
+            # No failed rows — file is header-only (delimited) or empty (fixed).
+            return {"exported_rows": 0, "output_path": output_path}
+
+        # Write failed rows in file order.
+        exported = 0
+        for row_num in sorted(error_rows):
+            line_idx = row_num - 1  # convert 1-indexed to 0-indexed
+            if 0 <= line_idx < len(all_lines):
+                out_fh.write(all_lines[line_idx].rstrip("\n") + "\n")
+                exported += 1
+
+    return {"exported_rows": exported, "output_path": output_path}

--- a/tests/unit/test_api_export_errors.py
+++ b/tests/unit/test_api_export_errors.py
@@ -1,0 +1,147 @@
+"""Unit tests for POST /api/v1/files/export-errors — Issue #228."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# App fixture — import after patching heavy optional dependencies
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def client():
+    """Return a TestClient with API keys disabled for simplicity."""
+    with patch.dict(os.environ, {"API_KEYS": ""}):
+        from src.api.main import app
+        yield TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pipe_file_bytes(rows: int = 5) -> bytes:
+    """Build a simple pipe-delimited file with a header and *rows* data rows."""
+    lines = ["name|value"]
+    for i in range(1, rows + 1):
+        lines.append(f"row{i}|{i}")
+    return "\n".join(lines).encode("utf-8")
+
+
+def _validation_result_with_errors(row_numbers: list[int]) -> dict:
+    return {
+        "valid": False,
+        "total_rows": 10,
+        "valid_rows": 10 - len(set(row_numbers)),
+        "invalid_rows": len(set(row_numbers)),
+        "errors": [{"row": r, "message": f"Error row {r}"} for r in row_numbers],
+        "warnings": [],
+        "quality_score": None,
+        "report_url": None,
+    }
+
+
+def _validation_result_clean() -> dict:
+    return {
+        "valid": True,
+        "total_rows": 5,
+        "valid_rows": 5,
+        "invalid_rows": 0,
+        "errors": [],
+        "warnings": [],
+        "quality_score": None,
+        "report_url": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestExportErrorsEndpoint:
+    """Tests for POST /api/v1/files/export-errors."""
+
+    def test_200_with_file_download_when_errors_exist(self, client, tmp_path):
+        """Endpoint returns 200 with a downloadable file when validation errors exist."""
+        mapping_id = "test_mapping_for_export"
+        mapping_file = Path("config/mappings") / f"{mapping_id}.json"
+        mapping_file.parent.mkdir(parents=True, exist_ok=True)
+        mapping_file.write_text(json.dumps({
+            "source": {"format": "pipe_delimited", "has_header": True},
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "value", "type": "string"},
+            ],
+        }), encoding="utf-8")
+
+        try:
+            with patch(
+                "src.api.routers.files.run_validate_service",
+                return_value=_validation_result_with_errors([2, 4]),
+            ):
+                resp = client.post(
+                    "/api/v1/files/export-errors",
+                    data={"mapping_id": mapping_id},
+                    files={"file": ("test.pipe", _pipe_file_bytes(), "text/plain")},
+                )
+
+            assert resp.status_code == 200
+            # Should be a file download (text/plain or application/octet-stream)
+            assert resp.content  # non-empty body
+        finally:
+            if mapping_file.exists():
+                mapping_file.unlink()
+
+    def test_200_empty_file_when_no_errors(self, client, tmp_path):
+        """Endpoint returns 200 with empty-ish body when no validation errors."""
+        mapping_id = "test_mapping_for_export_clean"
+        mapping_file = Path("config/mappings") / f"{mapping_id}.json"
+        mapping_file.parent.mkdir(parents=True, exist_ok=True)
+        mapping_file.write_text(json.dumps({
+            "source": {"format": "pipe_delimited", "has_header": True},
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "value", "type": "string"},
+            ],
+        }), encoding="utf-8")
+
+        try:
+            with patch(
+                "src.api.routers.files.run_validate_service",
+                return_value=_validation_result_clean(),
+            ):
+                resp = client.post(
+                    "/api/v1/files/export-errors",
+                    data={"mapping_id": mapping_id},
+                    files={"file": ("test.pipe", _pipe_file_bytes(), "text/plain")},
+                )
+
+            assert resp.status_code == 200
+        finally:
+            if mapping_file.exists():
+                mapping_file.unlink()
+
+    def test_404_unknown_mapping_id(self, client):
+        """Returns 404 when mapping_id refers to a non-existent mapping."""
+        resp = client.post(
+            "/api/v1/files/export-errors",
+            data={"mapping_id": "nonexistent_mapping_zzz"},
+            files={"file": ("test.pipe", _pipe_file_bytes(), "text/plain")},
+        )
+        assert resp.status_code == 404
+
+    def test_422_when_neither_mapping_nor_yaml(self, client):
+        """Returns 422 when both mapping_id and multi_record_config are absent."""
+        resp = client.post(
+            "/api/v1/files/export-errors",
+            files={"file": ("test.pipe", _pipe_file_bytes(), "text/plain")},
+        )
+        assert resp.status_code == 422

--- a/tests/unit/test_cli_export_errors.py
+++ b/tests/unit/test_cli_export_errors.py
@@ -1,0 +1,149 @@
+"""Unit tests for --export-errors flag on valdo validate — Issue #228."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from src.main import cli
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pipe_file(tmp_path: Path, rows: int = 5) -> Path:
+    lines = ["name|value"]
+    for i in range(1, rows + 1):
+        lines.append(f"row{i}|{i}")
+    p = tmp_path / "data.pipe"
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+def _make_mapping_file(tmp_path: Path) -> Path:
+    cfg = {
+        "source": {"format": "pipe_delimited", "has_header": True},
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "value", "type": "string"},
+        ],
+    }
+    p = tmp_path / "mapping.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCliExportErrors:
+    """Tests for the --export-errors flag on valdo validate."""
+
+    def test_export_errors_flag_triggers_extraction_and_prints_count(self, tmp_path):
+        """--export-errors writes error rows and prints the count."""
+        data_file = _make_pipe_file(tmp_path)
+        mapping_file = _make_mapping_file(tmp_path)
+        export_path = str(tmp_path / "failed_rows.txt")
+
+        validate_result = {
+            "valid": False,
+            "total_rows": 5,
+            "valid_rows": 3,
+            "invalid_rows": 2,
+            "error_count": 2,
+            "warning_count": 0,
+            "errors": [
+                {"row": 2, "message": "bad value"},
+                {"row": 4, "message": "missing field"},
+            ],
+            "warnings": [],
+        }
+
+        runner = CliRunner()
+        # Patch run_validate_service which is used by the service-layer path.
+        # The CLI validate command uses EnhancedFileValidator directly; patch
+        # _run_export_errors to isolate the export behaviour.
+        with patch(
+            "src.commands.validate_command._run_export_errors"
+        ) as mock_export, patch(
+            "src.parsers.enhanced_validator.EnhancedFileValidator"
+        ) as MockVal:
+            MockVal.return_value.validate.return_value = validate_result
+            # Simulate what _run_export_errors would do: create the file and echo.
+            def fake_export(fp, res, ep):
+                Path(ep).parent.mkdir(parents=True, exist_ok=True)
+                Path(ep).write_text("", encoding="utf-8")
+                import click as _click
+                n = len({e["row"] for e in res.get("errors", [])})
+                _click.echo(f"Exported {n} failed rows to {ep}")
+            mock_export.side_effect = fake_export
+
+            result = runner.invoke(
+                cli,
+                [
+                    "validate",
+                    "--file", str(data_file),
+                    "--mapping", str(mapping_file),
+                    "--export-errors", export_path,
+                ],
+            )
+
+        assert "Exported" in result.output
+        assert "2" in result.output
+        # _run_export_errors was called with the right path
+        mock_export.assert_called_once()
+        call_args = mock_export.call_args[0]
+        assert call_args[2] == export_path
+
+    def test_export_errors_no_errors_prints_zero(self, tmp_path):
+        """--export-errors prints 'Exported 0' when validation passes."""
+        data_file = _make_pipe_file(tmp_path)
+        mapping_file = _make_mapping_file(tmp_path)
+        export_path = str(tmp_path / "failed_rows.txt")
+
+        validate_result = {
+            "valid": True,
+            "total_rows": 5,
+            "valid_rows": 5,
+            "invalid_rows": 0,
+            "error_count": 0,
+            "warning_count": 0,
+            "errors": [],
+            "warnings": [],
+        }
+
+        runner = CliRunner()
+        with patch(
+            "src.commands.validate_command._run_export_errors"
+        ) as mock_export, patch(
+            "src.parsers.enhanced_validator.EnhancedFileValidator"
+        ) as MockVal:
+            MockVal.return_value.validate.return_value = validate_result
+
+            def fake_export(fp, res, ep):
+                Path(ep).parent.mkdir(parents=True, exist_ok=True)
+                Path(ep).write_text("", encoding="utf-8")
+                import click as _click
+                _click.echo(f"Exported 0 failed rows to {ep}")
+            mock_export.side_effect = fake_export
+
+            result = runner.invoke(
+                cli,
+                [
+                    "validate",
+                    "--file", str(data_file),
+                    "--mapping", str(mapping_file),
+                    "--export-errors", export_path,
+                ],
+            )
+
+        assert "Exported 0" in result.output
+        mock_export.assert_called_once()

--- a/tests/unit/test_error_extractor.py
+++ b/tests/unit/test_error_extractor.py
@@ -1,0 +1,181 @@
+"""Unit tests for src/services/error_extractor.py — Issue #227."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.services.error_extractor import extract_error_rows
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_temp(lines: list[str], suffix: str = ".txt") -> str:
+    """Write lines to a temp file and return the path."""
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    return path
+
+
+def _make_errors(row_numbers: list[int]) -> list[dict]:
+    """Build a minimal error list with the given 1-indexed row numbers."""
+    return [{"row": r, "message": f"Error on row {r}"} for r in row_numbers]
+
+
+# ---------------------------------------------------------------------------
+# Issue #227 test cases
+# ---------------------------------------------------------------------------
+
+class TestExtractErrorRowsFixedWidth:
+    """Fixed-width file: raw lines written without a header."""
+
+    def test_extracts_rows_2_4_6_from_10_row_file(self, tmp_path):
+        lines = [f"ROW{str(i).zfill(7)}" for i in range(1, 11)]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {"errors": _make_errors([2, 4, 6])}, out)
+
+        assert result["exported_rows"] == 3
+        assert Path(out).exists()
+        written = Path(out).read_text(encoding="utf-8").splitlines()
+        # should contain lines for rows 2, 4, 6 (content is "ROW0000002" etc.)
+        assert any("ROW0000002" in line for line in written)
+        assert any("ROW0000004" in line for line in written)
+        assert any("ROW0000006" in line for line in written)
+        # row 1 and row 3 should NOT be present
+        assert not any("ROW0000001" in line for line in written)
+        assert not any("ROW0000003" in line for line in written)
+
+
+class TestExtractErrorRowsDelimited:
+    """Pipe-delimited file: header preserved, failed rows follow."""
+
+    def test_pipe_header_plus_failed_rows(self, tmp_path):
+        lines = [
+            "name|age|status",
+            "Alice|30|OK",
+            "Bob|25|FAIL",
+            "Carol|40|OK",
+            "Dave|35|FAIL",
+        ]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {"errors": _make_errors([3, 5])}, out)
+
+        assert result["exported_rows"] == 2
+        written = Path(out).read_text(encoding="utf-8").splitlines()
+        # Header must be line 0
+        assert written[0] == "name|age|status"
+        # Failed rows present
+        assert any("Bob" in line for line in written)
+        assert any("Dave" in line for line in written)
+        # Valid rows absent
+        assert not any("Alice" in line for line in written)
+        assert not any("Carol" in line for line in written)
+
+
+class TestExtractErrorRowsNoErrors:
+    """When validation passes, output should be empty (0 bytes for fixed-width,
+    header-only for delimited) and exported_rows must be 0."""
+
+    def test_no_errors_fixed_width_empty_file(self, tmp_path):
+        lines = ["ROW0000001", "ROW0000002"]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {"errors": []}, out)
+
+        assert result["exported_rows"] == 0
+        assert result["output_path"] == out
+        assert Path(out).exists()
+        assert Path(out).stat().st_size == 0
+
+    def test_no_errors_delimited_header_only(self, tmp_path):
+        lines = ["col1|col2", "A|B", "C|D"]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {"errors": []}, out)
+
+        assert result["exported_rows"] == 0
+        written = Path(out).read_text(encoding="utf-8").splitlines()
+        # For delimited files with no errors: header row only (or empty)
+        # Both are acceptable; no data rows should appear
+        for line in written:
+            assert "A|B" not in line
+            assert "C|D" not in line
+
+
+class TestExtractErrorRowsMissingKey:
+    """No 'errors' key in result dict: treated as zero errors."""
+
+    def test_missing_errors_key_returns_zero(self, tmp_path):
+        lines = ["ROW0000001", "ROW0000002"]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {}, out)
+
+        assert result["exported_rows"] == 0
+        assert Path(out).exists()
+
+
+class TestExtractErrorRowsLargeRowNumbers:
+    """Row numbers near the end of a large file are extracted correctly."""
+
+    def test_rows_95_and_99_from_100_row_file(self, tmp_path):
+        lines = [f"RECORD{str(i).zfill(6)}" for i in range(1, 101)]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {"errors": _make_errors([95, 99])}, out)
+
+        assert result["exported_rows"] == 2
+        written = Path(out).read_text(encoding="utf-8").splitlines()
+        assert any("RECORD000095" in line for line in written)
+        assert any("RECORD000099" in line for line in written)
+        assert not any("RECORD000001" in line for line in written)
+
+
+class TestExtractErrorRowsDuplicates:
+    """A row with multiple errors is exported exactly once."""
+
+    def test_same_row_multiple_errors_exported_once(self, tmp_path):
+        lines = ["ROW0000001", "ROW0000002", "ROW0000003"]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        # Three errors all on row 2
+        errors = [
+            {"row": 2, "message": "Error A"},
+            {"row": 2, "message": "Error B"},
+            {"row": 2, "message": "Error C"},
+        ]
+        result = extract_error_rows(src, {"errors": errors}, out)
+
+        assert result["exported_rows"] == 1
+        written = Path(out).read_text(encoding="utf-8").splitlines()
+        row2_lines = [line for line in written if "ROW0000002" in line]
+        assert len(row2_lines) == 1
+
+
+class TestExtractErrorRowsReturnShape:
+    """Return dict always has exactly the two expected keys."""
+
+    def test_return_dict_keys(self, tmp_path):
+        lines = ["A|B", "1|2"]
+        src = _write_temp(lines)
+        out = str(tmp_path / "errors.txt")
+
+        result = extract_error_rows(src, {"errors": _make_errors([2])}, out)
+
+        assert set(result.keys()) == {"exported_rows", "output_path"}
+        assert result["output_path"] == out


### PR DESCRIPTION
## Summary

- **#227** — New `src/services/error_extractor.py` with `extract_error_rows()`: reads failed row numbers from validation result, deduplicates, writes those lines to output. Handles both fixed-width (raw lines) and delimited files (header + failed rows). 8 unit tests cover all acceptance criteria.
- **#228** — New `POST /api/v1/files/export-errors` endpoint (requires API key) that validates a file internally then streams back only the failed rows as a file download. Also adds `--export-errors <path>` flag to `valdo validate` CLI which calls the extractor after validation and prints `Exported N failed rows to <path>`. 6 unit tests cover API (200/404/422) and CLI (with/without errors).
- **#229** — New `#btnDownloadErrors` button in Quick Test tab below the metric cards. Hidden when `invalid_rows === 0`, shown when errors exist. Button POSTs to `/api/v1/files/export-errors` with same file + mapping used for validate, triggers browser download of `errors_<filename>`. Shows loading spinner during download. Button resets on new file upload. Sphinx RST and USAGE_AND_OPERATIONS_GUIDE.md updated.

## Test plan

- [ ] `python3 -m pytest tests/unit/test_error_extractor.py tests/unit/test_api_export_errors.py tests/unit/test_cli_export_errors.py -v` — all 14 tests pass
- [ ] Validate a file with known errors via CLI with `--export-errors output.txt` and confirm the output contains exactly the failed rows
- [ ] Upload a file to Quick Test, validate — confirm "Download Failed Rows" button appears only when `invalid_rows > 0`
- [ ] Click "Download Failed Rows" — confirm browser downloads `errors_<filename>` with header + failed rows
- [ ] Upload a new file — confirm button disappears
- [ ] `POST /api/v1/files/export-errors` with missing file field → 422; unknown mapping_id → 404; valid inputs → 200 file download

🤖 Generated with [Claude Code](https://claude.com/claude-code)