### PR TITLE
feat(baseline): add DB persistence and wire update_baseline into run_tests (#246)

### DIFF
--- a/alembic/versions/0003_cm3_baselines.py
+++ b/alembic/versions/0003_cm3_baselines.py
@@ -1,0 +1,58 @@
+"""Create CM3_BASELINES table for suite baseline persistence.
+
+Stores the latest rolled-up baseline record for each test suite so that
+historical quality comparisons survive application restarts and can be queried
+from Oracle/PostgreSQL/SQLite without reading the JSON file.
+
+The table uses ``suite_name`` as the primary key (one row per suite), and
+``payload`` as a CLOB/TEXT column containing the full baseline JSON blob.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-07
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(table_name: str) -> bool:
+    """Return True if the named table exists in the current schema.
+
+    Args:
+        table_name: The table name to look up (case-insensitive match).
+
+    Returns:
+        True if the table exists, False otherwise.
+    """
+    bind = op.get_bind()
+    inspector = sa_inspect(bind)
+    return table_name.upper() in [t.upper() for t in inspector.get_table_names()]
+
+
+def upgrade() -> None:
+    """Create CM3_BASELINES table if it does not already exist.
+
+    Idempotent: the creation is skipped when the table is already present,
+    so this migration is safe to apply against environments where the table
+    was created manually.
+    """
+    if not _table_exists("CM3_BASELINES"):
+        op.create_table(
+            "CM3_BASELINES",
+            sa.Column("suite_name", sa.String(255), nullable=False),
+            sa.Column("recorded_at", sa.DateTime, nullable=False),
+            sa.Column("payload", sa.Text, nullable=False),
+            sa.PrimaryKeyConstraint("suite_name"),
+        )
+
+
+def downgrade() -> None:
+    """Drop CM3_BASELINES table if it exists."""
+    if _table_exists("CM3_BASELINES"):
+        op.drop_table("CM3_BASELINES")

--- a/src/commands/run_tests_command.py
+++ b/src/commands/run_tests_command.py
@@ -22,6 +22,8 @@ try:
 except ImportError:  # service not yet present in all environments
     _db_write_run = None  # type: ignore[assignment]
 
+from src.services import baseline_service
+
 
 def _run_api_check_test(test: TestConfig, params: dict) -> dict:
     """Execute an HTTP API check test.
@@ -499,6 +501,39 @@ def _append_run_history(
             )
 
 
+def _build_suite_result(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a minimal result dict for baseline_service from per-test results.
+
+    Aggregates pass/fail/total counts and the first non-None quality_score
+    across all tests so that :func:`~src.services.baseline_service.update_baseline`
+    receives the fields it expects.
+
+    Args:
+        results: Per-test result dicts returned by :func:`_run_single_test`.
+
+    Returns:
+        Dict with keys: ``pass_count``, ``total_count``, ``invalid_rows``,
+        ``total_rows``, and optionally ``quality_score``.
+    """
+    pass_count = sum(1 for r in results if r.get("status") == "PASS")
+    total_count = len(results)
+    invalid_rows = sum(r.get("error_count", 0) or 0 for r in results)
+    total_rows = sum(r.get("row_count", 0) or 0 for r in results)
+    quality_score: float | None = next(
+        (r["quality_score"] for r in results if r.get("quality_score") is not None),
+        None,
+    )
+    suite_result: dict[str, Any] = {
+        "pass_count": pass_count,
+        "total_count": total_count,
+        "invalid_rows": invalid_rows,
+        "total_rows": total_rows,
+    }
+    if quality_score is not None:
+        suite_result["quality_score"] = quality_score
+    return suite_result
+
+
 def run_suite_from_path(
     suite_path: str,
     params: dict[str, str],
@@ -587,6 +622,11 @@ def run_suite_from_path(
         archive_path=archive_path_str,
         timestamp=run_timestamp,
     )
+
+    try:
+        baseline_service.update_baseline(suite.name, _build_suite_result(results))
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger(__name__).warning("baseline update failed: %s", exc)
 
     return results
 

--- a/src/services/baseline_service.py
+++ b/src/services/baseline_service.py
@@ -1,9 +1,15 @@
-"""JSON-backed rolling baseline store for per-suite quality metrics.
+"""Baseline store for per-suite quality metrics with JSON + DB persistence.
 
 Baselines are persisted to ``reports/baselines.json`` using the same
 read-modify-write pattern as ``reports/run_history.json``.  Each suite
 maintains a rolling window of its last 10 runs; averages are recomputed
 on every call to :func:`update_baseline`.
+
+When a SQLAlchemy engine is available (via
+:func:`~src.database.engine.get_engine`) each operation is also mirrored
+to the ``CM3_BASELINES`` database table.  DB calls are always wrapped in
+``try/except`` so the JSON fallback is never bypassed — callers are never
+broken by an absent or misconfigured database.
 
 Storage format (``reports/baselines.json``)::
 
@@ -29,9 +35,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
+
+from sqlalchemy import text
+
+from src.database.engine import get_engine, get_schema_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +153,151 @@ def _recompute_baseline(suite_name: str, history: list[dict[str, Any]]) -> dict[
 
 
 # ---------------------------------------------------------------------------
+# Private DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _qualified(schema: str, table: str) -> str:
+    """Return a schema-qualified table identifier.
+
+    Args:
+        schema: Schema name with optional trailing dot (e.g. ``'CM3INT.'``).
+            Pass ``''`` for SQLite (no schema).
+        table: Unqualified table name.
+
+    Returns:
+        ``'schema.TABLE'`` when schema is non-empty, otherwise ``'TABLE'``.
+    """
+    clean = schema.rstrip(".")
+    return f"{clean}.{table}" if clean else table
+
+
+def _db_upsert_baseline(suite_name: str, baseline: dict[str, Any]) -> None:
+    """Upsert a baseline row into CM3_BASELINES.
+
+    Uses INSERT OR REPLACE for SQLite and a SELECT-then-INSERT-or-UPDATE
+    strategy for Oracle/PostgreSQL so that a single primary key row is
+    maintained per suite.  All errors are logged as warnings; callers are
+    never broken.
+
+    Args:
+        suite_name: Primary key identifying the suite.
+        baseline: Baseline dict to serialise as the row payload.
+    """
+    try:
+        engine = get_engine()
+        schema = get_schema_prefix()
+        table = _qualified(schema, "CM3_BASELINES")
+        payload = json.dumps(baseline)
+        recorded_at = datetime.utcnow()
+
+        adapter = os.getenv("DB_ADAPTER", "oracle").lower()
+
+        with engine.connect() as conn:
+            if adapter == "sqlite":
+                conn.execute(
+                    text(
+                        f"INSERT OR REPLACE INTO {table} "
+                        "(suite_name, recorded_at, payload) "
+                        "VALUES (:suite_name, :recorded_at, :payload)"
+                    ),
+                    {
+                        "suite_name": suite_name,
+                        "recorded_at": recorded_at,
+                        "payload": payload,
+                    },
+                )
+            else:
+                # Generic strategy: SELECT then INSERT or UPDATE
+                row = conn.execute(
+                    text(
+                        f"SELECT suite_name FROM {table} "
+                        "WHERE suite_name = :suite_name"
+                    ),
+                    {"suite_name": suite_name},
+                ).fetchone()
+                if row is None:
+                    conn.execute(
+                        text(
+                            f"INSERT INTO {table} "
+                            "(suite_name, recorded_at, payload) "
+                            "VALUES (:suite_name, :recorded_at, :payload)"
+                        ),
+                        {
+                            "suite_name": suite_name,
+                            "recorded_at": recorded_at,
+                            "payload": payload,
+                        },
+                    )
+                else:
+                    conn.execute(
+                        text(
+                            f"UPDATE {table} "
+                            "SET recorded_at = :recorded_at, payload = :payload "
+                            "WHERE suite_name = :suite_name"
+                        ),
+                        {
+                            "suite_name": suite_name,
+                            "recorded_at": recorded_at,
+                            "payload": payload,
+                        },
+                    )
+            conn.commit()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("CM3_BASELINES DB write failed (JSON fallback still written): %s", exc)
+
+
+def _db_fetch_baseline(suite_name: str) -> Optional[dict[str, Any]]:
+    """Fetch a baseline row from CM3_BASELINES by suite name.
+
+    Args:
+        suite_name: Suite name to look up.
+
+    Returns:
+        Parsed baseline dict, or ``None`` when the row is absent or the DB
+        is unavailable.
+    """
+    try:
+        engine = get_engine()
+        schema = get_schema_prefix()
+        table = _qualified(schema, "CM3_BASELINES")
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    f"SELECT payload FROM {table} "
+                    "WHERE suite_name = :suite_name"
+                ),
+                {"suite_name": suite_name},
+            ).fetchone()
+        if row is None:
+            return None
+        return json.loads(row["payload"])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("CM3_BASELINES DB read failed (falling back to JSON): %s", exc)
+        return None
+
+
+def _db_fetch_all_baselines() -> Optional[list[dict[str, Any]]]:
+    """Fetch all baseline rows from CM3_BASELINES.
+
+    Returns:
+        List of parsed baseline dicts, or ``None`` when the DB is unavailable.
+    """
+    try:
+        engine = get_engine()
+        schema = get_schema_prefix()
+        table = _qualified(schema, "CM3_BASELINES")
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(f"SELECT suite_name, payload FROM {table}")
+            ).fetchall()
+        return [json.loads(row["payload"]) for row in rows]
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("CM3_BASELINES DB list failed (falling back to JSON): %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -201,6 +357,9 @@ def update_baseline(suite_name: str, result: dict[str, Any]) -> dict[str, Any]:
     store[suite_name] = {"baseline": baseline, "history": history}
     _save_store(path, store)
 
+    # Mirror to DB (best-effort — never breaks callers)
+    _db_upsert_baseline(suite_name, baseline)
+
     return baseline
 
 
@@ -215,6 +374,11 @@ def get_baseline(suite_name: str) -> Optional[dict[str, Any]]:
         avg_error_rate, sample_size, updated_at; or ``None`` if no baseline
         has been recorded for this suite yet.
     """
+    # Try DB first; fall back to JSON when DB is unavailable or returns nothing
+    db_result = _db_fetch_baseline(suite_name)
+    if db_result is not None:
+        return db_result
+
     path = _BASELINES_PATH
     store = _load_store(path)
     record = store.get(suite_name)
@@ -230,6 +394,11 @@ def list_baselines() -> list[dict[str, Any]]:
         List of baseline dicts (see :func:`get_baseline`), sorted by
         ``suite_name``.  Returns an empty list when no baselines exist.
     """
+    # Try DB first; fall back to JSON when DB is unavailable
+    db_result = _db_fetch_all_baselines()
+    if db_result is not None:
+        return sorted(db_result, key=lambda b: b.get("suite_name", ""))
+
     path = _BASELINES_PATH
     store = _load_store(path)
     baselines = [

--- a/tests/unit/test_baseline_service.py
+++ b/tests/unit/test_baseline_service.py
@@ -329,3 +329,244 @@ class TestJsonRoundTrip:
             "updated_at",
         }
         assert required_keys.issubset(set(baseline.keys()))
+
+
+# ---------------------------------------------------------------------------
+# Tests: DB persistence (TDD — written before implementation)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBaselineDB:
+    """DB persistence tests for update_baseline()."""
+
+    def test_update_baseline_writes_to_db(self, tmp_path: Path):
+        """update_baseline executes an INSERT/UPSERT touching CM3_BASELINES."""
+        from unittest.mock import MagicMock, patch, call
+        from src.services.baseline_service import update_baseline
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch("src.services.baseline_service.get_engine", return_value=mock_engine),
+            patch("src.services.baseline_service.get_schema_prefix", return_value=""),
+        ):
+            update_baseline("SUITE_DB", _make_result())
+
+        # At least one execute call must reference CM3_BASELINES in its SQL text
+        executed_sql = [
+            str(call_args.args[0])
+            for call_args in mock_conn.execute.call_args_list
+        ]
+        assert any("CM3_BASELINES" in s for s in executed_sql), (
+            f"Expected CM3_BASELINES in SQL, got: {executed_sql}"
+        )
+
+    def test_update_baseline_db_failure_falls_back_to_json(self, tmp_path: Path):
+        """DB failure does not raise — JSON is still written."""
+        from unittest.mock import patch
+        from src.services.baseline_service import update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch(
+                "src.services.baseline_service.get_engine",
+                side_effect=RuntimeError("no DB"),
+            ),
+        ):
+            # Must not raise
+            baseline = update_baseline("SUITE_DB", _make_result())
+
+        assert baseline["suite_name"] == "SUITE_DB"
+        assert storage.exists()
+
+    def test_get_baseline_reads_from_db(self, tmp_path: Path):
+        """get_baseline returns data from DB when available."""
+        import json as _json
+        from unittest.mock import MagicMock, patch
+        from src.services.baseline_service import get_baseline
+
+        payload = _json.dumps({
+            "suite_name": "SUITE_DB",
+            "pass_rate": 75.0,
+            "avg_quality_score": 85.0,
+            "avg_error_rate": 1.0,
+            "sample_size": 3,
+            "updated_at": "2026-01-01T00:00:00",
+        })
+
+        mock_row = MagicMock()
+        mock_row.__getitem__ = MagicMock(side_effect=lambda k: payload if k == "payload" else None)
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchone.return_value = mock_row
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch("src.services.baseline_service.get_engine", return_value=mock_engine),
+            patch("src.services.baseline_service.get_schema_prefix", return_value=""),
+        ):
+            result = get_baseline("SUITE_DB")
+
+        assert result is not None
+        assert result["pass_rate"] == 75.0
+        assert result["sample_size"] == 3
+
+    def test_get_baseline_db_failure_falls_back_to_json(self, tmp_path: Path):
+        """get_baseline falls back to JSON when DB raises."""
+        from unittest.mock import patch
+        from src.services.baseline_service import get_baseline, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        # Pre-populate the JSON file (no DB)
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch(
+                "src.services.baseline_service.get_engine",
+                side_effect=RuntimeError("no DB"),
+            ),
+        ):
+            update_baseline("SUITE_DB", _make_result(pass_count=7, total_count=10))
+
+        # Now read back with DB failing — should still get JSON data
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch(
+                "src.services.baseline_service.get_engine",
+                side_effect=RuntimeError("no DB"),
+            ),
+        ):
+            result = get_baseline("SUITE_DB")
+
+        assert result is not None
+        assert result["pass_rate"] == pytest.approx(70.0)
+
+    def test_list_baselines_reads_from_db(self, tmp_path: Path):
+        """list_baselines returns suite names from DB when available."""
+        import json as _json
+        from unittest.mock import MagicMock, patch
+        from src.services.baseline_service import list_baselines
+
+        suite_a_payload = _json.dumps({
+            "suite_name": "SUITE_A",
+            "pass_rate": 80.0,
+            "avg_quality_score": None,
+            "avg_error_rate": 0.0,
+            "sample_size": 1,
+            "updated_at": "2026-01-01T00:00:00",
+        })
+        suite_b_payload = _json.dumps({
+            "suite_name": "SUITE_B",
+            "pass_rate": 60.0,
+            "avg_quality_score": None,
+            "avg_error_rate": 0.0,
+            "sample_size": 1,
+            "updated_at": "2026-01-01T00:00:00",
+        })
+
+        row_a = MagicMock()
+        row_a.__getitem__ = MagicMock(
+            side_effect=lambda k: "SUITE_A" if k == "suite_name" else suite_a_payload
+        )
+        row_b = MagicMock()
+        row_b.__getitem__ = MagicMock(
+            side_effect=lambda k: "SUITE_B" if k == "suite_name" else suite_b_payload
+        )
+
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.fetchall.return_value = [row_a, row_b]
+
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value = mock_conn
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch("src.services.baseline_service.get_engine", return_value=mock_engine),
+            patch("src.services.baseline_service.get_schema_prefix", return_value=""),
+        ):
+            result = list_baselines()
+
+        names = [b["suite_name"] for b in result]
+        assert "SUITE_A" in names
+        assert "SUITE_B" in names
+
+    def test_list_baselines_db_failure_falls_back_to_json(self, tmp_path: Path):
+        """list_baselines falls back to JSON when DB raises."""
+        from unittest.mock import patch
+        from src.services.baseline_service import list_baselines, update_baseline
+
+        storage = tmp_path / "baselines.json"
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch(
+                "src.services.baseline_service.get_engine",
+                side_effect=RuntimeError("no DB"),
+            ),
+        ):
+            update_baseline("SUITE_A", _make_result())
+            update_baseline("SUITE_B", _make_result())
+
+        with (
+            patch("src.services.baseline_service._BASELINES_PATH", storage),
+            patch(
+                "src.services.baseline_service.get_engine",
+                side_effect=RuntimeError("no DB"),
+            ),
+        ):
+            result = list_baselines()
+
+        names = [b["suite_name"] for b in result]
+        assert set(names) == {"SUITE_A", "SUITE_B"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_tests_command wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRunTestsBaselineWiring:
+    """Verify run_tests_command calls update_baseline after _append_run_history."""
+
+    def test_run_tests_calls_update_baseline(self, tmp_path: Path):
+        """run_tests_command (via run_suite_from_path) calls baseline_service.update_baseline."""
+        from unittest.mock import patch, MagicMock
+        import src.commands.run_tests_command as rtc
+
+        # Minimal suite YAML written to tmp_path
+        suite_yaml = tmp_path / "suite.yaml"
+        suite_yaml.write_text(
+            "name: TEST_SUITE\ntests: []\nenvironment: test\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch.object(rtc, "_append_run_history"),
+            patch("src.commands.run_tests_command.baseline_service") as mock_bs,
+            patch.object(rtc, "SuiteReporter"),
+        ):
+            rtc.run_suite_from_path(
+                suite_path=str(suite_yaml),
+                params={},
+                env="test",
+                output_dir=str(tmp_path),
+            )
+
+        mock_bs.update_baseline.assert_called_once()
+        call_args = mock_bs.update_baseline.call_args
+        assert call_args[0][0] == "TEST_SUITE"


### PR DESCRIPTION
## Summary

- Adds `CM3_BASELINES` table via Alembic migration `0003` (idempotent, cross-DB)
- Extends `baseline_service` with DB persistence: `update_baseline`, `get_baseline`, `list_baselines` all try DB first, fall back to JSON; all DB calls are wrapped in try/except and never raise to callers
- Wires `baseline_service.update_baseline` into `run_tests_command` after `_append_run_history`, protected by try/except
- 7 new unit tests (6 DB path + 1 wiring), 1868 total tests passing

Closes #246

## Test plan

- [ ] `pytest tests/unit/test_baseline_service.py -v` — all 26 pass
- [ ] `pytest tests/unit/ -q` — 1868 pass, ≥80% coverage
- [ ] With `DB_ADAPTER=sqlite`, run `valdo schedule` — baseline is written to DB after suite completes
- [ ] Kill DB connection, verify JSON fallback still works and no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)