### PR TITLE
fix(e2e): check #dropZone2 visibility when revealing compare panel

### DIFF
--- a/scripts/e2e_full_ui.py
+++ b/scripts/e2e_full_ui.py
@@ -187,7 +187,7 @@ def workflow_quick_test(page: Page, out_dir: Path) -> None:
     step(tag, "reveal compare panel", page, out_dir, lambda: (
         page.locator("#btnToggleCompare").click(),
         page.wait_for_timeout(500),
-        pw_expect(page.locator("#fileInput2")).to_be_visible(),
+        pw_expect(page.locator("#dropZone2")).to_be_visible(),
     ))
 
     step(tag, "upload customers_updated.txt", page, out_dir, lambda: (


### PR DESCRIPTION
## Summary

`input[type="file"]` elements are always `display: none` (CSS rule in `ui.css:248`). `pw_expect(#fileInput2).to_be_visible()` always fails regardless of whether the compare section is actually open.

Fix: check `#dropZone2` instead — it's the visible drop-zone UI that becomes visible when `#compare-section` gets the `.visible` class after clicking `#btnToggleCompare`.

## Test plan

- [ ] `quick-test — reveal compare panel` passes in E2E CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)