### PR TITLE
fix(tests): capture env before yield in downloader test fixture

### DIFF
--- a/tests/unit/test_downloader_router.py
+++ b/tests/unit/test_downloader_router.py
@@ -16,19 +16,15 @@ from fastapi.testclient import TestClient
 def _reset_app_module():
     """Reload src.api.main after each test to prevent auth state leaking.
 
-    When a test calls reload(src.api.main) with API_KEYS set, the module
-    captures that state and remains in sys.modules. This fixture ensures
-    the module is reloaded with a clean environment after each test,
-    preventing auth state from leaking to subsequent tests.
+    Captures the environment BEFORE the test runs so the restore snapshot
+    never contains test-injected API_KEYS or ENABLE_FILE_DOWNLOADER values.
     """
+    saved = os.environ.copy()
     yield
-    saved = {k: v for k, v in os.environ.items()}
-    os.environ.pop("API_KEYS", None)
-    os.environ.pop("ENABLE_FILE_DOWNLOADER", None)
     import src.api.main as _m
-    importlib.reload(_m)
     os.environ.clear()
     os.environ.update(saved)
+    importlib.reload(_m)
 
 
 def _make_client(tmp_path: Path, env: dict, allowed_path: str = None):


### PR DESCRIPTION
## Summary

- The `_reset_app_module` autouse fixture in `test_downloader_router.py` was capturing `os.environ` **after** the test ran (post-`yield`)
- Any `API_KEYS` set during the test ended up in the snapshot, which was then restored — perpetuating the leak into subsequent test files
- Fix: move `saved = os.environ.copy()` to **before** `yield` so the clean pre-test state is always restored

## Test plan

- [ ] Confirm CI passes (no more `403` errors in `test_mapping_upload`, `test_negative_api`, `test_exploratory_boundaries`, etc.)
- [ ] All downloader tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)