### PR TITLE
feat: drift detection CLI, API endpoint, and Quick Test badge (#225 #226)

### DIFF
--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -702,6 +702,33 @@ Auto-detect file format.
 valdo detect --file data/batch/unknown_file.dat
 ```
 
+### detect-drift
+
+Detect layout drift between a batch file and its mapping.  Exits 0 if no
+error-severity drift is found; exits 1 if any field has drifted beyond the
+error threshold (offset > 5 bytes for fixed-width, or missing column for
+delimited).
+
+```bash
+# Basic drift check — prints a summary table to stdout
+valdo detect-drift \
+  --file data/batch/tranert.txt \
+  --mapping TRANERT
+
+# Write full JSON report in addition to stdout
+valdo detect-drift \
+  --file data/batch/tranert.txt \
+  --mapping TRANERT \
+  --output reports/drift_report.json
+```
+
+The command also accepts `--mappings-dir` to override the default
+`config/mappings/` search path.
+
+**API equivalent:** `POST /api/v1/files/detect-drift` (form fields: `file`,
+`mapping_id`).  The Quick Test UI fires this automatically after every
+validate run and displays a yellow drift badge if any fields have shifted.
+
 ### run-tests
 
 Run a complete test suite defined in YAML.
@@ -866,6 +893,7 @@ Review the draft, adjust field names and types as needed, then use it with
 | `convert-mappings` | Bulk convert CSV/Excel templates to mapping JSON |
 | `convert-rules` | Convert Excel/CSV rules template to JSON |
 | `convert-suite` | Convert Excel test suite to YAML |
+| `detect-drift` | Detect layout drift between a batch file and its mapping |
 | `extract` | Extract data from Oracle to file |
 | `generate-multi-record` | Interactive wizard (or non-interactive) to create multi-record YAML configs |
 | `infer-mapping` | Auto-generate a draft mapping JSON from a sample data file |

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -312,6 +312,10 @@ Pipeline
    :members:
    :undoc-members:
 
+.. automodule:: src.commands.detect_drift_command
+   :members:
+   :undoc-members:
+
 Transforms
 ----------
 

--- a/src/api/routers/files.py
+++ b/src/api/routers/files.py
@@ -37,6 +37,7 @@ from src.services.retry_policy import execute_with_retries
 from src.services.metrics_registry import METRICS
 from src.utils.structured_logger import get_structured_logger, log_event
 from src.validators.threshold import ThresholdEvaluator
+from src.services.drift_detector import detect_drift
 from src.api.auth import require_api_key
 from src.services.error_extractor import extract_error_rows
 
@@ -738,6 +739,58 @@ async def export_errors(
         raise
     except Exception as exc:
         raise HTTPException(status_code=500, detail=f"Error exporting errors: {exc}")
+
+    finally:
+        if upload_path.exists():
+            upload_path.unlink()
+
+
+@router.post("/detect-drift")
+async def detect_drift_endpoint(
+    file: UploadFile = File(...),
+    mapping_id: str = Form(...),
+    _key=Depends(require_api_key),
+):
+    """Detect schema drift between an uploaded file and a mapping config.
+
+    Saves the uploaded file to the uploads directory, loads the named mapping
+    from ``config/mappings/{mapping_id}.json``, and runs the drift detector.
+
+    Args:
+        file: The batch data file to inspect.
+        mapping_id: Stem of the mapping JSON file (no ``.json`` extension).
+        _key: Injected API key auth context (from ``require_api_key``).
+
+    Returns:
+        Drift report dict with keys ``drifted`` (bool) and ``fields`` (list).
+        Each entry in ``fields`` contains ``name``, ``expected_start``,
+        ``actual_start``, ``expected_length``, ``actual_length``, and
+        ``severity`` (``'warning'`` or ``'error'``).
+
+    Raises:
+        HTTPException: 404 when ``mapping_id`` does not resolve to a file.
+        HTTPException: 422 when the ``file`` field is missing (FastAPI automatic).
+        HTTPException: 500 on unexpected errors.
+    """
+    import json as _json
+
+    mapping_file = MAPPINGS_DIR / f"{mapping_id}.json"
+    if not mapping_file.exists():
+        raise HTTPException(status_code=404, detail=f"Mapping '{mapping_id}' not found")
+
+    upload_path = UPLOADS_DIR / f"drift_{file.filename}"
+    with open(upload_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    try:
+        mapping = _json.loads(mapping_file.read_text(encoding="utf-8"))
+        result = detect_drift(str(upload_path), mapping)
+        return result
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Error detecting drift: {exc}")
 
     finally:
         if upload_path.exists():

--- a/src/commands/detect_drift_command.py
+++ b/src/commands/detect_drift_command.py
@@ -1,0 +1,93 @@
+"""CLI command handler for ``valdo detect-drift``.
+
+Loads a mapping JSON, calls the drift detector service, prints a summary
+table to stdout, and exits with an appropriate code.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from src.services.drift_detector import detect_drift
+
+
+def run_detect_drift(
+    file_path: str,
+    mapping_id: str,
+    output_path: Optional[str] = None,
+    mappings_dir: str = "config/mappings",
+) -> int:
+    """Run drift detection and print results to stdout.
+
+    Loads the mapping JSON from ``{mappings_dir}/{mapping_id}.json``, calls
+    :func:`~src.services.drift_detector.detect_drift`, prints a summary table
+    of any drifted fields, and returns an exit code.
+
+    Args:
+        file_path: Path to the batch data file to inspect.
+        mapping_id: Stem of the mapping JSON file (no ``.json`` extension).
+        output_path: Optional filesystem path to write the full JSON result.
+            When ``None``, no file is written.
+        mappings_dir: Directory that contains mapping JSON files.
+            Defaults to ``config/mappings``.
+
+    Returns:
+        ``0`` when no drift is detected or all drifted fields have
+        severity ``'warning'``; ``1`` when at least one field has
+        severity ``'error'``.
+    """
+    mapping_file = Path(mappings_dir) / f"{mapping_id}.json"
+    if not mapping_file.exists():
+        click.echo(
+            click.style(
+                f"Error: Mapping '{mapping_id}' not found at {mapping_file}",
+                fg="red",
+            )
+        )
+        return 2
+
+    with open(mapping_file, "r", encoding="utf-8") as fh:
+        mapping = json.load(fh)
+
+    result = detect_drift(file_path, mapping)
+
+    drifted_fields = result.get("fields", [])
+    has_error = any(f.get("severity") == "error" for f in drifted_fields)
+
+    if not result.get("drifted"):
+        click.echo(click.style("No drift detected — file layout matches mapping.", fg="green"))
+    else:
+        # Print table header
+        click.echo(click.style("Schema drift detected:", fg="yellow"))
+        click.echo(
+            f"  {'Field':<20} {'Exp.Start':>10} {'Act.Start':>10} "
+            f"{'Exp.Len':>8} {'Severity':<10}"
+        )
+        click.echo("  " + "-" * 65)
+        for field in drifted_fields:
+            severity = field.get("severity", "warning")
+            color = "red" if severity == "error" else "yellow"
+            click.echo(
+                click.style(
+                    f"  {field.get('name', ''):<20} "
+                    f"{str(field.get('expected_start', '?')):>10} "
+                    f"{str(field.get('actual_start', '?')):>10} "
+                    f"{str(field.get('expected_length', '?')):>8} "
+                    f"{severity:<10}",
+                    fg=color,
+                )
+            )
+
+    if output_path:
+        out = Path(output_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(out, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2)
+        click.echo(f"\nJSON report written to: {output_path}")
+
+    return 1 if has_error else 0

--- a/src/main.py
+++ b/src/main.py
@@ -1061,6 +1061,40 @@ def db_migrate(revision, downgrade, dry_run):
         sys.exit(1)
 
 
+@cli.command('detect-drift')
+@click.option('--file', '-f', required=True, help='Path to the batch file to inspect')
+@click.option('--mapping', '-m', required=True, help='Mapping ID (JSON filename stem under config/mappings/)')
+@click.option('--output', '-o', default=None, help='Optional path to write JSON report')
+@click.option('--mappings-dir', default='config/mappings', show_default=True,
+              help='Directory containing mapping JSON files')
+def detect_drift(file, mapping, output, mappings_dir):
+    """Detect schema drift between a batch file and its mapping.
+
+    Compares the actual layout of FILE against the declared field positions
+    and lengths in MAPPING.  Exits 0 when no error-severity drift is found;
+    exits 1 when any field has drifted beyond the error threshold.
+
+    Example::
+
+        valdo detect-drift --file data/batch.txt --mapping TRANERT
+    """
+    logger = setup_logger('valdo', log_to_file=False)
+    try:
+        from src.commands.detect_drift_command import run_detect_drift
+        rc = run_detect_drift(
+            file_path=file,
+            mapping_id=mapping,
+            output_path=output,
+            mappings_dir=mappings_dir,
+        )
+        sys.exit(rc)
+    except SystemExit:
+        raise
+    except Exception as e:
+        logger.error(f"Error detecting drift: {e}")
+        sys.exit(1)
+
+
 @cli.command()
 @click.option('--host', default='0.0.0.0', show_default=True,
               help='Bind address for the server')

--- a/src/reports/static/ui.css
+++ b/src/reports/static/ui.css
@@ -1645,3 +1645,77 @@
   color: #fff;
   border-color: var(--accent);
 }
+
+/* ── Drift warning badge ─────────────────────────────────────────────────── */
+.drift-badge {
+  margin-top: 12px;
+  border: 1.5px solid var(--partial);
+  border-radius: var(--radius);
+  background: rgba(243, 156, 18, 0.10);
+  overflow: hidden;
+}
+[data-theme="light"] .drift-badge {
+  background: rgba(243, 156, 18, 0.08);
+}
+.drift-badge-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--partial);
+}
+.drift-badge-header:focus-visible {
+  outline: 2px solid var(--partial);
+  outline-offset: -2px;
+}
+.drift-badge-chevron {
+  margin-left: auto;
+  font-size: 11px;
+  transition: transform 0.15s ease;
+  display: inline-block;
+}
+.drift-badge.expanded .drift-badge-chevron {
+  transform: rotate(180deg);
+}
+.drift-badge-body {
+  display: none;
+  padding: 0 14px 12px;
+}
+.drift-badge.expanded .drift-badge-body {
+  display: block;
+}
+.drift-fields-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-top: 4px;
+}
+.drift-fields-table th {
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.drift-fields-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.drift-fields-table tr:last-child td {
+  border-bottom: none;
+}
+.drift-severity-error {
+  color: var(--fail);
+  font-weight: 700;
+}
+.drift-severity-warning {
+  color: var(--partial);
+  font-weight: 600;
+}

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -228,6 +228,32 @@
       </button>
     </div>
 
+    <!-- Drift warning badge (hidden by default, shown after validate if drift detected) -->
+    <div id="driftBadge" class="drift-badge" style="display:none;"
+         role="region" aria-label="Schema drift warning" aria-live="polite">
+      <div class="drift-badge-header" id="driftBadgeHeader"
+           tabindex="0" role="button" aria-expanded="false"
+           aria-controls="driftBadgeBody">
+        <span aria-hidden="true">&#x26A0;&#xFE0F;</span>
+        <span>Schema drift detected</span>
+        <span class="drift-badge-chevron" aria-hidden="true">&#x25BE;</span>
+      </div>
+      <div class="drift-badge-body" id="driftBadgeBody">
+        <table class="drift-fields-table" id="driftFieldsTable">
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Exp. Start</th>
+              <th>Act. Start</th>
+              <th>Exp. Length</th>
+              <th>Severity</th>
+            </tr>
+          </thead>
+          <tbody id="driftFieldsBody"></tbody>
+        </table>
+      </div>
+    </div>
+
     <!-- Compare section: side-by-side cards -->
     <div id="compare-section">
       <div class="compare-cards">

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -194,6 +194,7 @@ document.getElementById('btnRemovePrimary').addEventListener('click', function(e
   primaryFile = null;
   document.getElementById('primaryFileCard').classList.remove('visible');
   document.getElementById('fileInput').value = '';
+  _hideDriftBadge();
   updateButtons();
 });
 document.getElementById('btnRemoveSecondary').addEventListener('click', function(e) {
@@ -241,6 +242,8 @@ function setFile(file, slot) {
     document.getElementById('primaryFileMeta').textContent = formatBytes(file.size);
     document.getElementById('primaryFormatBadge').textContent = detectFormat(file.name);
     document.getElementById('primaryFileCard').classList.add('visible');
+    // Hide any stale drift badge when a new file is loaded.
+    _hideDriftBadge();
   } else {
     secondaryFile = file;
     document.getElementById('secondaryFileName').textContent = file.name;
@@ -447,6 +450,11 @@ document.getElementById('btnValidate').addEventListener('click', async function(
     } else {
       setStatusText(msg, data.valid ? 'success' : 'error');
     }
+
+    // Fire drift check non-blocking (standard mapping path only, not multi-record YAML).
+    if (!mrYamlFile && mapping) {
+      _runDriftCheck(primaryFile, mapping);
+    }
   } catch (err) {
     setStatusText('Error: ' + err.message, 'error');
   } finally {
@@ -507,6 +515,102 @@ document.getElementById('btnDownloadErrors').addEventListener('click', async fun
     setBtnLoading(btn, false);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Drift detection badge helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Show the drift warning badge and populate the fields table.
+ *
+ * @param {Array<Object>} fields - Array of drifted field objects from the
+ *   detect-drift API response.  Each object has ``name``, ``expected_start``,
+ *   ``actual_start``, ``expected_length``, and ``severity``.
+ */
+function _showDriftBadge(fields) {
+  var badge = document.getElementById('driftBadge');
+  var tbody = document.getElementById('driftFieldsBody');
+  if (!badge || !tbody) return;
+
+  // Clear previous rows.
+  while (tbody.firstChild) { tbody.removeChild(tbody.firstChild); }
+
+  fields.forEach(function(f) {
+    var tr = document.createElement('tr');
+    var sevClass = f.severity === 'error' ? 'drift-severity-error' : 'drift-severity-warning';
+
+    [
+      f.name || '\u2014',
+      f.expected_start != null ? f.expected_start : '\u2014',
+      f.actual_start   != null ? f.actual_start   : '\u2014',
+      f.expected_length != null ? f.expected_length : '\u2014',
+    ].forEach(function(val) {
+      var td = document.createElement('td');
+      td.textContent = val;
+      tr.appendChild(td);
+    });
+
+    var tdSev = document.createElement('td');
+    tdSev.className = sevClass;
+    tdSev.textContent = f.severity || '\u2014';
+    tr.appendChild(tdSev);
+
+    tbody.appendChild(tr);
+  });
+
+  badge.style.display = '';
+}
+
+/**
+ * Hide the drift warning badge.
+ */
+function _hideDriftBadge() {
+  var badge = document.getElementById('driftBadge');
+  if (badge) badge.style.display = 'none';
+}
+
+/**
+ * Fire-and-forget drift check after a successful validate response.
+ *
+ * Posts the file and mapping_id to the detect-drift endpoint.  Silently
+ * swallows any errors so it never disrupts the validation result display.
+ *
+ * @param {File} file - The primary file object already selected by the user.
+ * @param {string} mappingId - The mapping ID string from the mapping select.
+ */
+async function _runDriftCheck(file, mappingId) {
+  try {
+    var fd = new FormData();
+    fd.append('file', file);
+    fd.append('mapping_id', mappingId);
+    var resp = await fetch('/api/v1/files/detect-drift', { method: 'POST', body: fd });
+    if (!resp.ok) { _hideDriftBadge(); return; }
+    var data = await resp.json();
+    if (data && data.drifted && Array.isArray(data.fields) && data.fields.length > 0) {
+      _showDriftBadge(data.fields);
+    } else {
+      _hideDriftBadge();
+    }
+  } catch (_e) {
+    _hideDriftBadge();
+  }
+}
+
+// Expand/collapse drift badge on header click or Enter/Space keypress.
+(function() {
+  var header = document.getElementById('driftBadgeHeader');
+  if (!header) return;
+  function _toggleDriftBadge() {
+    var badge = document.getElementById('driftBadge');
+    if (!badge) return;
+    var expanded = badge.classList.toggle('expanded');
+    header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  }
+  header.addEventListener('click', _toggleDriftBadge);
+  header.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); _toggleDriftBadge(); }
+  });
+})();
 
 // ---------------------------------------------------------------------------
 // Compare

--- a/tests/unit/test_api_detect_drift.py
+++ b/tests/unit/test_api_detect_drift.py
@@ -1,0 +1,214 @@
+"""Unit tests for ``POST /api/v1/files/detect-drift`` endpoint.
+
+Tests cover:
+- 200 with drifted=False for clean file
+- 200 with drifted=True and fields list for drifted file (mocked service)
+- 404 for unknown mapping_id
+- 422 for missing file field
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+# Set up a dev API key before importing app.
+_api_keys = os.getenv("API_KEYS", "")
+if "dev-key" not in {k.split(":", 1)[0].strip() for k in _api_keys.split(",") if k.strip()}:
+    os.environ["API_KEYS"] = f"{_api_keys},dev-key:admin" if _api_keys else "dev-key:admin"
+
+from src.api.main import app
+
+client = TestClient(app)
+API_HEADERS = {"X-API-Key": "dev-key"}
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+CLEAN_DRIFT_RESULT = {"drifted": False, "fields": []}
+
+DRIFTED_RESULT = {
+    "drifted": True,
+    "fields": [
+        {
+            "name": "account_id",
+            "expected_start": 1,
+            "expected_length": 10,
+            "actual_start": 7,
+            "actual_length": 10,
+            "severity": "error",
+        }
+    ],
+}
+
+MAPPING_STUB = json.dumps({
+    "format": "fixed",
+    "fields": [
+        {"name": "account_id", "position": 1, "length": 10},
+    ],
+})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDetectDriftEndpointClean:
+    """200 + drifted=False for a clean file."""
+
+    def test_returns_200(self, tmp_path):
+        mapping_file = tmp_path / "my_mapping.json"
+        mapping_file.write_text(MAPPING_STUB)
+
+        file_content = b"ACCT000001DATA\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path), \
+             patch("src.api.routers.files.detect_drift", return_value=CLEAN_DRIFT_RESULT):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "my_mapping"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        assert resp.status_code == 200
+
+    def test_drifted_false_in_response(self, tmp_path):
+        mapping_file = tmp_path / "my_mapping.json"
+        mapping_file.write_text(MAPPING_STUB)
+
+        file_content = b"ACCT000001DATA\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path), \
+             patch("src.api.routers.files.detect_drift", return_value=CLEAN_DRIFT_RESULT):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "my_mapping"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        body = resp.json()
+        assert body["drifted"] is False
+        assert body["fields"] == []
+
+
+class TestDetectDriftEndpointDrifted:
+    """200 + drifted=True with fields list when service detects drift."""
+
+    def test_returns_200(self, tmp_path):
+        mapping_file = tmp_path / "my_mapping.json"
+        mapping_file.write_text(MAPPING_STUB)
+
+        file_content = b"      ACCT000001\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path), \
+             patch("src.api.routers.files.detect_drift", return_value=DRIFTED_RESULT):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "my_mapping"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        assert resp.status_code == 200
+
+    def test_drifted_true_in_response(self, tmp_path):
+        mapping_file = tmp_path / "my_mapping.json"
+        mapping_file.write_text(MAPPING_STUB)
+
+        file_content = b"      ACCT000001\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path), \
+             patch("src.api.routers.files.detect_drift", return_value=DRIFTED_RESULT):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "my_mapping"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        body = resp.json()
+        assert body["drifted"] is True
+        assert len(body["fields"]) == 1
+        assert body["fields"][0]["name"] == "account_id"
+        assert body["fields"][0]["severity"] == "error"
+
+    def test_fields_list_structure(self, tmp_path):
+        mapping_file = tmp_path / "my_mapping.json"
+        mapping_file.write_text(MAPPING_STUB)
+
+        file_content = b"      ACCT000001\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path), \
+             patch("src.api.routers.files.detect_drift", return_value=DRIFTED_RESULT):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "my_mapping"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        body = resp.json()
+        field = body["fields"][0]
+        assert "name" in field
+        assert "severity" in field
+        assert "expected_start" in field
+        assert "actual_start" in field
+
+
+class TestDetectDriftEndpointNotFound:
+    """404 when mapping_id does not resolve to a file."""
+
+    def test_returns_404_for_unknown_mapping(self, tmp_path):
+        file_content = b"ACCT000001DATA\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "does_not_exist"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        assert resp.status_code == 404
+
+    def test_404_detail_mentions_mapping(self, tmp_path):
+        file_content = b"ACCT000001DATA\n" * 5
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "does_not_exist"},
+                files={"file": ("data.txt", BytesIO(file_content), "text/plain")},
+                headers=API_HEADERS,
+            )
+
+        assert "does_not_exist" in resp.json()["detail"] or "not found" in resp.json()["detail"].lower()
+
+
+class TestDetectDriftEndpointMissingFile:
+    """422 when file field is missing from request."""
+
+    def test_returns_422_without_file(self, tmp_path):
+        mapping_file = tmp_path / "my_mapping.json"
+        mapping_file.write_text(MAPPING_STUB)
+
+        with patch("src.api.routers.files.MAPPINGS_DIR", tmp_path):
+            resp = client.post(
+                "/api/v1/files/detect-drift",
+                data={"mapping_id": "my_mapping"},
+                headers=API_HEADERS,
+            )
+
+        assert resp.status_code == 422

--- a/tests/unit/test_cli_detect_drift.py
+++ b/tests/unit/test_cli_detect_drift.py
@@ -1,0 +1,269 @@
+"""Unit tests for the ``valdo detect-drift`` CLI command.
+
+Tests cover:
+- Clean file returns exit code 0 and no drift fields
+- Drifted file with error severity returns exit code 1
+- Drifted file with warnings only returns exit code 0
+- ``--output`` flag writes JSON result to file
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+# Make sure src is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.main import cli
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MAPPING_STUB = {
+    "format": "fixed",
+    "fields": [
+        {"name": "id", "position": 1, "length": 5},
+        {"name": "name", "position": 6, "length": 10},
+    ],
+}
+
+CLEAN_RESULT = {"drifted": False, "fields": []}
+
+DRIFTED_ERROR_RESULT = {
+    "drifted": True,
+    "fields": [
+        {
+            "name": "name",
+            "expected_start": 6,
+            "expected_length": 10,
+            "actual_start": 12,
+            "actual_length": 10,
+            "severity": "error",
+        }
+    ],
+}
+
+DRIFTED_WARNING_RESULT = {
+    "drifted": True,
+    "fields": [
+        {
+            "name": "id",
+            "expected_start": 1,
+            "expected_length": 5,
+            "actual_start": 3,
+            "actual_length": 5,
+            "severity": "warning",
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _invoke(runner: CliRunner, args: list[str]) -> object:
+    """Invoke ``valdo detect-drift`` with the given args."""
+    return runner.invoke(cli, ["detect-drift"] + args)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDetectDriftCleanFile:
+    """Clean file — no drift detected, exit code 0."""
+
+    def test_exit_code_zero(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=CLEAN_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+            ])
+
+        assert result.exit_code == 0
+
+    def test_no_drift_message_printed(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=CLEAN_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+            ])
+
+        assert "No drift" in result.output or "clean" in result.output.lower()
+
+
+class TestDetectDriftErrorSeverity:
+    """Drifted file with error-severity field — exit code 1."""
+
+    def test_exit_code_one_on_error_severity(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=DRIFTED_ERROR_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+            ])
+
+        assert result.exit_code == 1
+
+    def test_drifted_field_name_in_output(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=DRIFTED_ERROR_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+            ])
+
+        assert "name" in result.output
+
+
+class TestDetectDriftWarningOnly:
+    """Drifted file with warning-only severity — exit code 0."""
+
+    def test_exit_code_zero_on_warnings_only(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=DRIFTED_WARNING_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+            ])
+
+        assert result.exit_code == 0
+
+    def test_warning_field_shown_in_output(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=DRIFTED_WARNING_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+            ])
+
+        assert "id" in result.output or "warning" in result.output.lower()
+
+
+class TestDetectDriftOutputFlag:
+    """--output flag writes JSON report to file."""
+
+    def test_output_file_written(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+        output_file = tmp_path / "report.json"
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=CLEAN_RESULT):
+            result = _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+                "--output", str(output_file),
+            ])
+
+        assert output_file.exists(), f"Output file was not written. CLI output: {result.output}"
+
+    def test_output_file_contains_valid_json(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+        output_file = tmp_path / "report.json"
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=DRIFTED_ERROR_RESULT):
+            _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+                "--output", str(output_file),
+            ])
+
+        data = json.loads(output_file.read_text())
+        assert "drifted" in data
+        assert "fields" in data
+        assert data["drifted"] is True
+
+    def test_output_file_contains_fields_list(self, tmp_path):
+        mapping_file = tmp_path / "test.json"
+        mapping_file.write_text(json.dumps(MAPPING_STUB))
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+        output_file = tmp_path / "report.json"
+
+        runner = CliRunner()
+        with patch("src.commands.detect_drift_command.detect_drift", return_value=DRIFTED_ERROR_RESULT):
+            _invoke(runner, [
+                "--file", str(data_file),
+                "--mapping", "test",
+                "--mappings-dir", str(tmp_path),
+                "--output", str(output_file),
+            ])
+
+        data = json.loads(output_file.read_text())
+        assert isinstance(data["fields"], list)
+        assert len(data["fields"]) == 1
+        assert data["fields"][0]["severity"] == "error"
+
+
+class TestDetectDriftMappingNotFound:
+    """Missing mapping file returns non-zero exit code."""
+
+    def test_missing_mapping_exits_nonzero(self, tmp_path):
+        data_file = tmp_path / "data.txt"
+        data_file.write_text("12345ABCDEFGHIJ\n")
+
+        runner = CliRunner()
+        result = _invoke(runner, [
+            "--file", str(data_file),
+            "--mapping", "nonexistent_mapping",
+            "--mappings-dir", str(tmp_path),
+        ])
+
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- **#225 — CLI:** `valdo detect-drift --file <path> --mapping <id>` loads the mapping JSON, calls `detect_drift()` from the existing service, prints a colour-coded field table, and exits 1 on any error-severity field (offset > 5 bytes) or 0 on clean/warning-only. `--output <path.json>` writes the full JSON report.
- **#225 — API:** `POST /api/v1/files/detect-drift` (multipart: `file` + `mapping_id`) saves the upload, calls the service, and returns `{ "drifted": bool, "fields": [...] }`. Returns 404 for unknown mapping, 422 for missing file.
- **#226 — UI:** After every validate run on a standard mapping (not multi-record YAML), `_runDriftCheck()` fires non-blocking in the background. If drift is found, a yellow amber `#driftBadge` appears below the metric cards with an accordion table of drifted fields. Badge is hidden on new file upload, clean results, or any network error.

## Files changed

| File | Change |
|---|---|
| `src/commands/detect_drift_command.py` | New — CLI command handler |
| `src/main.py` | Register `valdo detect-drift` command |
| `src/api/routers/files.py` | Add `POST /detect-drift` endpoint |
| `src/reports/static/ui.js` | `_runDriftCheck`, `_showDriftBadge`, `_hideDriftBadge`, accordion |
| `src/reports/static/ui.html` | `#driftBadge` markup |
| `src/reports/static/ui.css` | `.drift-badge` styles (amber, dark/light theme) |
| `tests/unit/test_cli_detect_drift.py` | 10 unit tests for CLI (TDD — written before implementation) |
| `tests/unit/test_api_detect_drift.py` | 8 unit tests for API endpoint (TDD — written before implementation) |
| `docs/sphinx/modules.rst` | Register new command module |
| `docs/USAGE_AND_OPERATIONS_GUIDE.md` | `detect-drift` section and command table entry |

## Test plan

- [x] `python3 -m pytest tests/unit/test_cli_detect_drift.py tests/unit/test_api_detect_drift.py -v` — 18/18 pass
- [x] Full unit suite passes (pre-existing test isolation failures are unrelated to this PR)
- [x] Sphinx docs build with `python3 -m sphinx docs/sphinx docs/sphinx/_build/html` — 0 errors
- [x] Manual: start server, upload a file + mapping in Quick Test, drift badge appears/hides correctly
- [x] Manual: `valdo detect-drift --file <path> --mapping <id>` prints table, exits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)