### PR TITLE
docs(downloader): subdirectory navigation docs + test count update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - API: `src/api/main.py` (FastAPI app at port 8000)
 - Web UI: `src/reports/static/ui.html` (served at `/ui`)
 
-**Test suite:** 1730 unit tests + 106 E2E Playwright tests = 1836 total, 80% coverage
+**Test suite:** 1836 unit tests + 125 E2E Playwright tests = 1961 total, 80% coverage
 
 **Active branch:** `main`
 

--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -546,7 +546,12 @@ tabs:
 
 #### Browse & Download
 
-Select a configured path, optionally filter by archive name pattern, then click Browse. Plain files have a direct Download button. Archives show an Expand button listing inner files — each has its own Download button. Whole-archive downloads are not permitted.
+Select a configured path, optionally filter by archive name pattern, then click Browse.
+
+- **Directories** (e.g. dated folders like `20260406/`) appear at the top of the listing with a folder icon and an **Open** button. Clicking Open drills into that subdirectory and updates the breadcrumb bar.
+- **Breadcrumb** — shows the current location relative to the configured root (e.g. `/ / 20260406`). Each segment is clickable to navigate back up.
+- **Plain files** have a direct Download button.
+- **Archives** show an Expand button that lists inner files — each inner file has its own Download button. Whole-archive downloads are not permitted.
 
 #### Search Files
 


### PR DESCRIPTION
## Summary

- Updates the **Browse & Download** section in `USAGE_AND_OPERATIONS_GUIDE.md` to document subdirectory drill-down and breadcrumb navigation (added in #334)
- Updates `CLAUDE.md` test counts: 1730 → 1836 unit, 106 → 125 E2E (reflects all tests added across recent PRs)
- Closes no additional issues — #332 and #333 were already closed after PR #334 merged

## Test plan

- [ ] Docs accurately describe folder icons, Open button, and breadcrumb behavior
- [ ] CLAUDE.md counts match `pytest tests/unit/ --co` (1836) and `pytest tests/e2e/ --co` (125)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)