### PR TITLE
test(e2e): expand E2E coverage — wizard, drift, download errors, help sidebar (#274)

### DIFF
--- a/tests/e2e/test_e2e_download_errors.py
+++ b/tests/e2e/test_e2e_download_errors.py
@@ -1,0 +1,83 @@
+"""E2E tests for the Download Failed Rows button in Quick Test tab (#274).
+
+The Download Failed Rows button (#btnDownloadErrors) is introduced by the
+failed-rows-export feature branch. These tests are written defensively —
+they remain stable whether or not the feature has been merged into main.
+When the element is present, tests verify the correct default (hidden) state
+and expected interaction behaviour using page.expect_download().
+"""
+
+import pytest
+
+
+class TestDownloadErrors:
+    """Download Failed Rows button E2E tests for the Quick Test tab.
+
+    All assertions use .count() > 0 guards so these tests run cleanly
+    against codebases that do not yet include the failed-rows-export feature.
+    """
+
+    def test_quick_test_panel_loads(self, ui_page):
+        """Quick Test panel should be visible on page load."""
+        panel = ui_page.locator("#panel-quick")
+        assert panel.is_visible()
+
+    def test_download_errors_button_hidden_on_load(self, ui_page):
+        """Download errors button should be hidden (or absent) on initial page load.
+
+        The button should only appear after a validation run that produced errors.
+        """
+        btn = ui_page.locator("#btnDownloadErrors")
+        if btn.count() > 0:
+            assert btn.is_hidden(), (
+                "btnDownloadErrors should be hidden (display:none) on initial page load "
+                "before any validation has run"
+            )
+        # If element is absent, the feature is not yet deployed — test passes
+
+    def test_download_errors_not_visible_without_validation(self, ui_page):
+        """Download errors button should not be visible before validation runs."""
+        btn = ui_page.locator("#btnDownloadErrors")
+        if btn.count() > 0:
+            assert not btn.is_visible(), (
+                "btnDownloadErrors should not be visible before validation runs"
+            )
+
+    def test_download_errors_hidden_after_new_file_upload(self, ui_page, sample_pipe_file):
+        """Uploading a new file should reset/hide the download errors button.
+
+        When a new file is selected, any stale error download state should
+        be cleared so the user does not download errors from a prior run.
+        """
+        ui_page.locator("#fileInput").set_input_files(str(sample_pipe_file))
+        ui_page.wait_for_timeout(500)
+
+        btn = ui_page.locator("#btnDownloadErrors")
+        if btn.count() > 0:
+            assert btn.is_hidden(), (
+                "btnDownloadErrors should be hidden when a new batch file is uploaded"
+            )
+
+    def test_download_errors_id_present_when_feature_active(self, ui_page):
+        """When the failed-rows-export feature is active, #btnDownloadErrors should exist.
+
+        This canary test fails if the feature is deployed but the button ID
+        has drifted from the expected 'btnDownloadErrors'.
+        """
+        panel_html = ui_page.evaluate(
+            "document.getElementById('panel-quick')?.innerHTML || ''"
+        )
+
+        if "download" in panel_html.lower() and "error" in panel_html.lower():
+            # Feature appears active — check the expected element exists
+            btn = ui_page.locator("#btnDownloadErrors")
+            assert btn.count() > 0, (
+                "Download/error content found in panel but #btnDownloadErrors not found — "
+                "check that the element ID matches the expected 'btnDownloadErrors'"
+            )
+
+    def test_core_quick_test_elements_unaffected(self, ui_page):
+        """Core Quick Test elements must always be present regardless of feature state."""
+        assert ui_page.locator("#fileInput").count() > 0, "fileInput must be present"
+        assert ui_page.locator("#btnValidate").count() > 0, "btnValidate must be present"
+        assert ui_page.locator("#mappingSelect").count() > 0, "mappingSelect must be present"

--- a/tests/e2e/test_e2e_drift_badge.py
+++ b/tests/e2e/test_e2e_drift_badge.py
@@ -1,0 +1,83 @@
+"""E2E tests for the drift warning badge in Quick Test tab (#274).
+
+The drift badge (#driftBadge) is introduced by the drift-detection feature
+branch. These tests are written defensively — when the element is not yet
+present in the DOM they verify the absence is handled gracefully, and when
+it is present they verify the correct default (hidden) state.
+"""
+
+import pytest
+
+
+class TestDriftBadge:
+    """Drift warning badge E2E tests for the Quick Test tab.
+
+    These tests must remain stable whether or not the drift-detection
+    feature has been merged. All assertions use .count() > 0 guards.
+    """
+
+    def test_quick_test_panel_loads(self, ui_page):
+        """Quick Test panel should be visible on page load."""
+        panel = ui_page.locator("#panel-quick")
+        assert panel.is_visible()
+
+    def test_drift_badge_hidden_on_load(self, ui_page):
+        """Drift badge should be hidden (or absent) on initial page load.
+
+        If #driftBadge exists in the DOM it must start in a hidden state
+        so as not to display stale warnings before any validation has run.
+        """
+        badge = ui_page.locator("#driftBadge")
+        if badge.count() > 0:
+            assert badge.is_hidden(), (
+                "driftBadge should be hidden (display:none) on initial page load"
+            )
+        # If element is absent, the test passes — drift feature not yet deployed
+
+    def test_drift_badge_not_visible_without_validation(self, ui_page):
+        """Drift badge should not be visible in the Quick Test panel before running validation."""
+        badge = ui_page.locator("#driftBadge")
+        # Either absent from DOM or hidden — both are acceptable initial states
+        if badge.count() > 0:
+            is_visible = badge.is_visible()
+            assert not is_visible, (
+                "driftBadge should not be visible before any validation has run"
+            )
+
+    def test_drift_badge_hidden_after_file_upload(self, ui_page, sample_pipe_file):
+        """Uploading a new file should not show the drift badge."""
+        ui_page.locator("#fileInput").set_input_files(str(sample_pipe_file))
+        ui_page.wait_for_timeout(500)
+
+        badge = ui_page.locator("#driftBadge")
+        if badge.count() > 0:
+            assert badge.is_hidden(), (
+                "driftBadge should remain hidden when a new file is uploaded "
+                "(drift check only runs after validation)"
+            )
+
+    def test_drift_badge_id_present_when_feature_active(self, ui_page):
+        """When the drift feature is active, #driftBadge should be in the DOM.
+
+        This test acts as a canary — if drift detection is deployed but the
+        element ID is missing, the test fails to alert developers.
+        """
+        # Check if drift-related content is present anywhere in the panel
+        panel = ui_page.locator("#panel-quick")
+        panel_html = ui_page.evaluate("document.getElementById('panel-quick')?.innerHTML || ''")
+
+        if "drift" in panel_html.lower():
+            # Drift feature is active — the badge element should be present
+            badge = ui_page.locator("#driftBadge")
+            assert badge.count() > 0, (
+                "drift content detected in panel but #driftBadge element not found — "
+                "check that the element ID matches the expected 'driftBadge'"
+            )
+
+    def test_quick_test_panel_no_unexpected_errors_on_load(self, ui_page):
+        """Quick Test panel should load cleanly with no JS console errors blocking UI."""
+        panel = ui_page.locator("#panel-quick")
+        assert panel.is_visible()
+        # Primary functional elements should still be present regardless of drift feature state
+        assert ui_page.locator("#fileInput").count() > 0, "fileInput must be present"
+        assert ui_page.locator("#btnValidate").count() > 0, "btnValidate must be present"

--- a/tests/e2e/test_e2e_help_sidebar.py
+++ b/tests/e2e/test_e2e_help_sidebar.py
@@ -1,0 +1,131 @@
+"""E2E tests for the help sidebar in the Valdo UI (#274)."""
+
+import pytest
+
+
+class TestHelpSidebar:
+    """Help sidebar E2E tests.
+
+    The help sidebar is opened by the '?' button (#btnHelp) in the page header.
+    It contains a search input (#helpSearch) and a body div (#helpBody).
+    Closing is handled by '#btnHelpClose' or clicking the overlay (#helpOverlay).
+    """
+
+    def test_help_button_visible_in_header(self, ui_page):
+        """The '?' help button should be visible in the page header."""
+        btn = ui_page.locator("#btnHelp")
+        assert btn.count() > 0, "btnHelp should be in the DOM"
+        assert btn.is_visible(), "btnHelp should be visible in the header"
+
+    def test_help_button_has_accessible_label(self, ui_page):
+        """Help button should have an aria-label for screen readers."""
+        btn = ui_page.locator("#btnHelp")
+        aria_label = btn.get_attribute("aria-label") or ""
+        assert len(aria_label) > 0, "btnHelp should have a non-empty aria-label"
+
+    def test_help_sidebar_exists_in_dom(self, ui_page):
+        """Help sidebar element (#helpSidebar) should be in the DOM."""
+        sidebar = ui_page.locator("#helpSidebar")
+        assert sidebar.count() > 0, "helpSidebar should be present in the DOM"
+
+    def test_help_sidebar_hidden_on_load(self, ui_page):
+        """Help sidebar should NOT be open on initial page load."""
+        sidebar = ui_page.locator("#helpSidebar")
+        # Sidebar starts without the 'open' class — it should not be positioned visibly
+        # Check that it does not have the open/active state class
+        class_attr = sidebar.get_attribute("class") or ""
+        assert "open" not in class_attr, (
+            "helpSidebar should not have 'open' class on initial page load"
+        )
+
+    def test_clicking_help_button_opens_sidebar(self, ui_page):
+        """Clicking the '?' button should open the help sidebar."""
+        ui_page.locator("#btnHelp").click()
+        ui_page.wait_for_timeout(500)
+
+        sidebar = ui_page.locator("#helpSidebar")
+        class_attr = sidebar.get_attribute("class") or ""
+        assert "open" in class_attr, (
+            "helpSidebar should have 'open' class after clicking btnHelp"
+        )
+
+    def test_help_search_input_exists(self, ui_page):
+        """Help search input (#helpSearch) should be present in the sidebar."""
+        search = ui_page.locator("#helpSearch")
+        assert search.count() > 0, "helpSearch input should be in the DOM"
+
+    def test_help_search_visible_when_sidebar_open(self, ui_page):
+        """Search input should be visible after the sidebar is opened."""
+        ui_page.locator("#btnHelp").click()
+        ui_page.wait_for_timeout(500)
+
+        search = ui_page.locator("#helpSearch")
+        assert search.is_visible(), "helpSearch should be visible when sidebar is open"
+
+    def test_help_close_button_exists(self, ui_page):
+        """Close button (#btnHelpClose) should be present inside the sidebar."""
+        close_btn = ui_page.locator("#btnHelpClose")
+        assert close_btn.count() > 0, "btnHelpClose should be in the DOM"
+
+    def test_clicking_close_button_dismisses_sidebar(self, ui_page):
+        """Clicking the close button should dismiss the help sidebar."""
+        # Open the sidebar first
+        ui_page.locator("#btnHelp").click()
+        ui_page.wait_for_timeout(500)
+
+        sidebar = ui_page.locator("#helpSidebar")
+        assert "open" in (sidebar.get_attribute("class") or ""), (
+            "Sidebar should be open before testing close"
+        )
+
+        # Close it
+        ui_page.locator("#btnHelpClose").click()
+        ui_page.wait_for_timeout(500)
+
+        class_attr = sidebar.get_attribute("class") or ""
+        assert "open" not in class_attr, (
+            "helpSidebar should not have 'open' class after clicking btnHelpClose"
+        )
+
+    def test_help_overlay_exists(self, ui_page):
+        """Help overlay element (#helpOverlay) should be in the DOM."""
+        overlay = ui_page.locator("#helpOverlay")
+        assert overlay.count() > 0, "helpOverlay should be present in the DOM"
+
+    def test_help_body_exists(self, ui_page):
+        """Help sidebar body (#helpBody) should be present for content rendering."""
+        body = ui_page.locator("#helpBody")
+        assert body.count() > 0, "helpBody should be present in the DOM"
+
+    def test_help_search_is_typeable(self, ui_page):
+        """Typing into the help search input should work without errors."""
+        ui_page.locator("#btnHelp").click()
+        ui_page.wait_for_timeout(500)
+
+        search = ui_page.locator("#helpSearch")
+        search.fill("validate")
+        ui_page.wait_for_timeout(300)
+
+        value = search.input_value()
+        assert value == "validate", (
+            f"helpSearch input should contain 'validate' after typing, got: '{value}'"
+        )
+
+    def test_overlay_click_dismisses_sidebar(self, ui_page):
+        """Clicking the overlay should dismiss the help sidebar."""
+        ui_page.locator("#btnHelp").click()
+        ui_page.wait_for_timeout(500)
+
+        sidebar = ui_page.locator("#helpSidebar")
+        assert "open" in (sidebar.get_attribute("class") or ""), (
+            "Sidebar should be open before testing overlay dismiss"
+        )
+
+        # Click the overlay to close
+        ui_page.locator("#helpOverlay").click()
+        ui_page.wait_for_timeout(500)
+
+        class_attr = sidebar.get_attribute("class") or ""
+        assert "open" not in class_attr, (
+            "helpSidebar should close when the overlay is clicked"
+        )

--- a/tests/e2e/test_e2e_multi_record_validate.py
+++ b/tests/e2e/test_e2e_multi_record_validate.py
@@ -1,0 +1,100 @@
+"""E2E tests for multi-record YAML upload in Quick Test tab (#274)."""
+
+import pytest
+
+
+class TestMultiRecordValidate:
+    """Multi-record YAML section in Quick Test tab E2E tests.
+
+    The Quick Test panel includes a file input (#qtMrYamlInput) that lets
+    users upload a multi-record YAML config as an alternative to selecting
+    a mapping. This section is always visible — not hidden behind a toggle.
+    """
+
+    def test_quick_test_panel_active(self, ui_page):
+        """Quick Test tab should be active on load."""
+        tab = ui_page.locator("#tab-quick")
+        assert tab.get_attribute("aria-selected") == "true"
+        panel = ui_page.locator("#panel-quick")
+        assert panel.is_visible()
+
+    def test_mr_yaml_input_exists(self, ui_page):
+        """Multi-record YAML file input (#qtMrYamlInput) should be in the DOM."""
+        yaml_input = ui_page.locator("#qtMrYamlInput")
+        assert yaml_input.count() > 0, "qtMrYamlInput should exist in Quick Test panel"
+
+    def test_mr_yaml_section_label_visible(self, ui_page):
+        """The Multi-record YAML label should be visible in Quick Test."""
+        panel = ui_page.locator("#panel-quick")
+        text = panel.text_content().lower()
+        assert "multi-record" in text or "yaml" in text, (
+            "Quick Test panel should mention multi-record YAML"
+        )
+
+    def test_mr_yaml_input_accepts_yaml_files(self, ui_page):
+        """qtMrYamlInput should accept .yaml and .yml file types."""
+        yaml_input = ui_page.locator("#qtMrYamlInput")
+        assert yaml_input.count() > 0, "qtMrYamlInput should exist"
+        accept = yaml_input.get_attribute("accept") or ""
+        assert ".yaml" in accept or ".yml" in accept, (
+            "qtMrYamlInput should accept .yaml or .yml files"
+        )
+
+    def test_validate_button_exists_in_quick_test(self, ui_page):
+        """The primary Validate button (#btnValidate) should be present."""
+        btn = ui_page.locator("#btnValidate")
+        assert btn.count() > 0, "btnValidate should be in Quick Test panel"
+        assert btn.is_visible()
+
+    def test_validate_button_disabled_without_file(self, ui_page):
+        """Validate button should be disabled when no batch file is uploaded."""
+        btn = ui_page.locator("#btnValidate")
+        assert btn.is_disabled(), (
+            "btnValidate should be disabled until a batch file is uploaded"
+        )
+
+    def test_upload_batch_file_enables_validate(self, ui_page, sample_pipe_file):
+        """Uploading a batch file should enable the Validate button."""
+        ui_page.locator("#fileInput").set_input_files(str(sample_pipe_file))
+        ui_page.wait_for_timeout(500)
+
+        btn = ui_page.locator("#btnValidate")
+        # The button should become enabled (or at least clickable via force) after upload
+        is_disabled = btn.is_disabled()
+        assert not is_disabled, (
+            "btnValidate should be enabled after uploading a batch file"
+        )
+
+    def test_toggle_mr_yaml_button_optional(self, ui_page):
+        """If a btnToggleMrYaml exists, clicking it should reveal the YAML section."""
+        # This element may exist in future versions — test defensively
+        toggle_btn = ui_page.locator("#btnToggleMrYaml")
+        if toggle_btn.count() > 0:
+            toggle_btn.click()
+            ui_page.wait_for_timeout(500)
+            yaml_section = ui_page.locator("#mrYamlSection")
+            assert yaml_section.count() > 0, (
+                "mrYamlSection should appear after clicking btnToggleMrYaml"
+            )
+        else:
+            # No toggle button — YAML input is always visible inline
+            yaml_input = ui_page.locator("#qtMrYamlInput")
+            assert yaml_input.count() > 0, (
+                "qtMrYamlInput should be present as inline YAML input"
+            )
+
+    def test_mr_yaml_section_link_to_mapping_generator(self, ui_page):
+        """The YAML section should link to the Mapping Generator tab."""
+        panel = ui_page.locator("#panel-quick")
+        # Look for a link that mentions Mapping Generator
+        links = panel.locator("a")
+        found_mapping_link = False
+        count = links.count()
+        for i in range(count):
+            text = links.nth(i).text_content().lower()
+            if "mapping" in text or "generator" in text:
+                found_mapping_link = True
+                break
+        assert found_mapping_link, (
+            "Quick Test panel should have a link to the Mapping Generator tab"
+        )

--- a/tests/e2e/test_e2e_multi_record_wizard.py
+++ b/tests/e2e/test_e2e_multi_record_wizard.py
@@ -1,0 +1,132 @@
+"""E2E tests for the Multi-Record Config Wizard in the Mapping Generator tab (#274)."""
+
+import pytest
+
+
+class TestMultiRecordWizard:
+    """Multi-Record Config Wizard E2E tests.
+
+    The wizard lives in the Mapping Generator tab under the section with
+    id="mrWizardSection". It is toggled open by the "Start Wizard" button
+    (#mrToggleBtn) and collapsed by default.
+    """
+
+    def test_mapping_tab_loads(self, ui_page):
+        """Clicking Mapping Generator tab should show the panel."""
+        tab = ui_page.locator("#tab-mapping")
+        tab.click()
+        ui_page.wait_for_timeout(500)
+
+        assert tab.get_attribute("aria-selected") == "true"
+        panel = ui_page.locator("#panel-mapping")
+        assert panel.is_visible()
+
+    def test_wizard_section_exists_in_mapping_tab(self, ui_page):
+        """Mapping Generator panel should contain the wizard section."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+
+        section = ui_page.locator("#mrWizardSection")
+        assert section.count() > 0, "mrWizardSection should be in the DOM"
+
+    def test_wizard_toggle_button_exists(self, ui_page):
+        """Start Wizard button (#mrToggleBtn) should be present."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+
+        btn = ui_page.locator("#mrToggleBtn")
+        assert btn.count() > 0, "mrToggleBtn should be present in the wizard section"
+
+    def test_wizard_body_hidden_by_default(self, ui_page):
+        """Wizard body (#mrWizardBody) should be collapsed before toggling."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+
+        wizard_body = ui_page.locator("#mrWizardBody")
+        assert wizard_body.count() > 0, "mrWizardBody should be in the DOM"
+        # Body is collapsed by default (display:none)
+        assert wizard_body.is_hidden(), "Wizard body should be hidden on initial load"
+
+    def test_wizard_opens_on_toggle(self, ui_page):
+        """Clicking Start Wizard should expand the wizard body."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        wizard_body = ui_page.locator("#mrWizardBody")
+        assert wizard_body.is_visible(), "Wizard body should be visible after toggle"
+
+    def test_wizard_step_indicators_exist(self, ui_page):
+        """Wizard step indicators should be present once wizard is open."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        indicators = ui_page.locator("#mrStepIndicators")
+        assert indicators.count() > 0, "Step indicators container should exist"
+        steps = indicators.locator("button")
+        assert steps.count() >= 4, "Should have at least 4 step indicator buttons"
+
+    def test_wizard_next_button_exists(self, ui_page):
+        """Next navigation button should be present once wizard is open."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        next_btn = ui_page.locator("#mrNextBtn")
+        assert next_btn.count() > 0, "mrNextBtn should exist in the wizard"
+
+    def test_wizard_back_button_exists_in_dom(self, ui_page):
+        """Back navigation button should exist in the DOM (hidden on first step)."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        back_btn = ui_page.locator("#mrBackBtn")
+        assert back_btn.count() > 0, "mrBackBtn should exist in the DOM"
+
+    def test_wizard_step1_record_types_visible(self, ui_page):
+        """Step 1 panel should be visible when wizard first opens."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        step1 = ui_page.locator("#mrStep1")
+        assert step1.count() > 0, "mrStep1 panel should exist"
+        assert step1.is_visible(), "Step 1 should be visible on wizard open"
+
+    def test_wizard_download_button_exists(self, ui_page):
+        """Download YAML button should exist in the wizard's preview step."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        download_btn = ui_page.locator("#mrDownloadBtn")
+        assert download_btn.count() > 0, "mrDownloadBtn should be in the DOM"
+
+    def test_wizard_validate_button_exists(self, ui_page):
+        """Validate File With This Config button should exist in the wizard."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        validate_btn = ui_page.locator("#mrValidateBtn")
+        assert validate_btn.count() > 0, "mrValidateBtn should be in the DOM"
+
+    def test_wizard_generate_yaml_button_exists(self, ui_page):
+        """Generate YAML button should exist in the wizard's preview step."""
+        ui_page.locator("#tab-mapping").click()
+        ui_page.wait_for_timeout(500)
+        ui_page.locator("#mrToggleBtn").click()
+        ui_page.wait_for_timeout(500)
+
+        gen_btn = ui_page.locator("#mrGenerateBtn")
+        assert gen_btn.count() > 0, "mrGenerateBtn should be in the DOM"


### PR DESCRIPTION
## Summary

- Add 46 new Playwright E2E tests across 5 new test files, doubling E2E coverage from 46 to 92 tests
- All tests target `chromium` only and use the existing `ui_page` fixture from `conftest.py`
- Tests are written defensively with `.count() > 0` and `.is_hidden()` guards so they remain stable whether or not unreleased feature branches (`feat/drift-detection-cli-api-ui`, `feat/failed-rows-export`) have been merged

## New test files

| File | Tests | Coverage area |
|------|-------|---------------|
| `test_e2e_multi_record_wizard.py` | 12 | Mapping Generator wizard toggle, step indicators, nav buttons, generate/download/validate |
| `test_e2e_multi_record_validate.py` | 9 | `qtMrYamlInput` presence, accept attribute, Mapping Generator link, `btnValidate` enable/disable |
| `test_e2e_drift_badge.py` | 6 | `driftBadge` hidden by default, hidden on new file upload, canary for drift feature |
| `test_e2e_download_errors.py` | 6 | `btnDownloadErrors` hidden on load, hidden on new upload, canary for failed-rows feature |
| `test_e2e_help_sidebar.py` | 13 | `btnHelp` visibility/aria-label, sidebar open/close via button and overlay, search input typeable |

## Key implementation decisions

- **Element IDs verified against `ui.html`** before writing selectors — no guessed selectors
- **`#btnValidate` ID selector** used throughout (not `button:has-text('Validate')`) per the constraint that two Validate buttons now exist in the UI
- **Defensive guards** on `driftBadge` and `btnDownloadErrors` since those elements live on feature branches not yet merged — tests pass whether elements are present or absent
- **Help sidebar** open/close confirmed against `ui.js` implementation (`classList.add('open')` / `classList.remove('open')`) to ensure class-based assertions are accurate

## Test plan

- [ ] Run `python3 -m pytest tests/e2e/ --browser chromium -q --ignore=tests/e2e/test_e2e_multi_record_wizard.py` — all 80 non-wizard tests pass against a running server
- [ ] Run with wizard file included once server confirms wizard tab is active
- [ ] Verify 92 total tests collected: `python3 -m pytest tests/e2e/ --collect-only -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)