### PR TITLE
fix(ci): correct CLI name and mapping ID in E2E + reconcile job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           ORACLE_DSN: ${{ secrets.ORACLE_DSN }}
         run: |
           mkdir -p reports
-          cm3-batch reconcile-all -d config/mappings -o reports/reconcile_all.json
+          valdo reconcile-all -d config/mappings -o reports/reconcile_all.json
 
   e2e:
     runs-on: ubuntu-latest

--- a/scripts/e2e_full_ui.py
+++ b/scripts/e2e_full_ui.py
@@ -135,7 +135,7 @@ def workflow_quick_test(page: Page, out_dir: Path) -> None:
     ))
 
     step(tag, "select customer_mapping", page, out_dir, lambda: (
-        page.locator("#mappingSelect").select_option(value="customer_mapping"),
+        page.locator("#mappingSelect").select_option(value="customer_file_to_db"),
         page.wait_for_timeout(300),
     ))
 


### PR DESCRIPTION
## Summary

Two pre-existing CI failures fixed:

**1. reconcile-check — `cm3-batch: command not found`**
- The reconcile job called `cm3-batch reconcile-all` but the package installs the CLI as `valdo` (see `setup.py` entry point)
- Fixed: `valdo reconcile-all -d config/mappings -o reports/reconcile_all.json`

**2. E2E — `quick-test — select customer_mapping` (+ 3 cascading failures)**
- `customer_mapping.json` has `mapping_name: "customer_file_to_db"`, which is what the API returns as the option `value` in the dropdown
- The E2E test used `select_option(value="customer_mapping")` which never matched
- Fixed: `select_option(value="customer_file_to_db")`
- Cascading failures that will also fix: `click Validate`, `assert inline report visible (customers)`, `reveal compare panel`

## Test plan

- [ ] reconcile-check no longer exits 127
- [ ] `quick-test — select customer_mapping` and its 3 cascading steps all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)