### PR TITLE
fix(downloader): guard against path traversal in archive inner filenames

### DIFF
--- a/src/services/downloader_service.py
+++ b/src/services/downloader_service.py
@@ -1,6 +1,7 @@
 """File downloader service — path validation, browse, archive handling, and search."""
 
 import fnmatch
+import logging
 import tarfile
 import zipfile
 from dataclasses import dataclass, field
@@ -9,10 +10,29 @@ from typing import Iterator, Literal, Optional
 
 _ARCHIVE_SUFFIXES = (".tar.gz", ".tgz", ".zip")
 _MAX_SEARCH_RESULTS = 50
+_log = logging.getLogger(__name__)
 
 
 def _is_archive(name: str) -> bool:
     return any(name.endswith(s) for s in _ARCHIVE_SUFFIXES)
+
+
+def _safe_inner_path(name: str) -> bool:
+    """Return True if *name* is a safe archive inner path.
+
+    Rejects absolute paths, paths containing '..' components, and paths
+    containing null bytes to prevent path traversal attacks from crafted archives.
+
+    Args:
+        name: The inner path string from an archive member.
+
+    Returns:
+        True if the path is safe to use, False otherwise.
+    """
+    if '\x00' in name:
+        return False
+    p = Path(name)
+    return not p.is_absolute() and '..' not in p.parts
 
 
 @dataclass
@@ -125,10 +145,26 @@ def list_archive_contents(archive_path: Path) -> list:
     name = archive_path.name
     if name.endswith((".tar.gz", ".tgz")):
         with tarfile.open(archive_path, "r:gz") as tf:
-            return [m.name for m in tf.getmembers() if m.isfile()]
+            result = []
+            for m in tf.getmembers():
+                if not m.isfile():
+                    continue
+                if not _safe_inner_path(m.name):
+                    _log.warning("Skipping unsafe inner path in archive: %r", m.name)
+                    continue
+                result.append(m.name)
+            return result
     if name.endswith(".zip"):
         with zipfile.ZipFile(archive_path, "r") as zf:
-            return [n for n in zf.namelist() if not n.endswith("/")]
+            result = []
+            for n in zf.namelist():
+                if n.endswith("/"):
+                    continue
+                if not _safe_inner_path(n):
+                    _log.warning("Skipping unsafe inner path in archive: %r", n)
+                    continue
+                result.append(n)
+            return result
     raise ValueError(f"Unsupported archive format: {name}")
 
 
@@ -146,6 +182,8 @@ def extract_file(archive_path: Path, inner_filename: str) -> Iterator[bytes]:
         FileNotFoundError: If *inner_filename* is not in the archive.
         ValueError: If the archive format is not supported.
     """
+    if not _safe_inner_path(inner_filename):
+        raise ValueError(f"Unsafe archive inner path: {inner_filename!r}")
     name = archive_path.name
     chunk = 65536
     if name.endswith((".tar.gz", ".tgz")):

--- a/tests/unit/test_downloader_service.py
+++ b/tests/unit/test_downloader_service.py
@@ -4,7 +4,7 @@ import tarfile
 import zipfile
 import pytest
 from pathlib import Path
-from src.services.downloader_service import validate_path, browse_path, BrowseEntry, list_archive_contents, extract_file, search_in_files, search_in_archives
+from src.services.downloader_service import validate_path, browse_path, BrowseEntry, list_archive_contents, extract_file, search_in_files, search_in_archives, _safe_inner_path
 
 
 def test_validate_path_accepts_allowed(tmp_path):
@@ -272,3 +272,89 @@ def test_search_archives_file_pattern_filters(tmp_path):
     files = {h.file for h in r.results}
     assert "e.log" in files
     assert "d.csv" not in files
+
+
+# ---------------------------------------------------------------------------
+# _safe_inner_path
+# ---------------------------------------------------------------------------
+
+def test_safe_inner_path_accepts_normal():
+    assert _safe_inner_path("logs/errors.log") is True
+
+
+def test_safe_inner_path_accepts_nested():
+    assert _safe_inner_path("subdir/nested/file.log") is True
+
+
+def test_safe_inner_path_accepts_single():
+    assert _safe_inner_path("file.txt") is True
+
+
+def test_safe_inner_path_rejects_dotdot():
+    assert _safe_inner_path("../../etc/passwd") is False
+
+
+def test_safe_inner_path_rejects_dotdot_relative():
+    assert _safe_inner_path("../sibling.txt") is False
+
+
+def test_safe_inner_path_rejects_absolute():
+    assert _safe_inner_path("/etc/shadow") is False
+
+
+def test_safe_inner_path_rejects_absolute_tmp():
+    assert _safe_inner_path("/tmp/evil") is False
+
+
+def test_safe_inner_path_rejects_null_byte():
+    assert _safe_inner_path("name\x00injected") is False
+
+
+# ---------------------------------------------------------------------------
+# list_archive_contents skips unsafe paths
+# ---------------------------------------------------------------------------
+
+def test_list_archive_skips_traversal_paths(tmp_path):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        safe_data = b"safe"
+        info1 = tarfile.TarInfo(name="safe.txt")
+        info1.size = len(safe_data)
+        tf.addfile(info1, io.BytesIO(safe_data))
+        info2 = tarfile.TarInfo(name="../../etc/passwd")
+        evil_data = b"evil"
+        info2.size = len(evil_data)
+        tf.addfile(info2, io.BytesIO(evil_data))
+    arc = tmp_path / "crafted.tar.gz"
+    arc.write_bytes(buf.getvalue())
+    contents = list_archive_contents(arc)
+    assert "safe.txt" in contents
+    assert "../../etc/passwd" not in contents
+
+
+def test_list_archive_all_unsafe_returns_empty(tmp_path):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="../../evil")
+        data = b"x"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    arc = tmp_path / "evil.tar.gz"
+    arc.write_bytes(buf.getvalue())
+    assert list_archive_contents(arc) == []
+
+
+# ---------------------------------------------------------------------------
+# extract_file raises on traversal path
+# ---------------------------------------------------------------------------
+
+def test_extract_file_rejects_traversal_path(tmp_path):
+    arc = _make_targz(tmp_path / "a.tar.gz", {"safe.txt": b"x"})
+    with pytest.raises(ValueError, match="Unsafe archive inner path"):
+        list(extract_file(arc, "../../etc/passwd"))
+
+
+def test_extract_file_rejects_absolute_path(tmp_path):
+    arc = _make_targz(tmp_path / "a.tar.gz", {"safe.txt": b"x"})
+    with pytest.raises(ValueError, match="Unsafe archive inner path"):
+        list(extract_file(arc, "/etc/shadow"))


### PR DESCRIPTION
## Summary

- Adds `_safe_inner_path(name: str) -> bool` helper in `src/services/downloader_service.py` that rejects archive inner paths containing `..` components, absolute paths, and null bytes
- `list_archive_contents` now skips unsafe entries and logs a warning for each one (no exception raised — silently filtered)
- `extract_file` raises `ValueError` at the top of the function if the requested inner filename fails the guard

## Test plan

- [x] `test_safe_inner_path_accepts_normal` — normal relative paths pass
- [x] `test_safe_inner_path_accepts_nested` — nested relative paths pass
- [x] `test_safe_inner_path_accepts_single` — single filename passes
- [x] `test_safe_inner_path_rejects_dotdot` — `../../etc/passwd` rejected
- [x] `test_safe_inner_path_rejects_dotdot_relative` — `../sibling.txt` rejected
- [x] `test_safe_inner_path_rejects_absolute` — `/etc/shadow` rejected
- [x] `test_safe_inner_path_rejects_absolute_tmp` — `/tmp/evil` rejected
- [x] `test_safe_inner_path_rejects_null_byte` — null byte in name rejected
- [x] `test_list_archive_skips_traversal_paths` — crafted tar.gz with traversal entry is filtered; safe entry remains
- [x] `test_list_archive_all_unsafe_returns_empty` — archive with only unsafe entries returns `[]`
- [x] `test_extract_file_rejects_traversal_path` — `extract_file` raises `ValueError` on `../../etc/passwd`
- [x] `test_extract_file_rejects_absolute_path` — `extract_file` raises `ValueError` on `/etc/shadow`
- [x] Full unit suite: 1848 passed, 81.45% coverage (≥80% gate)

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)