### PR TITLE
feat(downloader): subdirectory drill-down navigation with breadcrumb

### DIFF
--- a/src/reports/static/ui.css
+++ b/src/reports/static/ui.css
@@ -1946,6 +1946,17 @@
   color:var(--text-primary); font-family:monospace;
 }
 
+.fd-breadcrumb {
+  font-size:12px; padding:4px 0 6px; color:var(--text-secondary);
+  min-height:18px;
+}
+.fd-bc-sep { color:var(--text-secondary); }
+.fd-bc-link {
+  cursor:pointer; color:var(--accent); text-decoration:underline;
+}
+.fd-bc-link:hover { opacity:0.8; }
+.fd-bc-current { color:var(--text-primary); font-weight:600; }
+
 .fd-truncation-warn {
   display:flex; align-items:center; gap:10px; padding:8px 12px;
   background:var(--surface); border:1px solid #f59e0b;

--- a/src/reports/static/ui.html
+++ b/src/reports/static/ui.html
@@ -934,6 +934,7 @@
                placeholder="e.g. batch_*.tar.gz  (leave blank for plain files)">
         <button class="btn btn-secondary" onclick="fdBrowse()">Browse</button>
       </div>
+      <div id="fdBreadcrumb" class="fd-breadcrumb" aria-label="Current browse path"></div>
       <div id="fdBrowseResults" class="fd-results" aria-live="polite"></div>
     </div>
 

--- a/src/reports/static/ui.js
+++ b/src/reports/static/ui.js
@@ -79,6 +79,7 @@ function initTabVisibility() {
 // File Downloader Tab
 // ===========================================================================
 var _fdPaths = [];
+var _fdCurrentPath = null;
 
 /**
  * Return authentication headers for API requests.
@@ -138,10 +139,13 @@ function loadDownloaderPaths() {
  * Clear browse/search result panels when the selected path changes.
  */
 function onFdPathChange() {
+  _fdCurrentPath = null;
   ['fdBrowseResults', 'fdSearchResults', 'fdArchSearchResults'].forEach(function(id) {
     var el = document.getElementById(id);
     if (el) el.textContent = '';
   });
+  var bc = document.getElementById('fdBreadcrumb');
+  if (bc) bc.textContent = '';
 }
 
 /**
@@ -174,19 +178,36 @@ function _fdFormatBytes(bytes) {
 }
 
 /**
- * List files in the selected path and render them in #fdBrowseResults.
+ * List files in the selected root path and render them in #fdBrowseResults.
  *
- * Reads the optional archive pattern from #fdArchivePattern. Shows a loading
- * indicator while the request is in flight and an error message on failure.
+ * Reads the optional archive pattern from #fdArchivePattern. Resets the
+ * current sub-path state and breadcrumb back to the root before browsing.
  */
 function fdBrowse() {
   var path = document.getElementById('fdPathSelect').value;
   if (!path) { alert('Please select a path first.'); return; }
   var pattern = document.getElementById('fdArchivePattern').value.trim() || null;
-  var url = '/api/v1/downloader/browse?path=' + encodeURIComponent(path);
-  if (pattern) url += '&pattern=' + encodeURIComponent(pattern);
+  _fdCurrentPath = path;
+  _fdBrowseDir(path, pattern);
+}
+
+/**
+ * Browse a specific directory path and render results in #fdBrowseResults.
+ *
+ * Updates the breadcrumb to reflect the current location. Called by fdBrowse
+ * for the root and by directory entry clicks when drilling into sub-folders.
+ *
+ * @param {string}  dirPath - Absolute filesystem path to browse.
+ * @param {string|null} pattern - Optional fnmatch pattern for file filtering.
+ */
+function _fdBrowseDir(dirPath, pattern) {
+  var rootPath = document.getElementById('fdPathSelect').value;
   var container = document.getElementById('fdBrowseResults');
   container.textContent = 'Loading\u2026';
+  _fdRenderBreadcrumb(rootPath, dirPath, pattern);
+
+  var url = '/api/v1/downloader/browse?path=' + encodeURIComponent(dirPath);
+  if (pattern) url += '&pattern=' + encodeURIComponent(pattern);
 
   fetch(url, { headers: _apiHeaders() })
     .then(function(r) { return r.ok ? r.json() : Promise.reject(r.status); })
@@ -197,7 +218,7 @@ function fdBrowse() {
         return;
       }
       data.entries.forEach(function(entry) {
-        container.appendChild(_fdRenderEntry(entry, path));
+        container.appendChild(_fdRenderEntry(entry, dirPath, pattern));
       });
     })
     .catch(function(err) {
@@ -206,18 +227,87 @@ function fdBrowse() {
 }
 
 /**
- * Build a DOM row for a single browse entry (file or archive).
+ * Update the #fdBreadcrumb bar to show the current location within rootPath.
+ *
+ * Each ancestor segment is rendered as a clickable link. The current
+ * (leaf) segment is rendered as plain text.
+ *
+ * @param {string}      rootPath    - The configured root (from #fdPathSelect).
+ * @param {string}      currentPath - The path being browsed (rootPath or deeper).
+ * @param {string|null} pattern     - Pattern forwarded to _fdBrowseDir on click.
+ */
+function _fdRenderBreadcrumb(rootPath, currentPath, pattern) {
+  var bc = document.getElementById('fdBreadcrumb');
+  if (!bc) return;
+  bc.textContent = '';
+
+  var rel = (currentPath.indexOf(rootPath) === 0) ? currentPath.slice(rootPath.length) : '';
+  var segments = rel.split('/').filter(function(s) { return s.length > 0; });
+
+  var rootSpan = document.createElement('span');
+  rootSpan.className = 'fd-bc-seg fd-bc-link';
+  rootSpan.textContent = '/';
+  rootSpan.setAttribute('title', rootPath);
+  rootSpan.onclick = function() { _fdBrowseDir(rootPath, pattern); };
+  bc.appendChild(rootSpan);
+
+  var accPath = rootPath;
+  segments.forEach(function(seg, i) {
+    accPath = accPath + '/' + seg;
+    var sep = document.createElement('span');
+    sep.className = 'fd-bc-sep';
+    sep.textContent = ' / ';
+    bc.appendChild(sep);
+
+    var segSpan = document.createElement('span');
+    segSpan.textContent = seg;
+    if (i === segments.length - 1) {
+      segSpan.className = 'fd-bc-seg fd-bc-current';
+    } else {
+      segSpan.className = 'fd-bc-seg fd-bc-link';
+      var segPath = accPath;
+      segSpan.onclick = function() { _fdBrowseDir(segPath, pattern); };
+    }
+    bc.appendChild(segSpan);
+  });
+}
+
+/**
+ * Build a DOM row for a single browse entry (file, archive, or directory).
  *
  * All server-provided strings (name, type, size) are assigned via textContent
  * to prevent XSS.
  *
- * @param {Object} entry - Entry object with name, type, and size_bytes fields.
- * @param {string} path  - The selected path alias used for download requests.
+ * @param {Object}      entry   - Entry object with name, type, and size_bytes.
+ * @param {string}      path    - The current browsed path (for download/drill-down).
+ * @param {string|null} pattern - Active file pattern (forwarded on drill-down).
  * @returns {HTMLElement} A div element representing the entry row.
  */
-function _fdRenderEntry(entry, path) {
+function _fdRenderEntry(entry, path, pattern) {
   var row = document.createElement('div');
   row.className = 'fd-entry';
+
+  if (entry.type === 'directory') {
+    var nameEl = document.createElement('span');
+    nameEl.className = 'fd-entry-name';
+    nameEl.textContent = '\uD83D\uDCC1  ' + entry.name;
+
+    var meta = document.createElement('span');
+    meta.className = 'fd-entry-meta';
+    meta.textContent = 'directory';
+
+    var openBtn = document.createElement('button');
+    openBtn.className = 'btn btn-secondary';
+    openBtn.style.cssText = 'font-size:11px;padding:3px 10px';
+    openBtn.textContent = '\u25B6 Open';
+    var subPath = path + '/' + entry.name;
+    openBtn.onclick = function() { _fdBrowseDir(subPath, pattern); };
+
+    row.appendChild(nameEl);
+    row.appendChild(meta);
+    row.appendChild(openBtn);
+    return row;
+  }
 
   var nameEl = document.createElement('span');
   nameEl.className = 'fd-entry-name';

--- a/src/services/downloader_service.py
+++ b/src/services/downloader_service.py
@@ -17,11 +17,11 @@ def _is_archive(name: str) -> bool:
 
 @dataclass
 class BrowseEntry:
-    """A file or archive entry returned by browse_path."""
+    """A file, archive, or directory entry returned by browse_path."""
 
     name: str
-    type: Literal["plain", "archive"]
-    size_bytes: int
+    type: Literal["plain", "archive", "directory"]
+    size_bytes: Optional[int] = None
 
 
 @dataclass
@@ -78,28 +78,36 @@ def validate_path(requested: str, allowed_paths: list[str]) -> Path:
 
 
 def browse_path(path: Path, pattern: Optional[str] = None) -> list:
-    """List files in *path*, optionally filtered by *pattern*.
+    """List files and subdirectories in *path*, optionally filtering files by *pattern*.
+
+    Subdirectories are always included (pattern does not apply to them) and
+    are sorted before files so dated folders (e.g. ``20260406/``) appear at
+    the top of the results.
 
     Args:
         path: Directory to list (already validated).
-        pattern: Optional ``fnmatch`` wildcard (e.g. ``"batch_*.tar.gz"``).
+        pattern: Optional ``fnmatch`` wildcard applied to files only
+            (e.g. ``"batch_*.tar.gz"``).  Directories are never filtered.
 
     Returns:
-        Sorted list of :class:`BrowseEntry` objects (directories excluded).
+        Sorted list of :class:`BrowseEntry` objects — directories first,
+        then files.
     """
     if not path.exists():
         raise FileNotFoundError(f"Directory not found: {path}")
     if not path.is_dir():
         raise NotADirectoryError(f"Not a directory: {path}")
-    entries: list[BrowseEntry] = []
+    dirs: list[BrowseEntry] = []
+    files: list[BrowseEntry] = []
     for item in sorted(path.iterdir()):
-        if not item.is_file():
-            continue
-        if pattern and not fnmatch.fnmatch(item.name, pattern):
-            continue
-        entry_type: Literal["plain", "archive"] = "archive" if _is_archive(item.name) else "plain"
-        entries.append(BrowseEntry(name=item.name, type=entry_type, size_bytes=item.stat().st_size))
-    return entries
+        if item.is_dir():
+            dirs.append(BrowseEntry(name=item.name, type="directory", size_bytes=None))
+        elif item.is_file():
+            if pattern and not fnmatch.fnmatch(item.name, pattern):
+                continue
+            entry_type: Literal["plain", "archive"] = "archive" if _is_archive(item.name) else "plain"
+            files.append(BrowseEntry(name=item.name, type=entry_type, size_bytes=item.stat().st_size))
+    return dirs + files
 
 
 def list_archive_contents(archive_path: Path) -> list:

--- a/tests/unit/test_downloader_service.py
+++ b/tests/unit/test_downloader_service.py
@@ -58,6 +58,42 @@ def test_browse_identifies_archives(tmp_path):
     assert types["c.tgz"] == "archive"
 
 
+def test_browse_includes_subdirectories(tmp_path):
+    (tmp_path / "20260406").mkdir()
+    (tmp_path / "20260405").mkdir()
+    (tmp_path / "report.txt").write_text("x")
+    entries = browse_path(tmp_path)
+    types = {e.name: e.type for e in entries}
+    assert types["20260406"] == "directory"
+    assert types["20260405"] == "directory"
+    assert types["report.txt"] == "plain"
+
+
+def test_browse_directories_sorted_before_files(tmp_path):
+    (tmp_path / "z_dir").mkdir()
+    (tmp_path / "a_file.txt").write_text("x")
+    entries = browse_path(tmp_path)
+    names = [e.name for e in entries]
+    assert names.index("z_dir") < names.index("a_file.txt")
+
+
+def test_browse_pattern_does_not_filter_directories(tmp_path):
+    (tmp_path / "20260406").mkdir()
+    (tmp_path / "batch_01.tar.gz").write_bytes(b"x")
+    (tmp_path / "unrelated.txt").write_text("x")
+    entries = browse_path(tmp_path, pattern="batch_*.tar.gz")
+    names = [e.name for e in entries]
+    assert "20260406" in names
+    assert "batch_01.tar.gz" in names
+    assert "unrelated.txt" not in names
+
+
+def test_browse_directory_entry_has_no_size(tmp_path):
+    (tmp_path / "subdir").mkdir()
+    entry = next(e for e in browse_path(tmp_path) if e.name == "subdir")
+    assert entry.size_bytes is None
+
+
 def test_browse_wildcard_filter(tmp_path):
     (tmp_path / "batch_01.tar.gz").write_bytes(b"x")
     (tmp_path / "unrelated.txt").write_text("x")


### PR DESCRIPTION
## Summary

- **Backend** (`downloader_service.py`): `BrowseEntry.type` now includes `"directory"`; `browse_path` returns directories before files; pattern filter only applies to files, not directories. 4 new unit tests (30 total).
- **UI** (`ui.js`): `_fdRenderEntry` handles `type='directory'` with a folder icon and **Open** button that drills into the subdirectory. `fdBrowse()` resets to root; new `_fdBrowseDir(dirPath, pattern)` fetches any path. New `_fdRenderBreadcrumb()` renders clickable path segments above results so users can navigate back up.
- **CSS** (`ui.css`): breadcrumb styles (`.fd-breadcrumb`, `.fd-bc-link`, `.fd-bc-current`).
- **HTML** (`ui.html`): `#fdBreadcrumb` div inserted above `#fdBrowseResults`.

## Test plan

- [ ] Select a configured path in the File Downloader tab, click Browse — directories (e.g. `20260406/`) appear first with folder icons
- [ ] Click **Open** on a dated directory — results refresh with contents of that subdirectory; breadcrumb shows `/ / 20260406`
- [ ] Click the `/` breadcrumb segment — returns to root listing
- [ ] Changing the path dropdown clears breadcrumb and results
- [ ] Pattern filter (e.g. `batch_*.tar.gz`) still excludes non-matching files inside subdirectories, but directories always show
- [ ] All 30 unit tests pass: `pytest tests/unit/test_downloader_service.py -q`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)