### PR TITLE
fix(e2e): use customer_batch_universal mapping in quick-test

### DIFF
--- a/scripts/e2e_full_ui.py
+++ b/scripts/e2e_full_ui.py
@@ -134,8 +134,8 @@ def workflow_quick_test(page: Page, out_dir: Path) -> None:
         page.wait_for_timeout(600),
     ))
 
-    step(tag, "select customer_mapping", page, out_dir, lambda: (
-        page.locator("#mappingSelect").select_option(value="customer_file_to_db"),
+    step(tag, "select customer_batch_universal mapping", page, out_dir, lambda: (
+        page.locator("#mappingSelect").select_option(value="customer_batch_universal"),
         page.wait_for_timeout(300),
     ))
 


### PR DESCRIPTION
## Summary

`customer_mapping.json` has no `fields` key, so `list_mappings` silently skips it (the API does `len(mapping['fields'])` inside a `try/except Exception: continue`). It never appears in the UI dropdown.

`customer_batch_universal` has the required structure (`fields` + `source.format`), is pipe-delimited (matches `data/samples/customers.txt`), and is returned by the API.

This is the real fix for the 4 cascading quick-test failures — PR #329 used `customer_file_to_db` which is the `mapping_name` inside `customer_mapping.json`, but that file never makes it into the dropdown.

## Test plan

- [ ] `quick-test — select customer_batch_universal mapping` passes
- [ ] `click Validate`, `assert inline report visible`, `reveal compare panel` all pass as cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)