### PR TITLE
fix(tests): make _ts() relative to utcnow() in summary service tests

### DIFF
--- a/tests/unit/test_downloader_router.py
+++ b/tests/unit/test_downloader_router.py
@@ -16,19 +16,15 @@ from fastapi.testclient import TestClient
 def _reset_app_module():
     """Reload src.api.main after each test to prevent auth state leaking.
 
-    When a test calls reload(src.api.main) with API_KEYS set, the module
-    captures that state and remains in sys.modules. This fixture ensures
-    the module is reloaded with a clean environment after each test,
-    preventing auth state from leaking to subsequent tests.
+    Captures the environment BEFORE the test runs so the restore snapshot
+    never contains test-injected API_KEYS or ENABLE_FILE_DOWNLOADER values.
     """
+    saved = os.environ.copy()
     yield
-    saved = {k: v for k, v in os.environ.items()}
-    os.environ.pop("API_KEYS", None)
-    os.environ.pop("ENABLE_FILE_DOWNLOADER", None)
     import src.api.main as _m
-    importlib.reload(_m)
     os.environ.clear()
     os.environ.update(saved)
+    importlib.reload(_m)
 
 
 def _make_client(tmp_path: Path, env: dict, allowed_path: str = None):

--- a/tests/unit/test_summary_service.py
+++ b/tests/unit/test_summary_service.py
@@ -55,9 +55,12 @@ def _make_entry(
 
 
 def _ts(days_ago: int) -> str:
-    """Return ISO timestamp string for N days ago from 2026-03-31."""
-    base = datetime(2026, 3, 31, 12, 0, 0)
-    return (base - timedelta(days=days_ago)).isoformat()
+    """Return ISO timestamp string for N days and 1 minute ago from now.
+
+    The extra minute ensures ``_ts(7)`` falls just past the 7-day cutoff
+    (into the prior-7-day window) even if the test runs near midnight.
+    """
+    return (datetime.utcnow() - timedelta(days=days_ago, minutes=1)).isoformat()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_ts()` in `test_summary_service.py` was anchored to a hardcoded date (`2026-03-31`)
- The service computes 7-day/14-day windows from `datetime.utcnow()`, so once the current date moved past the anchor, test data fell outside the expected windows and `trend_direction` returned `"flat"` instead of `"up"`/`"down"`
- Fix: `_ts(days_ago)` now returns `utcnow() - timedelta(days=days_ago, minutes=1)`, keeping data in the correct windows regardless of when tests run

## Test plan

- [ ] `test_trend_up_when_recent_pass_rate_higher` passes
- [ ] `test_trend_down_when_recent_pass_rate_lower` passes
- [ ] All 15 summary service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)