### PR TITLE
feat(enterprise): downloader ui.yml consolidation, archive search, IP whitelist, TLS strategy (#365–#368)

### DIFF
--- a/config/file-downloader.yml
+++ b/config/file-downloader.yml
@@ -1,3 +1,6 @@
+# DEPRECATED: configuration has moved to config/ui.yml downloader section.
+# This file is no longer read.
+#
 # Configured server paths exposed in the File Downloader tab.
 # Only paths listed here are accessible — no arbitrary filesystem access.
 paths:

--- a/config/ui.yml
+++ b/config/ui.yml
@@ -25,3 +25,48 @@ downloader:
 security:
   ip_whitelist: []        # Add IPs/CIDR ranges to restrict access, e.g. ["10.0.0.0/8"]
   trust_proxy: false      # Set true if behind a reverse proxy (uses X-Forwarded-For)
+
+# TLS configuration — switch strategy by changing 'strategy' value only, no code changes needed.
+# Strategies: manual (default), self_signed, enterprise_ca
+#
+# Example — manual (pre-existing cert files):
+#   tls:
+#     enabled: true
+#     strategy: "manual"
+#     cert_path: "/etc/valdo/tls/cert.pem"
+#     key_path: "/etc/valdo/tls/key.pem"
+#
+# Example — self_signed (generated at startup, useful for dev/internal):
+#   tls:
+#     enabled: true
+#     strategy: "self_signed"
+#     cert_path: "/tmp/valdo-tls/cert.pem"
+#     key_path: "/tmp/valdo-tls/key.pem"
+#     cn: "valdo.internal"
+#     san:
+#       - "valdo.internal"
+#       - "localhost"
+#
+# Example — enterprise_ca (fetch from internal CA API):
+#   tls:
+#     enabled: true
+#     strategy: "enterprise_ca"
+#     ca_api_url: "https://ca.corp.example.com/issue"
+#     ca_api_token_env: "CA_API_TOKEN"   # env var holding the bearer token
+#     cert_path: "/etc/valdo/tls/cert.pem"
+#     key_path: "/etc/valdo/tls/key.pem"
+#     cn: "valdo.internal"
+#     san:
+#       - "valdo.internal"
+#     expiry_warn_days: 30
+tls:
+  enabled: false
+  strategy: "manual"            # "manual" | "self_signed" | "enterprise_ca"
+  cert_path: "/etc/valdo/tls/cert.pem"
+  key_path: "/etc/valdo/tls/key.pem"
+  cn: "valdo.internal"
+  san:
+    - "valdo.internal"
+  ca_api_url: ""               # enterprise_ca only: URL to CA API
+  ca_api_token_env: "CA_API_TOKEN"  # enterprise_ca only: env var holding the bearer token
+  expiry_warn_days: 30

--- a/config/ui.yml
+++ b/config/ui.yml
@@ -7,3 +7,17 @@ tabs:
   tester: true
   dbcompare: true
   downloader: false
+
+# File Downloader configuration — replaces the env var ENABLE_FILE_DOWNLOADER
+# and the separate config/file-downloader.yml (now deprecated).
+downloader:
+  enabled: false
+  log_path: "logs/file-downloads.log"
+  archive_base_dir: "/data/archives"
+  paths:
+    - label: "Batch Output"
+      path: /data/batch/output
+    - label: "ETL Logs"
+      path: /opt/etl/logs
+    - label: "Report Archive"
+      path: /data/reports

--- a/config/ui.yml
+++ b/config/ui.yml
@@ -21,3 +21,7 @@ downloader:
       path: /opt/etl/logs
     - label: "Report Archive"
       path: /data/reports
+
+security:
+  ip_whitelist: []        # Add IPs/CIDR ranges to restrict access, e.g. ["10.0.0.0/8"]
+  trust_proxy: false      # Set true if behind a reverse proxy (uses X-Forwarded-For)

--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -3324,6 +3324,92 @@ For full details, see `prompts/README.md`.
 
 ---
 
+## 12.5 TLS / HTTPS Configuration
+
+By default `valdo serve` starts in plain HTTP mode.  To enable HTTPS, add a
+`tls` section to `config/ui.yml`.  **No code changes are needed** — switching
+strategy is a config-only operation.
+
+### Strategies
+
+| Strategy | Description | Required config keys |
+|---|---|---|
+| `manual` | Use pre-existing cert/key files on disk | `cert_path`, `key_path` |
+| `self_signed` | Generate a self-signed cert at startup (dev/internal) | *(optional)* `cert_path`, `key_path`, `cn`, `san` |
+| `enterprise_ca` | Fetch cert/key from a corporate CA REST API | `ca_api_url`, optionally `ca_api_token_env`, `cert_path`, `key_path` |
+
+### Common config keys
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Set to `true` to enable TLS |
+| `strategy` | `"manual"` | One of `manual`, `self_signed`, `enterprise_ca` |
+| `cert_path` | — | Path where the PEM cert is stored / will be written |
+| `key_path` | — | Path where the PEM private key is stored / will be written |
+| `cn` | `"localhost"` | Certificate common name |
+| `san` | `[cn]` | Subject Alternative Name list (DNS or IP) |
+| `ca_api_url` | — | (`enterprise_ca`) URL to POST the cert request to |
+| `ca_api_token_env` | `"CA_API_TOKEN"` | (`enterprise_ca`) Env var with bearer token |
+| `expiry_warn_days` | `30` | Warn in logs when cert has fewer than this many days left |
+
+### Example — manual (production)
+
+```yaml
+tls:
+  enabled: true
+  strategy: "manual"
+  cert_path: "/etc/valdo/tls/cert.pem"
+  key_path: "/etc/valdo/tls/key.pem"
+  expiry_warn_days: 30
+```
+
+### Example — self-signed (development / internal)
+
+```yaml
+tls:
+  enabled: true
+  strategy: "self_signed"
+  cert_path: "/tmp/valdo-tls/cert.pem"
+  key_path: "/tmp/valdo-tls/key.pem"
+  cn: "valdo.internal"
+  san:
+    - "valdo.internal"
+    - "localhost"
+```
+
+The `cryptography` package must be installed: `pip install cryptography`.
+
+### Example — enterprise CA
+
+```yaml
+tls:
+  enabled: true
+  strategy: "enterprise_ca"
+  ca_api_url: "https://ca.corp.example.com/issue"
+  ca_api_token_env: "CA_API_TOKEN"
+  cert_path: "/etc/valdo/tls/cert.pem"
+  key_path: "/etc/valdo/tls/key.pem"
+  cn: "valdo.internal"
+  san:
+    - "valdo.internal"
+  expiry_warn_days: 30
+```
+
+Set the bearer token in the environment: `export CA_API_TOKEN=<token>`.
+
+The strategy caches the fetched cert to `cert_path`.  On subsequent startups
+it reuses the cached cert as long as it has at least `expiry_warn_days` of
+validity remaining.
+
+### Cert expiry warnings
+
+`valdo serve` logs a `WARNING` message when the resolved cert has fewer days
+of validity remaining than `expiry_warn_days` (default 30).  Monitor these
+warnings in Splunk / your log aggregator to trigger renewal workflows before
+the cert expires.
+
+---
+
 ## 13. Operations Guide
 
 ### Docker Deployment

--- a/docs/USAGE_AND_OPERATIONS_GUIDE.md
+++ b/docs/USAGE_AND_OPERATIONS_GUIDE.md
@@ -3479,6 +3479,56 @@ steps including:
 
 ---
 
+### IP Whitelisting
+
+Valdo supports a configurable IP whitelist so that access to the API server can
+be restricted to known enterprise VDI or office network ranges.  The feature is
+disabled by default (all IPs permitted) for backwards compatibility.
+
+#### Configuration
+
+Add a `security` block to `config/ui.yml`:
+
+```yaml
+security:
+  ip_whitelist: []        # Add IPs/CIDR ranges to restrict access, e.g. ["10.0.0.0/8"]
+  trust_proxy: false      # Set true if behind a reverse proxy (uses X-Forwarded-For)
+```
+
+**Examples:**
+
+```yaml
+# Allow a specific VDI subnet and an individual machine
+security:
+  ip_whitelist:
+    - "10.100.0.0/16"
+    - "192.168.5.42"
+  trust_proxy: false
+
+# Behind an Nginx / HAProxy reverse proxy — trust the forwarded header
+security:
+  ip_whitelist:
+    - "10.0.0.0/8"
+  trust_proxy: true
+```
+
+When `ip_whitelist` is an empty list (the default), the middleware is not added
+and all requests pass through unchanged.
+
+#### Behaviour
+
+- Requests from IPs that are **not** in any configured range receive a
+  `403 Forbidden` response with JSON body `{"error": "Forbidden", "detail": "..."}`.
+- When `trust_proxy: true`, the first IP in the `X-Forwarded-For` header is used
+  as the client address.  Enable this only when a trusted reverse proxy is in
+  front of Valdo.
+- Invalid entries in `ip_whitelist` (e.g. hostnames) are logged as warnings at
+  startup and silently skipped; all valid entries still apply.
+- The middleware uses Python's built-in `ipaddress` module — no additional
+  dependencies are required.
+
+---
+
 ### Performance Tuning
 
 #### Chunked Processing

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -203,6 +203,14 @@ Configuration & Validators
    :members:
    :undoc-members:
 
+API Middleware
+-------------
+
+.. automodule:: src.api.middleware.ip_whitelist
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 API Routers
 -----------
 

--- a/docs/sphinx/modules.rst
+++ b/docs/sphinx/modules.rst
@@ -309,6 +309,10 @@ Services
    :members:
    :undoc-members:
 
+.. automodule:: src.services.tls_service
+   :members:
+   :undoc-members:
+
 Contracts & Adapters
 --------------------
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -105,6 +105,22 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# IP Whitelist middleware — loaded from ui.yml security section at module load time.
+# add_middleware must be called before the app starts serving, so we read the config
+# here rather than in the lifespan handler.
+_ui_cfg_for_security: dict = {}
+if _UI_CONFIG_PATH.exists():
+    import yaml as _yaml_sec
+    _ui_cfg_for_security = _yaml_sec.safe_load(_UI_CONFIG_PATH.read_text()) or {}
+
+_security_cfg = _ui_cfg_for_security.get("security", {})
+_ip_whitelist = _security_cfg.get("ip_whitelist", [])
+_trust_proxy = _security_cfg.get("trust_proxy", False)
+
+if _ip_whitelist:  # only add middleware if whitelist is configured
+    from src.api.middleware.ip_whitelist import IPWhitelistMiddleware
+    app.add_middleware(IPWhitelistMiddleware, whitelist=_ip_whitelist, trust_proxy=_trust_proxy)
+
 # Include routers
 app.include_router(
     mappings.router,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -29,7 +29,13 @@ logger = logging.getLogger(__name__)
 FILE_RETENTION_HOURS = float(os.getenv("FILE_RETENTION_HOURS", "24"))
 _UPLOADS_DIR = Path(__file__).parent.parent.parent / "uploads"
 _UI_CONFIG_PATH = Path(__file__).parent.parent.parent / "config" / "ui.yml"
-_FD_CONFIG_PATH = Path(__file__).parent.parent.parent / "config" / "file-downloader.yml"
+
+# Read ui.yml early (before app creation) so the downloader router can be
+# conditionally registered based on downloader.enabled in config/ui.yml.
+_ui_cfg_early: dict = {}
+if _UI_CONFIG_PATH.exists():
+    import yaml as _yaml_early
+    _ui_cfg_early = _yaml_early.safe_load(_UI_CONFIG_PATH.read_text()) or {}
 
 
 @asynccontextmanager
@@ -44,24 +50,17 @@ async def lifespan(app: FastAPI):
             result["deleted_bytes"],
         )
 
-    # Load tab visibility config
+    # Load tab visibility + downloader config from ui.yml
     if _UI_CONFIG_PATH.exists():
         with open(_UI_CONFIG_PATH) as _f:
             app.state.ui_config = yaml.safe_load(_f) or {}
     else:
         app.state.ui_config = {}
 
-    # Load file-downloader path config
-    if _FD_CONFIG_PATH.exists():
-        with open(_FD_CONFIG_PATH) as _f:
-            app.state.fd_config = yaml.safe_load(_f) or {}
-    else:
-        app.state.fd_config = {}
-
     logger.info(
-        "Loaded ui_config with %d tab entries; fd_config with %d path entries",
+        "Loaded ui_config with %d tab entries; downloader.enabled=%s",
         len((app.state.ui_config or {}).get("tabs", {})),
-        len((app.state.fd_config or {}).get("paths", {})),
+        (app.state.ui_config or {}).get("downloader", {}).get("enabled", False),
     )
 
     yield
@@ -151,8 +150,8 @@ app.include_router(
     dependencies=[Depends(require_api_key)],
 )
 
-# File Downloader — only registered when ENABLE_FILE_DOWNLOADER=true
-if os.getenv("ENABLE_FILE_DOWNLOADER", "").lower() == "true":
+# File Downloader — registered when downloader.enabled is true in config/ui.yml
+if _ui_cfg_early.get("downloader", {}).get("enabled", False):
     from src.api.routers import downloader as _dl_mod
     app.include_router(_dl_mod.router, prefix="/api/v1/downloader", tags=["downloader"])
 

--- a/src/api/middleware/ip_whitelist.py
+++ b/src/api/middleware/ip_whitelist.py
@@ -1,0 +1,86 @@
+"""IP whitelist middleware for enterprise VDI environments."""
+import ipaddress
+import logging
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+class IPWhitelistMiddleware(BaseHTTPMiddleware):
+    """Middleware that restricts access to configured IP ranges.
+
+    When ip_whitelist is empty or not configured, all IPs are allowed
+    (backwards compatible default-open behaviour).
+
+    Args:
+        app: The ASGI application.
+        whitelist: List of IP addresses and/or CIDR ranges as strings.
+            E.g. ["10.0.0.0/8", "192.168.1.50"].
+        trust_proxy: If True, use X-Forwarded-For header as client IP
+            (first entry). Default False.
+    """
+
+    def __init__(self, app, whitelist: list = None, trust_proxy: bool = False):
+        """Initialise the middleware, parsing whitelist entries into network objects.
+
+        Args:
+            app: The ASGI application to wrap.
+            whitelist: List of IP addresses and/or CIDR ranges as strings.
+                Invalid entries are logged as warnings and skipped.
+            trust_proxy: If True, use X-Forwarded-For header as client IP.
+        """
+        super().__init__(app)
+        self.trust_proxy = trust_proxy
+        self._networks = []
+        for entry in (whitelist or []):
+            try:
+                self._networks.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                logger.warning("Invalid IP whitelist entry ignored: %s", entry)
+
+    def _is_allowed(self, client_ip: str) -> bool:
+        """Return True if client_ip is in the whitelist (or whitelist is empty).
+
+        Args:
+            client_ip: The IP address string to check.
+
+        Returns:
+            True if the IP is permitted or no whitelist is configured;
+            False if the IP is blocked.
+        """
+        if not self._networks:
+            return True
+        try:
+            addr = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return False
+        return any(addr in net for net in self._networks)
+
+    async def dispatch(self, request: Request, call_next):
+        """Check client IP against the whitelist before forwarding the request.
+
+        Args:
+            request: The incoming HTTP request.
+            call_next: The next middleware/route handler in the chain.
+
+        Returns:
+            A 403 JSONResponse if the client IP is not permitted, otherwise
+            the response from the downstream handler.
+        """
+        if self.trust_proxy:
+            forwarded = request.headers.get("X-Forwarded-For", "")
+            client_ip = forwarded.split(",")[0].strip() if forwarded else (
+                request.client.host if request.client else ""
+            )
+        else:
+            client_ip = request.client.host if request.client else ""
+
+        if not self._is_allowed(client_ip):
+            logger.warning("Blocked request from %s — not in IP whitelist", client_ip)
+            return JSONResponse(
+                status_code=403,
+                content={"error": "Forbidden", "detail": "Your IP address is not permitted."},
+            )
+        return await call_next(request)

--- a/src/api/routers/downloader.py
+++ b/src/api/routers/downloader.py
@@ -1,34 +1,62 @@
 """File Downloader API router.
 
-Provides browse, download, and archive-inspection endpoints.
-All endpoints require a valid API key and path must be under a
-configured allowed path (from file-downloader.yml).
+Provides browse, download, archive-inspection, and nested-archive-search
+endpoints. All endpoints require a valid API key and the requested path must
+be under a configured allowed path (from the ``downloader.paths`` section in
+``config/ui.yml``).
 """
 
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from src.api.auth import require_api_key
 from src.services import downloader_service as svc
-from src.services.downloader_logger import log_activity, resolve_client_info
+from src.services.downloader_logger import DownloaderLogger, resolve_client_info
 
 router = APIRouter()
 
 
-def _allowed_paths(request: Request) -> list:
-    """Extract allowed path strings from app state fd_config.
+def _dl_cfg(request: Request) -> dict:
+    """Extract the downloader config dict from app state.
 
     Args:
         request: Current FastAPI request.
 
     Returns:
-        List of allowed path strings from file-downloader.yml config.
+        The ``downloader`` sub-dict from ``app.state.ui_config``, or an empty
+        dict when not configured.
     """
-    return [p["path"] for p in getattr(request.app.state, "fd_config", {}).get("paths", [])]
+    return getattr(request.app.state, "ui_config", {}).get("downloader", {})
+
+
+def _allowed_paths(request: Request) -> list:
+    """Extract allowed path strings from the downloader config in ui_config.
+
+    Args:
+        request: Current FastAPI request.
+
+    Returns:
+        List of allowed path strings from ``config/ui.yml`` downloader section.
+    """
+    return [p["path"] for p in _dl_cfg(request).get("paths", [])]
+
+
+def _get_logger(request: Request) -> DownloaderLogger:
+    """Construct a :class:`DownloaderLogger` using the configured log path.
+
+    Args:
+        request: Current FastAPI request.
+
+    Returns:
+        :class:`DownloaderLogger` instance pointing at the path from
+        ``downloader.log_path`` in ``config/ui.yml``.
+    """
+    log_path = _dl_cfg(request).get("log_path", "logs/file-downloads.log")
+    return DownloaderLogger(log_path=log_path)
 
 
 def _safe_filename(name: str) -> str:
@@ -41,7 +69,8 @@ def _safe_filename(name: str) -> str:
         The original name if safe.
 
     Raises:
-        HTTPException: 400 if the name contains path separators or is absolute.
+        HTTPException: 400 if the name contains path separators or is
+            absolute.
     """
     if Path(name).name != name:
         raise HTTPException(status_code=400, detail=f"Invalid filename: {name!r}")
@@ -94,16 +123,16 @@ class SearchArchiveRequest(BaseModel):
 
 @router.get("/paths")
 async def get_paths(request: Request, _: object = Depends(require_api_key)):
-    """Return configured paths from file-downloader.yml.
+    """Return configured paths from the downloader section of config/ui.yml.
 
     Args:
         request: Current FastAPI request.
         _: Unused auth context (validates API key).
 
     Returns:
-        Dict with ``paths`` list from app state fd_config.
+        Dict with ``paths`` list from the downloader config.
     """
-    return {"paths": getattr(request.app.state, "fd_config", {}).get("paths", [])}
+    return {"paths": _dl_cfg(request).get("paths", [])}
 
 
 @router.get("/browse")
@@ -122,7 +151,8 @@ async def browse(
         _: Unused auth context (validates API key).
 
     Returns:
-        Dict with ``entries`` list, each having ``name``, ``type``, ``size_bytes``.
+        Dict with ``entries`` list, each having ``name``, ``type``,
+        ``size_bytes``.
 
     Raises:
         HTTPException: 403 if path is not under an allowed configured path.
@@ -184,7 +214,8 @@ async def download_file(
     """Stream a single file from disk or extracted from an archive.
 
     Args:
-        body: Download request with ``path``, ``filename``, and optional ``archive``.
+        body: Download request with ``path``, ``filename``, and optional
+            ``archive``.
         request: Current FastAPI request.
         _: Unused auth context (validates API key).
 
@@ -198,6 +229,7 @@ async def download_file(
     """
     resolved = _validate(body.path, request)
     client_ip, client_host = resolve_client_info(request)
+    dl_logger = _get_logger(request)
 
     if body.archive:
         _safe_filename(body.archive)  # archive itself must be a simple filename
@@ -227,7 +259,7 @@ async def download_file(
 
         stream = _plain()
 
-    log_activity(
+    dl_logger.log_activity(
         operation="download",
         client_ip=client_ip,
         client_host=client_host,
@@ -254,9 +286,9 @@ def _fmt_result(r) -> dict:
         r: A ``SearchResult`` dataclass returned by the downloader service.
 
     Returns:
-        Dict with keys: ``results``, ``truncated``, ``total_matches``, ``shown``,
-        and ``download_ref`` (``None`` or a dict with ``path``, ``filename``,
-        ``archive``).
+        Dict with keys: ``results``, ``truncated``, ``total_matches``,
+        ``shown``, and ``download_ref`` (``None`` or a dict with ``path``,
+        ``filename``, ``archive``).
     """
     return {
         "results": [
@@ -279,7 +311,8 @@ async def search_files(body: SearchFilesRequest, request: Request, _: object = D
     """Search a string in plain files matching a filename wildcard.
 
     Args:
-        body: Request body with ``path``, ``filename_pattern``, and ``search_string``.
+        body: Request body with ``path``, ``filename_pattern``, and
+            ``search_string``.
         request: Current FastAPI request.
         _: Unused auth context (validates API key).
 
@@ -292,9 +325,10 @@ async def search_files(body: SearchFilesRequest, request: Request, _: object = D
     """
     resolved = _validate(body.path, request)
     client_ip, client_host = resolve_client_info(request)
+    dl_logger = _get_logger(request)
     result = svc.search_in_files(resolved, body.filename_pattern, body.search_string)
-    log_activity(operation="search_files", client_ip=client_ip, client_host=client_host,
-                 path=body.path, filename=body.filename_pattern, archive=None, status="success")
+    dl_logger.log_activity(operation="search_files", client_ip=client_ip, client_host=client_host,
+                           path=body.path, filename=body.filename_pattern, archive=None, status="success")
     return _fmt_result(result)
 
 
@@ -303,8 +337,8 @@ async def search_archive(body: SearchArchiveRequest, request: Request, _: object
     """Search a string inside archive inner files — both patterns support wildcards.
 
     Args:
-        body: Request body with ``path``, ``archive_pattern``, ``file_pattern``,
-            and ``search_string``.
+        body: Request body with ``path``, ``archive_pattern``,
+            ``file_pattern``, and ``search_string``.
         request: Current FastAPI request.
         _: Unused auth context (validates API key).
 
@@ -317,7 +351,50 @@ async def search_archive(body: SearchArchiveRequest, request: Request, _: object
     """
     resolved = _validate(body.path, request)
     client_ip, client_host = resolve_client_info(request)
+    dl_logger = _get_logger(request)
     result = svc.search_in_archives(resolved, body.archive_pattern, body.file_pattern, body.search_string)
-    log_activity(operation="search_archive", client_ip=client_ip, client_host=client_host,
-                 path=body.path, filename=body.file_pattern, archive=body.archive_pattern, status="success")
+    dl_logger.log_activity(operation="search_archive", client_ip=client_ip, client_host=client_host,
+                           path=body.path, filename=body.file_pattern, archive=body.archive_pattern,
+                           status="success")
     return _fmt_result(result)
+
+
+@router.post("/search-nested-archives")
+async def search_nested_archives(
+    request: Request,
+    archive_pattern: str = Body(...),
+    member_pattern: str = Body(...),
+    _: object = Depends(require_api_key),
+):
+    """Recursively search archives in the configured base directory.
+
+    Walks ``downloader.archive_base_dir`` (from ``config/ui.yml``) recursively,
+    finds archives whose filename matches *archive_pattern*, and returns
+    members whose basename matches *member_pattern*. No extraction is
+    performed.
+
+    Args:
+        request: Current FastAPI request.
+        archive_pattern: Wildcard for archive filenames
+            (e.g. ``"archive_*.zip"``).
+        member_pattern: Wildcard for member basenames
+            (e.g. ``"TRANS_*.txt"``).
+        _: Unused auth context (validates API key).
+
+    Returns:
+        Dict with ``results`` (list of ``{archive_path, member_path}``) and
+        ``count`` (int).
+
+    Raises:
+        HTTPException: 400 if ``archive_base_dir`` is not configured in
+            ``config/ui.yml``.
+    """
+    cfg = _dl_cfg(request)
+    archive_base_dir = cfg.get("archive_base_dir")
+    if not archive_base_dir:
+        raise HTTPException(
+            status_code=400,
+            detail="archive_base_dir is not configured in config/ui.yml downloader section",
+        )
+    results = svc.search_archives(archive_base_dir, archive_pattern, member_pattern)
+    return {"results": results, "count": len(results)}

--- a/src/api/routers/system.py
+++ b/src/api/routers/system.py
@@ -4,7 +4,6 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from src.api.models.response import HealthResponse, SystemInfoResponse
 from datetime import datetime
 from typing import List
-import os
 import sys
 
 from src.api.auth import require_api_key, require_role
@@ -202,8 +201,8 @@ _ALL_TABS = ["quick", "runs", "mapping", "tester", "dbcompare", "downloader"]
 async def get_ui_config(request: Request):
     """Return effective tab visibility from config/ui.yml.
 
-    The ``downloader`` tab is additionally gated by the
-    ``ENABLE_FILE_DOWNLOADER`` environment variable.
+    The ``downloader`` tab is gated by ``downloader.enabled`` in
+    ``config/ui.yml``.
     No auth required — tab visibility is not sensitive.
 
     Args:
@@ -214,13 +213,13 @@ async def get_ui_config(request: Request):
     """
     ui_cfg = getattr(request.app.state, "ui_config", {})
     tabs_cfg = ui_cfg.get("tabs", {})
-    fd_enabled = os.getenv("ENABLE_FILE_DOWNLOADER", "").lower() == "true"
+    dl_enabled = bool(ui_cfg.get("downloader", {}).get("enabled", False))
 
     tabs = {}
     for tab in _ALL_TABS:
         enabled = bool(tabs_cfg.get(tab, False))
         if tab == "downloader":
-            enabled = enabled and fd_enabled
+            enabled = enabled and dl_enabled
         tabs[tab] = enabled
 
     return {"tabs": tabs}

--- a/src/main.py
+++ b/src/main.py
@@ -1129,14 +1129,27 @@ def generate_test_data(mapping, rows, output, seed, inject_errors_json, multi_re
 
 
 @cli.command()
-@click.option('--host', default='0.0.0.0', show_default=True,
-              help='Bind address for the server')
-@click.option('--port', default=8000, type=int, show_default=True,
-              help='Port to listen on')
+@click.option('--host', default='0.0.0.0', show_default=True, help='Bind address for the server')
+@click.option('--port', default=8000, type=int, show_default=True, help='Port to listen on')
 def serve(host, port):
     """Start the FastAPI validation server."""
     import uvicorn
-    uvicorn.run("src.api.main:app", host=host, port=port)
+    import yaml
+    from pathlib import Path as _Path
+    from src.services.tls_service import resolve_tls
+
+    _ui_yml = _Path(__file__).parent.parent / "config" / "ui.yml"
+    _tls_config = {}
+    if _ui_yml.exists():
+        _tls_config = (yaml.safe_load(_ui_yml.read_text()) or {}).get("tls", {})
+
+    tls_result = resolve_tls(_tls_config)
+    ssl_kwargs = {}
+    if tls_result:
+        cert_path, key_path = tls_result
+        ssl_kwargs = {"ssl_certfile": str(cert_path), "ssl_keyfile": str(key_path)}
+
+    uvicorn.run("src.api.main:app", host=host, port=port, **ssl_kwargs)
 
 
 def main():

--- a/src/services/downloader_logger.py
+++ b/src/services/downloader_logger.py
@@ -9,43 +9,110 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
-_logger: Optional[logging.Logger] = None
+_DEFAULT_LOG_PATH = "logs/file-downloads.log"
 
 
-def _get_logger() -> logging.Logger:
-    """Return the singleton download activity logger, creating it if needed.
+class DownloaderLogger:
+    """Stateful download activity logger backed by a rotating file handler.
 
-    The logger writes JSON-line entries to a rotating log file. The file path
-    is read from the ``DOWNLOADER_LOG_PATH`` environment variable (default:
-    ``logs/file-downloads.log``). Existing handlers are cleared on each
-    (re)initialisation so that test reloads pick up the correct file path.
+    Each instance writes JSON-line entries to its own log file, so the router
+    can supply the path from ``request.app.state.ui_config`` at construction
+    time rather than relying on an environment variable.
+
+    Args:
+        log_path: Path to the log file. Defaults to
+            ``"logs/file-downloads.log"``. Parent directories are created
+            automatically.
+    """
+
+    def __init__(self, log_path: str = _DEFAULT_LOG_PATH) -> None:
+        self._log_path = log_path
+        self._logger = self._build_logger(log_path)
+
+    @staticmethod
+    def _build_logger(log_path: str) -> logging.Logger:
+        """Create and configure a rotating file logger for *log_path*.
+
+        Args:
+            log_path: Destination file path.
+
+        Returns:
+            Configured ``logging.Logger`` instance.
+        """
+        path = Path(log_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Use a unique logger name per path so parallel instances don't clash.
+        logger = logging.getLogger(f"valdo.downloader.{log_path}")
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        logger.handlers.clear()
+
+        handler = logging.handlers.TimedRotatingFileHandler(
+            filename=str(path), when="midnight", backupCount=30, utc=True
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        return logger
+
+    def log_activity(
+        self,
+        *,
+        operation: str,
+        client_ip: str,
+        client_host: str,
+        path: str,
+        filename: str,
+        archive: Optional[str],
+        status: str,
+    ) -> None:
+        """Write a JSON-line entry to the download activity log.
+
+        Args:
+            operation: ``"download"``, ``"search_files"``, or
+                ``"search_archive"``.
+            client_ip: Client IP from ``X-Forwarded-For`` or
+                ``request.client.host``.
+            client_host: Best-effort reverse-DNS hostname (falls back to IP).
+            path: Configured server path that was accessed.
+            filename: File that was downloaded or searched.
+            archive: Archive filename if applicable, else ``None``.
+            status: ``"success"`` or ``"error"``.
+        """
+        entry = {
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "client_ip": client_ip,
+            "client_host": client_host,
+            "operation": operation,
+            "path": path,
+            "archive": archive,
+            "file": filename,
+            "environment": os.getenv("CM3_ENVIRONMENT", "unknown"),
+            "status": status,
+        }
+        self._logger.info(json.dumps(entry))
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience shims for backwards compatibility.
+# The downloader router now constructs a DownloaderLogger directly; the
+# functions below remain so existing callers (e.g. old tests that import
+# log_activity and resolve_client_info at module level) continue to work.
+# ---------------------------------------------------------------------------
+
+_module_logger: Optional[DownloaderLogger] = None
+
+
+def _get_module_logger() -> DownloaderLogger:
+    """Return the module-level singleton DownloaderLogger.
 
     Returns:
-        Configured ``logging.Logger`` instance for download activity.
+        Singleton :class:`DownloaderLogger` using the default log path.
     """
-    global _logger
-    if _logger is not None:
-        return _logger
-
-    log_path = Path(os.getenv("DOWNLOADER_LOG_PATH", "logs/file-downloads.log"))
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-
-    logger = logging.getLogger("valdo.downloader")
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
-
-    # Clear any handlers from previous (test) instantiations so that a module
-    # reload always writes to the path given by the current environment.
-    logger.handlers.clear()
-
-    handler = logging.handlers.TimedRotatingFileHandler(
-        filename=str(log_path), when="midnight", backupCount=30, utc=True
-    )
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    logger.addHandler(handler)
-
-    _logger = logger
-    return logger
+    global _module_logger
+    if _module_logger is None:
+        _module_logger = DownloaderLogger()
+    return _module_logger
 
 
 def log_activity(
@@ -60,27 +127,29 @@ def log_activity(
 ) -> None:
     """Write a JSON-line entry to the download activity log.
 
+    Convenience wrapper around the module-level :class:`DownloaderLogger`
+    singleton. Prefer constructing a :class:`DownloaderLogger` directly
+    when a custom log path is required.
+
     Args:
         operation: ``"download"``, ``"search_files"``, or ``"search_archive"``.
-        client_ip: Client IP from ``X-Forwarded-For`` or ``request.client.host``.
+        client_ip: Client IP from ``X-Forwarded-For`` or
+            ``request.client.host``.
         client_host: Best-effort reverse-DNS hostname (falls back to IP).
         path: Configured server path that was accessed.
         filename: File that was downloaded or searched.
         archive: Archive filename if applicable, else ``None``.
         status: ``"success"`` or ``"error"``.
     """
-    entry = {
-        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "client_ip": client_ip,
-        "client_host": client_host,
-        "operation": operation,
-        "path": path,
-        "archive": archive,
-        "file": filename,
-        "environment": os.getenv("CM3_ENVIRONMENT", "unknown"),
-        "status": status,
-    }
-    _get_logger().info(json.dumps(entry))
+    _get_module_logger().log_activity(
+        operation=operation,
+        client_ip=client_ip,
+        client_host=client_host,
+        path=path,
+        filename=filename,
+        archive=archive,
+        status=status,
+    )
 
 
 def resolve_client_info(request) -> Tuple[str, str]:
@@ -90,10 +159,15 @@ def resolve_client_info(request) -> Tuple[str, str]:
         request: FastAPI ``Request`` object.
 
     Returns:
-        Tuple of ``(ip_address, hostname)``. Hostname falls back to IP on failure.
+        Tuple of ``(ip_address, hostname)``. Hostname falls back to IP on
+        failure.
     """
     forwarded = request.headers.get("X-Forwarded-For")
-    ip = forwarded.split(",")[0].strip() if forwarded else (request.client.host if request.client else "unknown")
+    ip = (
+        forwarded.split(",")[0].strip()
+        if forwarded
+        else (request.client.host if request.client else "unknown")
+    )
     try:
         host = socket.gethostbyaddr(ip)[0]
     except (socket.herror, socket.gaierror, OSError):

--- a/src/services/downloader_service.py
+++ b/src/services/downloader_service.py
@@ -385,6 +385,74 @@ def _grep_search_archive_file(
     return hits, total
 
 
+def search_archives(
+    base_dir: str,
+    archive_pattern: str,
+    member_pattern: str,
+) -> list:
+    """Recursively search for files inside archives matching wildcard patterns.
+
+    Walks *base_dir* recursively to find archive files (``.zip``, ``.tar.gz``,
+    ``.tar``) whose filename matches *archive_pattern* (fnmatch). Then searches
+    inside each matched archive for members whose basename matches
+    *member_pattern*. No full extraction is performed.
+
+    Args:
+        base_dir: Root directory to walk recursively.
+        archive_pattern: Wildcard pattern for archive filenames
+            (e.g. ``"archive_*.zip"``).
+        member_pattern: Wildcard pattern for member basenames
+            (e.g. ``"TRANS_*.txt"``).
+
+    Returns:
+        List of dicts with keys:
+
+        * ``archive_path``: Absolute path to the archive file on disk.
+        * ``member_path``: Full internal path of the matching member.
+    """
+    results = []
+    base = Path(base_dir)
+
+    for archive_file in sorted(base.rglob("*")):
+        if not archive_file.is_file():
+            continue
+        # Filter by supported archive extensions
+        name = archive_file.name
+        is_zip = name.endswith(".zip")
+        is_tar_gz = name.endswith(".tar.gz") or name.endswith(".tgz")
+        is_tar = name.endswith(".tar") and not is_tar_gz
+        if not (is_zip or is_tar_gz or is_tar):
+            continue
+        # Filter archive filename by pattern
+        if not fnmatch.fnmatch(name, archive_pattern):
+            continue
+
+        try:
+            if is_zip:
+                with zipfile.ZipFile(archive_file, "r") as zf:
+                    for member in zf.namelist():
+                        if fnmatch.fnmatch(Path(member).name, member_pattern):
+                            results.append({
+                                "archive_path": str(archive_file),
+                                "member_path": member,
+                            })
+            else:
+                # .tar.gz, .tgz, or plain .tar
+                mode = "r:gz" if is_tar_gz else "r:"
+                with tarfile.open(archive_file, mode) as tf:
+                    for m in tf.getmembers():
+                        if fnmatch.fnmatch(Path(m.name).name, member_pattern):
+                            results.append({
+                                "archive_path": str(archive_file),
+                                "member_path": m.name,
+                            })
+        except Exception as exc:
+            _log.warning("Skipping unreadable archive %s: %s", archive_file, exc)
+            continue
+
+    return results
+
+
 def search_in_archives(
     path: Path,
     archive_pattern: str,

--- a/src/services/tls_service.py
+++ b/src/services/tls_service.py
@@ -1,0 +1,339 @@
+"""TLS certificate resolution service with pluggable strategy support.
+
+Implements a strategy pattern so that switching TLS mode requires only a
+``config/ui.yml`` change — no code modifications needed.
+
+Supported strategies
+--------------------
+- ``manual``       — use pre-existing cert/key files at configured paths
+- ``self_signed``  — generate a self-signed cert at server startup
+- ``enterprise_ca``— fetch cert/key from an enterprise CA REST API
+
+Usage::
+
+    from src.services.tls_service import resolve_tls
+
+    tls_result = resolve_tls(ui_yml_tls_section)
+    if tls_result:
+        cert_path, key_path = tls_result
+        uvicorn.run(..., ssl_certfile=str(cert_path), ssl_keyfile=str(key_path))
+"""
+import datetime
+import logging
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class TLSStrategy(ABC):
+    """Abstract base for TLS certificate resolution strategies.
+
+    Subclasses must implement :meth:`resolve` and return a
+    ``(cert_path, key_path)`` tuple.
+    """
+
+    @abstractmethod
+    def resolve(self, config: dict) -> tuple:
+        """Resolve cert and key paths, generating or fetching as needed.
+
+        Args:
+            config: The ``tls`` section dict from ``ui.yml``.
+
+        Returns:
+            Tuple of ``(cert_path, key_path)`` as :class:`pathlib.Path` objects.
+
+        Raises:
+            RuntimeError: If the cert cannot be resolved.
+        """
+
+
+class ManualTLSStrategy(TLSStrategy):
+    """Use pre-existing cert/key files at paths specified in ``ui.yml``.
+
+    The paths must exist on disk before the server starts.  No generation
+    or network calls are made.
+
+    Required config keys:
+        ``cert_path`` — absolute path to the PEM certificate.
+        ``key_path``  — absolute path to the PEM private key.
+    """
+
+    def resolve(self, config: dict) -> tuple:
+        """Return the configured cert/key paths after verifying they exist.
+
+        Args:
+            config: The ``tls`` section dict from ``ui.yml``.
+
+        Returns:
+            ``(cert_path, key_path)`` as :class:`pathlib.Path` objects.
+
+        Raises:
+            RuntimeError: If either file does not exist.
+        """
+        cert = Path(config["cert_path"])
+        key = Path(config["key_path"])
+        if not cert.exists():
+            raise RuntimeError(f"TLS cert not found: {cert}")
+        if not key.exists():
+            raise RuntimeError(f"TLS key not found: {key}")
+        return cert, key
+
+
+class SelfSignedTLSStrategy(TLSStrategy):
+    """Generate a self-signed TLS certificate at server startup.
+
+    Requires the ``cryptography`` package (``pip install cryptography``).
+    The certificate is written to the configured paths and is valid for
+    365 days.  The ``cn`` and ``san`` config keys control the certificate
+    subject / SANs.
+
+    Optional config keys:
+        ``cert_path`` — destination PEM cert file (default:
+            ``/tmp/valdo-tls/cert.pem``).
+        ``key_path``  — destination PEM key file (default:
+            ``/tmp/valdo-tls/key.pem``).
+        ``cn``        — common name (default: ``localhost``).
+        ``san``       — list of DNS names or IP addresses for the SAN
+            extension (default: ``[cn]``).
+    """
+
+    def resolve(self, config: dict) -> tuple:
+        """Generate a self-signed cert/key pair and return their paths.
+
+        Args:
+            config: The ``tls`` section dict from ``ui.yml``.
+
+        Returns:
+            ``(cert_path, key_path)`` as :class:`pathlib.Path` objects.
+
+        Raises:
+            RuntimeError: If the ``cryptography`` package is not installed.
+        """
+        try:
+            from cryptography import x509
+            from cryptography.hazmat.primitives import hashes, serialization
+            from cryptography.hazmat.primitives.asymmetric import rsa
+            from cryptography.x509.oid import NameOID
+        except ImportError as exc:
+            raise RuntimeError(
+                "cryptography package required for self_signed TLS. "
+                "Install with: pip install cryptography"
+            ) from exc
+
+        cert_path = Path(config.get("cert_path", "/tmp/valdo-tls/cert.pem"))
+        key_path = Path(config.get("key_path", "/tmp/valdo-tls/key.pem"))
+        cn = config.get("cn", "localhost")
+        san_names = config.get("san", [cn])
+
+        cert_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Generate private key
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_path.write_bytes(
+            private_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            )
+        )
+
+        # Build SAN list — split IP addresses from DNS names
+        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+        san_list = []
+        for name in san_names:
+            try:
+                import ipaddress as _ip
+                san_list.append(x509.IPAddress(_ip.ip_address(name)))
+            except ValueError:
+                san_list.append(x509.DNSName(name))
+
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow())
+            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=365))
+            .add_extension(x509.SubjectAlternativeName(san_list), critical=False)
+            .sign(private_key, hashes.SHA256())
+        )
+        cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+        logger.info("Self-signed TLS cert generated: %s (CN=%s)", cert_path, cn)
+        return cert_path, key_path
+
+
+class EnterpriseCAStrategy(TLSStrategy):
+    """Fetch a TLS certificate from an enterprise certificate authority API.
+
+    On first call the strategy POSTs a JSON request to ``ca_api_url`` and
+    caches the returned cert/key to disk.  On subsequent calls it returns
+    the cached cert if its remaining validity exceeds ``expiry_warn_days``.
+
+    Required config keys:
+        ``ca_api_url``       — URL of the CA issuance endpoint.
+
+    Optional config keys:
+        ``cert_path``        — destination PEM cert (default:
+            ``/tmp/valdo-tls/cert.pem``).
+        ``key_path``         — destination PEM key (default:
+            ``/tmp/valdo-tls/key.pem``).
+        ``cn``               — common name sent in the API request
+            (default: ``localhost``).
+        ``san``              — SAN list sent in the API request
+            (default: ``[cn]``).
+        ``ca_api_token_env`` — name of the env var holding the bearer token
+            (default: ``CA_API_TOKEN``).
+        ``expiry_warn_days`` — minimum days of validity required to use the
+            cached cert (default: ``30``).
+    """
+
+    def resolve(self, config: dict) -> tuple:
+        """Return cert/key paths, using cache if valid or fetching from CA.
+
+        Args:
+            config: The ``tls`` section dict from ``ui.yml``.
+
+        Returns:
+            ``(cert_path, key_path)`` as :class:`pathlib.Path` objects.
+
+        Raises:
+            RuntimeError: If the CA API returns an error or the response
+                cannot be parsed.
+        """
+        import json
+        import urllib.request
+
+        ca_api_url = config["ca_api_url"]
+        token_env = config.get("ca_api_token_env", "CA_API_TOKEN")
+        token = os.getenv(token_env, "")
+        cert_path = Path(config.get("cert_path", "/tmp/valdo-tls/cert.pem"))
+        key_path = Path(config.get("key_path", "/tmp/valdo-tls/key.pem"))
+        cn = config.get("cn", "localhost")
+        san_names = config.get("san", [cn])
+        warn_days = config.get("expiry_warn_days", 30)
+
+        # Return cached cert if still sufficiently valid
+        if cert_path.exists() and key_path.exists():
+            cached_expiry = _cert_expiry(cert_path)
+            if cached_expiry and cached_expiry > datetime.datetime.utcnow() + datetime.timedelta(
+                days=warn_days
+            ):
+                logger.info(
+                    "Using cached enterprise cert (expires %s)", cached_expiry.date()
+                )
+                return cert_path, key_path
+
+        # Fetch from CA API
+        payload = json.dumps({"cn": cn, "san": san_names}).encode()
+        req = urllib.request.Request(
+            ca_api_url,
+            data=payload,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+
+        cert_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        cert_path.write_text(data["cert"])
+        key_path.write_text(data["key"])
+        logger.info("Enterprise CA cert fetched and cached to %s", cert_path)
+        return cert_path, key_path
+
+
+def _cert_expiry(cert_path: Path):
+    """Return the expiry :class:`datetime.datetime` of a PEM cert, or ``None``.
+
+    Args:
+        cert_path: Path to the PEM-encoded X.509 certificate.
+
+    Returns:
+        A naive UTC :class:`datetime.datetime` representing the
+        ``notAfter`` field, or ``None`` if the cert cannot be read or
+        the ``cryptography`` package is unavailable.
+    """
+    try:
+        from cryptography import x509 as _x509
+
+        cert = _x509.load_pem_x509_certificate(cert_path.read_bytes())
+        # not_valid_after_utc is available in cryptography >= 42; fall back
+        # to not_valid_after for older installs.
+        try:
+            return cert.not_valid_after_utc.replace(tzinfo=None)
+        except AttributeError:
+            return cert.not_valid_after  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover
+        return None
+
+
+_STRATEGIES: dict = {
+    "manual": ManualTLSStrategy,
+    "self_signed": SelfSignedTLSStrategy,
+    "enterprise_ca": EnterpriseCAStrategy,
+}
+
+
+def resolve_tls(tls_config: dict):
+    """Resolve TLS cert and key from the ``tls`` section of ``ui.yml``.
+
+    This is the primary public entry-point used by the ``valdo serve``
+    command.  If TLS is disabled (or the config is empty) it returns
+    ``None`` and the server starts in plain HTTP mode.
+
+    Args:
+        tls_config: The ``tls`` dict parsed from ``config/ui.yml``.
+            Pass ``{}`` or ``None`` for no TLS.
+
+    Returns:
+        A ``(cert_path, key_path)`` tuple of :class:`pathlib.Path` objects,
+        or ``None`` when TLS is disabled.
+
+    Raises:
+        RuntimeError: If the strategy name is unrecognised or cert
+            resolution fails.
+
+    Example::
+
+        result = resolve_tls({"enabled": True, "strategy": "self_signed",
+                               "cn": "valdo.internal"})
+        if result:
+            cert_path, key_path = result
+    """
+    if not tls_config or not tls_config.get("enabled", False):
+        return None
+
+    strategy_name = tls_config.get("strategy", "manual")
+    strategy_cls = _STRATEGIES.get(strategy_name)
+    if not strategy_cls:
+        raise RuntimeError(
+            f"Unknown TLS strategy: {strategy_name!r}. Valid: {list(_STRATEGIES)}"
+        )
+
+    strategy = strategy_cls()
+    cert_path, key_path = strategy.resolve(tls_config)
+
+    # Log cert info and warn if near expiry
+    expiry = _cert_expiry(cert_path)
+    warn_days = tls_config.get("expiry_warn_days", 30)
+    logger.info(
+        "TLS strategy=%s cert=%s expires=%s",
+        strategy_name,
+        cert_path,
+        expiry.date() if expiry else "unknown",
+    )
+    if expiry:
+        days_left = (expiry - datetime.datetime.utcnow()).days
+        if days_left < warn_days:
+            logger.warning(
+                "TLS cert expires in %d days (threshold: %d)", days_left, warn_days
+            )
+
+    return cert_path, key_path

--- a/tests/unit/test_downloader_archive_search.py
+++ b/tests/unit/test_downloader_archive_search.py
@@ -1,0 +1,161 @@
+# tests/unit/test_downloader_archive_search.py
+"""Unit tests for downloader_service.search_archives (Issue #366)."""
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from src.services.downloader_service import search_archives
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_zip(path: Path, members: dict) -> Path:
+    """Create a zip archive at *path* with *members* (name → bytes)."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+    return path
+
+
+def _make_tar_gz(path: Path, members: dict) -> Path:
+    """Create a .tar.gz archive at *path* with *members* (name → bytes)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in members.items():
+            raw = data if isinstance(data, bytes) else data.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(raw)
+            tf.addfile(info, io.BytesIO(raw))
+    path.write_bytes(buf.getvalue())
+    return path
+
+
+def _make_tar(path: Path, members: dict) -> Path:
+    """Create a plain .tar archive at *path* with *members* (name → bytes)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:") as tf:
+        for name, data in members.items():
+            raw = data if isinstance(data, bytes) else data.encode()
+            info = tarfile.TarInfo(name=name)
+            info.size = len(raw)
+            tf.addfile(info, io.BytesIO(raw))
+    path.write_bytes(buf.getvalue())
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_search_zip_root_level(tmp_path):
+    """zip at root of base_dir with a matching member is found."""
+    _make_zip(tmp_path / "archive_2026.zip", {"TRANS_001.txt": b"hello"})
+    results = search_archives(str(tmp_path), "archive_*.zip", "TRANS_*.txt")
+    assert len(results) == 1
+    assert results[0]["archive_path"] == str(tmp_path / "archive_2026.zip")
+    assert results[0]["member_path"] == "TRANS_001.txt"
+
+
+def test_search_zip_nested_2_levels(tmp_path):
+    """zip nested two sub-directories deep is discovered via rglob."""
+    nested = tmp_path / "subdir" / "subdir2"
+    nested.mkdir(parents=True)
+    _make_zip(nested / "archive_deep.zip", {"BATCH.txt": b"data"})
+    results = search_archives(str(tmp_path), "archive_deep.zip", "BATCH.txt")
+    assert len(results) == 1
+    assert "subdir2" in results[0]["archive_path"]
+
+
+def test_search_tar_gz(tmp_path):
+    """.tar.gz archive member match is returned."""
+    _make_tar_gz(tmp_path / "logs_2026.tar.gz", {"server.log": b"entry"})
+    results = search_archives(str(tmp_path), "logs_*.tar.gz", "server.log")
+    assert len(results) == 1
+    assert results[0]["member_path"] == "server.log"
+
+
+def test_search_tar(tmp_path):
+    """Plain .tar archive member match is returned."""
+    _make_tar(tmp_path / "backup.tar", {"data.csv": b"row1"})
+    results = search_archives(str(tmp_path), "backup.tar", "data.csv")
+    assert len(results) == 1
+    assert results[0]["member_path"] == "data.csv"
+
+
+def test_wildcard_archive_name(tmp_path):
+    """archive_name_*.zip pattern matches only the targeted archive."""
+    _make_zip(tmp_path / "archive_JAN.zip", {"report.txt": b"x"})
+    _make_zip(tmp_path / "other_FEB.zip", {"report.txt": b"y"})
+    results = search_archives(str(tmp_path), "archive_*.zip", "report.txt")
+    paths = [r["archive_path"] for r in results]
+    assert any("archive_JAN.zip" in p for p in paths)
+    assert not any("other_FEB.zip" in p for p in paths)
+
+
+def test_wildcard_member_name(tmp_path):
+    """TRANS_*.txt wildcard matches a nested member."""
+    _make_zip(tmp_path / "batch.zip", {"TRANS_20260401.txt": b"payload"})
+    results = search_archives(str(tmp_path), "batch.zip", "TRANS_*.txt")
+    assert len(results) == 1
+    assert "TRANS_20260401.txt" in results[0]["member_path"]
+
+
+def test_no_match_archive(tmp_path):
+    """archive_pattern that matches no file returns empty list."""
+    _make_zip(tmp_path / "data.zip", {"file.txt": b"content"})
+    results = search_archives(str(tmp_path), "nonexistent_*.zip", "file.txt")
+    assert results == []
+
+
+def test_no_match_member(tmp_path):
+    """Archive found but member pattern matches nothing returns empty list."""
+    _make_zip(tmp_path / "batch.zip", {"other.csv": b"row"})
+    results = search_archives(str(tmp_path), "batch.zip", "TRANS_*.txt")
+    assert results == []
+
+
+def test_member_in_nested_dir_inside_archive(tmp_path):
+    """Member at data/2026/april/TRANS.txt is matched by TRANS*.txt via basename."""
+    _make_zip(tmp_path / "archive.zip", {"data/2026/april/TRANS.txt": b"nested"})
+    results = search_archives(str(tmp_path), "archive.zip", "TRANS*.txt")
+    assert len(results) == 1
+    assert results[0]["member_path"] == "data/2026/april/TRANS.txt"
+
+
+def test_result_has_archive_path_and_member_path(tmp_path):
+    """Every result dict has exactly 'archive_path' and 'member_path' keys."""
+    _make_zip(tmp_path / "a.zip", {"f.txt": b"x"})
+    results = search_archives(str(tmp_path), "a.zip", "f.txt")
+    assert len(results) == 1
+    assert set(results[0].keys()) == {"archive_path", "member_path"}
+
+
+def test_corrupt_archive_skipped(tmp_path):
+    """A corrupt/unreadable archive is silently skipped; valid ones still return results."""
+    (tmp_path / "corrupt.zip").write_bytes(b"this is not a zip")
+    _make_zip(tmp_path / "valid.zip", {"data.txt": b"ok"})
+    results = search_archives(str(tmp_path), "*.zip", "data.txt")
+    # corrupt archive is skipped; valid.zip contributes 1 result
+    paths = [r["archive_path"] for r in results]
+    assert any("valid.zip" in p for p in paths)
+    assert not any("corrupt.zip" in p for p in paths)
+
+
+def test_multiple_members_matched(tmp_path):
+    """Multiple matching members in a single archive are all returned."""
+    _make_zip(tmp_path / "multi.zip", {
+        "TRANS_A.txt": b"a",
+        "TRANS_B.txt": b"b",
+        "OTHER.csv": b"c",
+    })
+    results = search_archives(str(tmp_path), "multi.zip", "TRANS_*.txt")
+    member_names = {r["member_path"] for r in results}
+    assert "TRANS_A.txt" in member_names
+    assert "TRANS_B.txt" in member_names
+    assert "OTHER.csv" not in member_names

--- a/tests/unit/test_downloader_config_consolidation.py
+++ b/tests/unit/test_downloader_config_consolidation.py
@@ -1,0 +1,82 @@
+# tests/unit/test_downloader_config_consolidation.py
+"""Unit tests for Issue #365 — env-based config consolidation into ui.yml."""
+
+import io
+import logging
+import logging.handlers
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_log_path_from_constructor(tmp_path):
+    """DownloaderLogger accepts log_path as a constructor parameter."""
+    from src.services.downloader_logger import DownloaderLogger
+
+    log_file = tmp_path / "custom.log"
+    dl = DownloaderLogger(log_path=str(log_file))
+    dl.log_activity(
+        operation="download",
+        client_ip="1.2.3.4",
+        client_host="host",
+        path="/data",
+        filename="f.txt",
+        archive=None,
+        status="success",
+    )
+    assert log_file.exists()
+    import json
+    entry = json.loads(log_file.read_text().strip())
+    assert entry["operation"] == "download"
+
+
+def test_log_path_default(tmp_path, monkeypatch):
+    """DownloaderLogger uses default log path when none supplied."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "logs").mkdir()
+    from src.services.downloader_logger import DownloaderLogger
+
+    dl = DownloaderLogger()
+    assert "file-downloads.log" in dl._log_path
+
+
+def test_deprecated_file_downloader_yml_comment():
+    """config/file-downloader.yml contains the DEPRECATED comment."""
+    config_path = Path(__file__).parent.parent.parent / "config" / "file-downloader.yml"
+    assert config_path.exists(), "config/file-downloader.yml must still exist"
+    content = config_path.read_text()
+    assert "DEPRECATED" in content
+
+
+def test_enable_flag_from_ui_yml(tmp_path):
+    """Router registration reads downloader.enabled from ui.yml, not env var."""
+    # Confirm the env var ENABLE_FILE_DOWNLOADER is no longer referenced
+    # in src/api/main.py for router registration.
+    main_path = Path(__file__).parent.parent.parent / "src" / "api" / "main.py"
+    source = main_path.read_text()
+    # The old env-var gate must be gone
+    assert "ENABLE_FILE_DOWNLOADER" not in source, (
+        "src/api/main.py must not reference ENABLE_FILE_DOWNLOADER for registration"
+    )
+    # The new gate must read from ui_config / ui.yml
+    assert "downloader" in source
+
+
+def test_system_router_no_enable_file_downloader():
+    """src/api/routers/system.py no longer references ENABLE_FILE_DOWNLOADER."""
+    system_path = Path(__file__).parent.parent.parent / "src" / "api" / "routers" / "system.py"
+    source = system_path.read_text()
+    assert "ENABLE_FILE_DOWNLOADER" not in source, (
+        "system.py must not reference ENABLE_FILE_DOWNLOADER"
+    )
+
+
+def test_downloader_router_uses_ui_config_not_fd_config():
+    """downloader.py router reads from ui_config, not fd_config."""
+    router_path = Path(__file__).parent.parent.parent / "src" / "api" / "routers" / "downloader.py"
+    source = router_path.read_text()
+    # Must NOT reference fd_config
+    assert "fd_config" not in source, (
+        "downloader.py must not reference fd_config — use ui_config instead"
+    )
+    # Must reference ui_config
+    assert "ui_config" in source

--- a/tests/unit/test_downloader_logger.py
+++ b/tests/unit/test_downloader_logger.py
@@ -2,15 +2,15 @@ import json
 import os
 from unittest.mock import patch
 
+from src.services.downloader_logger import DownloaderLogger
+
 
 def test_log_writes_json_line(tmp_path):
     log_path = tmp_path / "dl.log"
-    with patch.dict(os.environ, {"DOWNLOADER_LOG_PATH": str(log_path), "CM3_ENVIRONMENT": "SIT"}):
-        from importlib import reload
-        import src.services.downloader_logger as mod
-        reload(mod)
-        mod.log_activity(operation="download", client_ip="10.0.0.1", client_host="host1",
-                         path="/data/batch", filename="r.csv", archive="b.tar.gz", status="success")
+    with patch.dict(os.environ, {"CM3_ENVIRONMENT": "SIT"}):
+        dl = DownloaderLogger(log_path=str(log_path))
+        dl.log_activity(operation="download", client_ip="10.0.0.1", client_host="host1",
+                        path="/data/batch", filename="r.csv", archive="b.tar.gz", status="success")
     entry = json.loads(log_path.read_text().strip())
     assert entry["operation"] == "download"
     assert entry["client_ip"] == "10.0.0.1"
@@ -22,11 +22,9 @@ def test_log_writes_json_line(tmp_path):
 
 def test_log_no_archive(tmp_path):
     log_path = tmp_path / "dl.log"
-    with patch.dict(os.environ, {"DOWNLOADER_LOG_PATH": str(log_path), "CM3_ENVIRONMENT": "DEV"}):
-        from importlib import reload
-        import src.services.downloader_logger as mod
-        reload(mod)
-        mod.log_activity(operation="search_files", client_ip="1.2.3.4", client_host="h",
-                         path="/opt/logs", filename="e.log", archive=None, status="success")
+    with patch.dict(os.environ, {"CM3_ENVIRONMENT": "DEV"}):
+        dl = DownloaderLogger(log_path=str(log_path))
+        dl.log_activity(operation="search_files", client_ip="1.2.3.4", client_host="h",
+                        path="/opt/logs", filename="e.log", archive=None, status="success")
     entry = json.loads(log_path.read_text().strip())
     assert entry["archive"] is None

--- a/tests/unit/test_downloader_router.py
+++ b/tests/unit/test_downloader_router.py
@@ -17,7 +17,7 @@ def _reset_app_module():
     """Reload src.api.main after each test to prevent auth state leaking.
 
     Captures the environment BEFORE the test runs so the restore snapshot
-    never contains test-injected API_KEYS or ENABLE_FILE_DOWNLOADER values.
+    never contains test-injected API_KEYS values.
     """
     saved = os.environ.copy()
     yield
@@ -28,30 +28,41 @@ def _reset_app_module():
 
 
 def _make_client(tmp_path: Path, env: dict, allowed_path: str = None):
-    """Reload the FastAPI app and return (client, patch_ctx) tuple.
+    """Reload the FastAPI app and return a TestClient with ui_config set.
 
-    The caller must use the patch context as a context manager to ensure
-    environment variables are active when requests are made.
+    Patches ``yaml.safe_load`` during the reload so the downloader router is
+    conditionally registered (``enabled: True``), then injects ``ui_config``
+    into ``app.state`` with the allowed paths for path-validation tests.
 
     Args:
-        tmp_path: Temporary directory to use as the fd_config allowed path.
+        tmp_path: Temporary directory to use as the ui_config allowed path.
         env: Environment variables to apply via ``patch.dict``.
         allowed_path: Override for the single allowed path label entry.
             Defaults to ``str(tmp_path)``.
 
     Returns:
-        Tuple of ``(TestClient, app_module)`` with env already patched in.
+        Configured ``TestClient`` with downloader ui_config injected.
     """
+    import yaml
     import src.api.main as m
-    reload(m)
     path_str = allowed_path if allowed_path is not None else str(tmp_path)
-    m.app.state.fd_config = {"paths": [{"label": "T", "path": path_str}]}
+    dl_cfg = {
+        "enabled": True,
+        "log_path": "logs/file-downloads.log",
+        "paths": [{"label": "T", "path": path_str}],
+    }
+    ui_cfg = {"downloader": dl_cfg}
+    # Patch yaml.safe_load so _ui_cfg_early picks up enabled=True at module
+    # reload time, which causes the router to be registered.
+    with patch.object(yaml, "safe_load", return_value=ui_cfg):
+        reload(m)
+    m.app.state.ui_config = ui_cfg
     return TestClient(m.app)
 
 
 def test_get_paths(tmp_path):
     """GET /paths returns configured paths from app state."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.get("/api/v1/downloader/paths", headers={"X-API-Key": "k"})
@@ -62,7 +73,7 @@ def test_get_paths(tmp_path):
 def test_browse_lists_files(tmp_path):
     """GET /browse returns file entries in the specified directory."""
     (tmp_path / "report.csv").write_text("a,b")
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.get(
@@ -77,7 +88,7 @@ def test_browse_rejects_unlisted_path(tmp_path):
     """GET /browse returns 403 for a path not in allowed_paths."""
     other = tmp_path / "other"
     other.mkdir()
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env, allowed_path=str(tmp_path / "safe"))
         r = client.get(
@@ -90,7 +101,7 @@ def test_browse_rejects_unlisted_path(tmp_path):
 def test_download_plain_file(tmp_path):
     """POST /download streams a plain file from disk."""
     (tmp_path / "r.csv").write_text("col1,col2\n")
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.post(
@@ -104,7 +115,7 @@ def test_download_plain_file(tmp_path):
 
 def test_download_rejects_absolute_filename(tmp_path):
     """POST /download returns 400 when filename is an absolute path."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.post(
@@ -117,7 +128,7 @@ def test_download_rejects_absolute_filename(tmp_path):
 
 def test_download_rejects_path_traversal_filename(tmp_path):
     """POST /download returns 400 when filename contains path traversal."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.post(
@@ -129,7 +140,7 @@ def test_download_rejects_path_traversal_filename(tmp_path):
 
 
 def _setup_app(tmp_path: Path, env: dict) -> TestClient:
-    """Create a TestClient with env patched in and fd_config set.
+    """Create a TestClient with env patched in and ui_config set.
 
     Unlike ``_make_client``, this helper patches the environment permanently
     for the lifetime of the returned client (uses ``patch.dict`` without a
@@ -137,22 +148,19 @@ def _setup_app(tmp_path: Path, env: dict) -> TestClient:
     outside of a ``with`` block.
 
     Args:
-        tmp_path: Directory used as the single allowed path in fd_config.
+        tmp_path: Directory used as the single allowed path in ui_config.
         env: Environment variables to inject via ``os.environ``.
 
     Returns:
         Configured ``TestClient`` with the patched app state.
     """
     patch.dict(os.environ, env).__enter__()
-    import src.api.main as m
-    reload(m)
-    m.app.state.fd_config = {"paths": [{"label": "T", "path": str(tmp_path)}]}
-    return TestClient(m.app)
+    return _make_client(tmp_path, env)
 
 
 def test_search_files_returns_results(tmp_path):
     (tmp_path / "errors.log").write_text("line1\nERROR found\nline3\n")
-    client = _setup_app(tmp_path, {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"})
+    client = _setup_app(tmp_path, {"API_KEYS": "k"})
     r = client.post("/api/v1/downloader/search-files",
                     json={"path": str(tmp_path), "filename_pattern": "*.log", "search_string": "ERROR"},
                     headers={"X-API-Key": "k"})
@@ -170,7 +178,7 @@ def test_search_archive_returns_results(tmp_path):
         info.size = len(data)
         tf.addfile(info, io.BytesIO(data))
     (tmp_path / "batch.tar.gz").write_bytes(buf.getvalue())
-    client = _setup_app(tmp_path, {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"})
+    client = _setup_app(tmp_path, {"API_KEYS": "k"})
     r = client.post("/api/v1/downloader/search-archive",
                     json={"path": str(tmp_path), "archive_pattern": "*.tar.gz",
                           "file_pattern": "*.log", "search_string": "ERROR"},
@@ -182,13 +190,9 @@ def test_search_archive_returns_results(tmp_path):
 def test_browse_returns_404_for_missing_directory(tmp_path):
     """GET /browse returns 404 when the directory does not exist."""
     missing = str(tmp_path / "nonexistent")
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     # Allow the parent so the path validation passes, but the subdir is missing
     with patch.dict(os.environ, env):
-        import src.api.main as m
-        from importlib import reload
-        reload(m)
-        m.app.state.fd_config = {"paths": [{"label": "T", "path": str(tmp_path)}]}
         client = _make_client(tmp_path, env)
         r = client.get(
             f"/api/v1/downloader/browse?path={missing}",
@@ -199,7 +203,7 @@ def test_browse_returns_404_for_missing_directory(tmp_path):
 
 def test_archive_contents_returns_404_when_archive_missing(tmp_path):
     """GET /archive-contents returns 404 when archive file does not exist."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.get(
@@ -213,7 +217,7 @@ def test_archive_contents_returns_400_for_unsupported_format(tmp_path):
     """GET /archive-contents returns 400 for an unsupported archive format."""
     bad_archive = tmp_path / "data.rar"
     bad_archive.write_bytes(b"not a real rar")
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.get(
@@ -225,7 +229,7 @@ def test_archive_contents_returns_400_for_unsupported_format(tmp_path):
 
 def test_download_archive_not_found_returns_404(tmp_path):
     """POST /download returns 404 when the named archive does not exist."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.post(
@@ -251,7 +255,7 @@ def test_download_inner_file_not_found_raises(tmp_path):
         info.size = len(data)
         tf.addfile(info, io.BytesIO(data))
     (tmp_path / "batch.tar.gz").write_bytes(buf.getvalue())
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         with pytest.raises(FileNotFoundError, match="missing.csv"):
@@ -264,7 +268,7 @@ def test_download_inner_file_not_found_raises(tmp_path):
 
 def test_download_plain_file_not_found_returns_404(tmp_path):
     """POST /download returns 404 when plain file does not exist."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.post(
@@ -277,7 +281,7 @@ def test_download_plain_file_not_found_returns_404(tmp_path):
 
 def test_download_rejects_path_traversal_archive_name(tmp_path):
     """POST /download returns 400 when archive name contains path traversal."""
-    env = {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"}
+    env = {"API_KEYS": "k"}
     with patch.dict(os.environ, env):
         client = _make_client(tmp_path, env)
         r = client.post(
@@ -297,7 +301,7 @@ def test_download_nested_archive_inner_file(tmp_path):
         info.size = len(data)
         tf.addfile(info, io.BytesIO(data))
     (tmp_path / "a.tar.gz").write_bytes(buf.getvalue())
-    client = _setup_app(tmp_path, {"ENABLE_FILE_DOWNLOADER": "true", "API_KEYS": "k"})
+    client = _setup_app(tmp_path, {"API_KEYS": "k"})
     r = client.post(
         "/api/v1/downloader/download",
         json={"path": str(tmp_path), "filename": "subdir/nested.log", "archive": "a.tar.gz"},

--- a/tests/unit/test_ip_whitelist_middleware.py
+++ b/tests/unit/test_ip_whitelist_middleware.py
@@ -1,0 +1,140 @@
+"""Unit tests for IPWhitelistMiddleware.
+
+Note on TestClient: Starlette's TestClient sets ``request.client.host`` to the
+string ``"testclient"`` (not a real IP).  Tests that need to exercise IP-based
+allow/deny logic for a specific address therefore use ``trust_proxy=True`` and
+supply an ``X-Forwarded-For`` header so the middleware reads a controllable IP.
+Tests that verify the *no-whitelist* (open) path use the raw testclient host,
+which is always allowed when the whitelist is empty.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from src.api.middleware.ip_whitelist import IPWhitelistMiddleware
+
+
+def make_app(whitelist, trust_proxy=False):
+    """Create a minimal FastAPI app with IPWhitelistMiddleware attached.
+
+    Args:
+        whitelist: List of IP addresses and/or CIDR ranges to allow.
+        trust_proxy: If True, use X-Forwarded-For header as client IP.
+
+    Returns:
+        FastAPI application with the middleware and a /ping route.
+    """
+    app = FastAPI()
+    app.add_middleware(IPWhitelistMiddleware, whitelist=whitelist, trust_proxy=trust_proxy)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    return app
+
+
+def test_empty_whitelist_allows_all():
+    """No whitelist configured — every IP (including 'testclient') is allowed."""
+    app = make_app(whitelist=[])
+    client = TestClient(app)
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_exact_ip_match_allowed():
+    """An IP that exactly matches a whitelist entry is allowed (200)."""
+    app = make_app(whitelist=["192.168.1.50"], trust_proxy=True)
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Forwarded-For": "192.168.1.50"})
+    assert response.status_code == 200
+
+
+def test_exact_ip_not_in_whitelist_denied():
+    """An IP not in the whitelist is blocked (403)."""
+    app = make_app(whitelist=["10.0.0.1"], trust_proxy=True)
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Forwarded-For": "192.168.1.99"})
+    assert response.status_code == 403
+
+
+def test_cidr_range_match_allowed():
+    """An IP within a CIDR range whitelist entry is allowed (200)."""
+    app = make_app(whitelist=["10.0.0.0/8"], trust_proxy=True)
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Forwarded-For": "10.20.30.40"})
+    assert response.status_code == 200
+
+
+def test_cidr_range_no_match_denied():
+    """An IP outside all CIDR ranges is blocked (403)."""
+    app = make_app(whitelist=["10.0.0.0/8"], trust_proxy=True)
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Forwarded-For": "172.16.0.1"})
+    assert response.status_code == 403
+
+
+def test_multiple_ranges():
+    """IPs from each of multiple ranges are allowed; outside all ranges is denied."""
+    app = make_app(whitelist=["10.0.0.0/8", "192.168.0.0/16"], trust_proxy=True)
+    client = TestClient(app)
+
+    # IP in first range
+    response = client.get("/ping", headers={"X-Forwarded-For": "10.0.0.5"})
+    assert response.status_code == 200
+
+    # IP in second range
+    response2 = client.get("/ping", headers={"X-Forwarded-For": "192.168.5.1"})
+    assert response2.status_code == 200
+
+    # IP outside both ranges
+    response3 = client.get("/ping", headers={"X-Forwarded-For": "172.16.0.1"})
+    assert response3.status_code == 403
+
+
+def test_trust_proxy_x_forwarded_for():
+    """When trust_proxy=True, X-Forwarded-For header is used as client IP."""
+    # Whitelist only 192.168.1.50; provide matching header
+    app = make_app(whitelist=["192.168.1.50"], trust_proxy=True)
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Forwarded-For": "192.168.1.50"})
+    assert response.status_code == 200
+
+
+def test_trust_proxy_false_ignores_header():
+    """When trust_proxy=False, X-Forwarded-For header is NOT used.
+
+    Even if the header contains a whitelisted IP, the actual client host
+    ('testclient', which is not a valid IP) is evaluated instead and blocked.
+    """
+    app = make_app(whitelist=["192.168.1.50"], trust_proxy=False)
+    client = TestClient(app)
+    # Header says whitelisted IP, but trust_proxy=False so it is ignored.
+    # The real client host 'testclient' is not a valid IP → denied.
+    response = client.get("/ping", headers={"X-Forwarded-For": "192.168.1.50"})
+    assert response.status_code == 403
+
+
+def test_invalid_whitelist_entry_ignored():
+    """A non-IP string in the whitelist is silently skipped; valid entries still apply."""
+    # "not-an-ip" should be logged as a warning and ignored.
+    # The remaining valid entry "192.168.1.10" still applies.
+    app = make_app(whitelist=["not-an-ip", "192.168.1.10"], trust_proxy=True)
+    client = TestClient(app)
+    # IP matching the valid entry → allowed
+    response = client.get("/ping", headers={"X-Forwarded-For": "192.168.1.10"})
+    assert response.status_code == 200
+    # IP not matching → denied (middleware is still functional)
+    response2 = client.get("/ping", headers={"X-Forwarded-For": "10.0.0.1"})
+    assert response2.status_code == 403
+
+
+def test_403_response_body():
+    """Blocked response must contain 'error' and 'detail' keys."""
+    app = make_app(whitelist=["10.0.0.1"], trust_proxy=True)
+    client = TestClient(app)
+    response = client.get("/ping", headers={"X-Forwarded-For": "9.9.9.9"})
+    assert response.status_code == 403
+    body = response.json()
+    assert "error" in body
+    assert "detail" in body

--- a/tests/unit/test_tls_service.py
+++ b/tests/unit/test_tls_service.py
@@ -1,0 +1,470 @@
+"""Unit tests for tls_service — config-driven TLS certificate resolution.
+
+Tests cover all three strategies (manual, self_signed, enterprise_ca),
+disabled/empty config paths, expiry warning logging, and the output contract.
+"""
+import datetime
+import importlib
+import json
+import logging
+import unittest.mock as mock
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_self_signed_pem(tmp_path: Path, cn: str = "test.local"):
+    """Generate a minimal self-signed PEM cert+key for testing."""
+    pytest.importorskip("cryptography")
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key_path = tmp_path / "key.pem"
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow())
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=90))
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = tmp_path / "cert.pem"
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    return cert_path, key_path
+
+
+# ---------------------------------------------------------------------------
+# resolve_tls — disabled / empty config
+# ---------------------------------------------------------------------------
+
+class TestResolveTlsDisabled:
+    """Tests for the disabled/empty TLS configuration path."""
+
+    def test_resolve_tls_disabled_flag(self):
+        """enabled: false returns None."""
+        from src.services.tls_service import resolve_tls
+
+        result = resolve_tls({"enabled": False, "strategy": "manual"})
+        assert result is None
+
+    def test_resolve_tls_no_config(self):
+        """Empty dict returns None."""
+        from src.services.tls_service import resolve_tls
+
+        result = resolve_tls({})
+        assert result is None
+
+    def test_resolve_tls_none_config(self):
+        """None returns None."""
+        from src.services.tls_service import resolve_tls
+
+        result = resolve_tls(None)
+        assert result is None
+
+    def test_resolve_tls_missing_enabled_key(self):
+        """Dict without 'enabled' key defaults to disabled."""
+        from src.services.tls_service import resolve_tls
+
+        result = resolve_tls({"strategy": "manual"})
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ManualTLSStrategy
+# ---------------------------------------------------------------------------
+
+class TestManualTLSStrategy:
+    """Tests for the ManualTLSStrategy (pre-existing cert/key on disk)."""
+
+    def test_manual_strategy_resolves_existing_paths(self, tmp_path):
+        """Existing cert and key → returns the correct (Path, Path) tuple."""
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        from src.services.tls_service import ManualTLSStrategy
+
+        c, k = ManualTLSStrategy().resolve(
+            {"cert_path": str(cert), "key_path": str(key)}
+        )
+        assert c == cert
+        assert k == key
+
+    def test_manual_strategy_missing_cert_raises(self, tmp_path):
+        """RuntimeError when cert_path does not exist."""
+        key = tmp_path / "key.pem"
+        key.write_text("KEY")
+
+        from src.services.tls_service import ManualTLSStrategy
+
+        with pytest.raises(RuntimeError, match="cert not found"):
+            ManualTLSStrategy().resolve(
+                {"cert_path": str(tmp_path / "missing.pem"), "key_path": str(key)}
+            )
+
+    def test_manual_strategy_missing_key_raises(self, tmp_path):
+        """RuntimeError when key_path does not exist."""
+        cert = tmp_path / "cert.pem"
+        cert.write_text("CERT")
+
+        from src.services.tls_service import ManualTLSStrategy
+
+        with pytest.raises(RuntimeError, match="key not found"):
+            ManualTLSStrategy().resolve(
+                {"cert_path": str(cert), "key_path": str(tmp_path / "missing.pem")}
+            )
+
+
+# ---------------------------------------------------------------------------
+# SelfSignedTLSStrategy
+# ---------------------------------------------------------------------------
+
+class TestSelfSignedTLSStrategy:
+    """Tests for the SelfSignedTLSStrategy (runtime cert generation)."""
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("cryptography") is None,
+        reason="cryptography package not installed",
+    )
+    def test_self_signed_generates_cert(self, tmp_path):
+        """Generates cert and key files at the configured paths."""
+        from src.services.tls_service import SelfSignedTLSStrategy
+
+        cert_path = tmp_path / "cert.pem"
+        key_path = tmp_path / "key.pem"
+
+        c, k = SelfSignedTLSStrategy().resolve(
+            {
+                "cert_path": str(cert_path),
+                "key_path": str(key_path),
+                "cn": "localhost",
+                "san": ["localhost"],
+            }
+        )
+        assert c.exists()
+        assert k.exists()
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("cryptography") is None,
+        reason="cryptography package not installed",
+    )
+    def test_self_signed_cert_readable(self, tmp_path):
+        """Generated cert is valid PEM that can be parsed by cryptography."""
+        from cryptography import x509
+        from src.services.tls_service import SelfSignedTLSStrategy
+
+        cert_path = tmp_path / "cert.pem"
+        key_path = tmp_path / "key.pem"
+
+        c, _ = SelfSignedTLSStrategy().resolve(
+            {
+                "cert_path": str(cert_path),
+                "key_path": str(key_path),
+                "cn": "localhost",
+            }
+        )
+        loaded = x509.load_pem_x509_certificate(c.read_bytes())
+        assert loaded.not_valid_after_utc > datetime.datetime.now(datetime.timezone.utc)
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("cryptography") is None,
+        reason="cryptography package not installed",
+    )
+    def test_self_signed_uses_default_paths(self, tmp_path, monkeypatch):
+        """Without explicit cert_path/key_path, falls back to /tmp/valdo-tls/."""
+        import src.services.tls_service as svc
+
+        # Redirect /tmp/valdo-tls to tmp_path so we don't write system /tmp
+        default_cert = tmp_path / "cert.pem"
+        default_key = tmp_path / "key.pem"
+
+        orig = svc.SelfSignedTLSStrategy.resolve
+
+        def patched(self, config):
+            config = dict(config)
+            config.setdefault("cert_path", str(default_cert))
+            config.setdefault("key_path", str(default_key))
+            return orig(self, config)
+
+        monkeypatch.setattr(svc.SelfSignedTLSStrategy, "resolve", patched)
+
+        c, k = svc.SelfSignedTLSStrategy().resolve({"cn": "localhost"})
+        assert c.exists()
+        assert k.exists()
+
+    def test_self_signed_raises_without_cryptography(self, monkeypatch):
+        """RuntimeError with install hint when cryptography is not available."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "cryptography":
+                raise ImportError("mocked missing")
+            # Also block submodules
+            if name.startswith("cryptography."):
+                raise ImportError("mocked missing")
+            return real_import(name, *args, **kwargs)
+
+        from src.services import tls_service as svc
+
+        strategy = svc.SelfSignedTLSStrategy()
+
+        with monkeypatch.context() as m:
+            m.setattr(builtins, "__import__", mock_import)
+            with pytest.raises(RuntimeError, match="cryptography package required"):
+                strategy.resolve({"cn": "localhost"})
+
+
+# ---------------------------------------------------------------------------
+# EnterpriseCAStrategy
+# ---------------------------------------------------------------------------
+
+class TestEnterpriseCAStrategy:
+    """Tests for the EnterpriseCAStrategy (external CA API)."""
+
+    def _valid_cache(self, tmp_path):
+        """Write a cached cert with a far-future expiry."""
+        pytest.importorskip("cryptography")
+        return _make_self_signed_pem(tmp_path)
+
+    def test_enterprise_ca_uses_cached_cert(self, tmp_path):
+        """If cert is cached and not near expiry, no HTTP request is made."""
+        pytest.importorskip("cryptography")
+        cert_path, key_path = self._valid_cache(tmp_path)
+
+        from src.services.tls_service import EnterpriseCAStrategy
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            c, k = EnterpriseCAStrategy().resolve(
+                {
+                    "ca_api_url": "https://ca.example.com/issue",
+                    "cert_path": str(cert_path),
+                    "key_path": str(key_path),
+                    "cn": "valdo.internal",
+                    "san": ["valdo.internal"],
+                    "expiry_warn_days": 30,
+                }
+            )
+            mock_urlopen.assert_not_called()
+        assert c == cert_path
+        assert k == key_path
+
+    def test_enterprise_ca_fetches_when_missing(self, tmp_path):
+        """When no cached cert exists, the CA API is called and cert is saved."""
+        cert_path = tmp_path / "cert.pem"
+        key_path = tmp_path / "key.pem"
+
+        # Build a fake PEM response that cryptography (if present) won't need
+        fake_cert_pem = "-----BEGIN CERTIFICATE-----\nFAKEDATA\n-----END CERTIFICATE-----\n"
+        fake_key_pem = "-----BEGIN RSA PRIVATE KEY-----\nFAKEDATA\n-----END RSA PRIVATE KEY-----\n"
+        response_body = json.dumps({"cert": fake_cert_pem, "key": fake_key_pem}).encode()
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = response_body
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        from src.services.tls_service import EnterpriseCAStrategy
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            c, k = EnterpriseCAStrategy().resolve(
+                {
+                    "ca_api_url": "https://ca.example.com/issue",
+                    "cert_path": str(cert_path),
+                    "key_path": str(key_path),
+                    "cn": "valdo.internal",
+                }
+            )
+
+        assert cert_path.read_text() == fake_cert_pem
+        assert key_path.read_text() == fake_key_pem
+
+    def test_enterprise_ca_fetches_when_expired(self, tmp_path):
+        """Expired cached cert triggers a fresh CA API call."""
+        pytest.importorskip("cryptography")
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        # Write an already-expired cert
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_path = tmp_path / "key.pem"
+        key_path.write_bytes(
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            )
+        )
+        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "old")])
+        expired_cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow() - datetime.timedelta(days=400))
+            .not_valid_after(datetime.datetime.utcnow() - datetime.timedelta(days=10))
+            .sign(key, hashes.SHA256())
+        )
+        cert_path = tmp_path / "cert.pem"
+        cert_path.write_bytes(expired_cert.public_bytes(serialization.Encoding.PEM))
+
+        fake_pem = "-----BEGIN CERTIFICATE-----\nNEW\n-----END CERTIFICATE-----\n"
+        fake_key_pem = "-----BEGIN RSA PRIVATE KEY-----\nNEW\n-----END RSA PRIVATE KEY-----\n"
+        response_body = json.dumps({"cert": fake_pem, "key": fake_key_pem}).encode()
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = response_body
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        from src.services.tls_service import EnterpriseCAStrategy
+
+        with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+            EnterpriseCAStrategy().resolve(
+                {
+                    "ca_api_url": "https://ca.example.com/issue",
+                    "cert_path": str(cert_path),
+                    "key_path": str(key_path),
+                    "cn": "valdo.internal",
+                    "expiry_warn_days": 30,
+                }
+            )
+            mock_urlopen.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# resolve_tls — unknown strategy / output contract
+# ---------------------------------------------------------------------------
+
+class TestResolveTlsMisc:
+    """Miscellaneous resolve_tls tests — error handling and output contract."""
+
+    def test_unknown_strategy_raises(self):
+        """RuntimeError for an unrecognised strategy name."""
+        from src.services.tls_service import resolve_tls
+
+        with pytest.raises(RuntimeError, match="Unknown TLS strategy"):
+            resolve_tls({"enabled": True, "strategy": "magic_beans"})
+
+    def test_resolve_tls_returns_correct_output_contract(self, tmp_path):
+        """resolve_tls returns a (Path, Path) tuple when TLS is enabled."""
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cert.write_text("CERT")
+        key.write_text("KEY")
+
+        from src.services.tls_service import resolve_tls
+
+        result = resolve_tls(
+            {
+                "enabled": True,
+                "strategy": "manual",
+                "cert_path": str(cert),
+                "key_path": str(key),
+            }
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], Path)
+        assert isinstance(result[1], Path)
+
+
+# ---------------------------------------------------------------------------
+# Expiry warning logging
+# ---------------------------------------------------------------------------
+
+class TestExpiryWarningLogged:
+    """Tests for the expiry-warning log path."""
+
+    def test_expiry_warning_logged_when_near_expiry(self, tmp_path, caplog):
+        """A cert expiring in fewer than warn_days triggers a WARNING log."""
+        pytest.importorskip("cryptography")
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        # Create cert that expires in 5 days (below default 30-day threshold)
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        key_path = tmp_path / "key.pem"
+        key_path.write_bytes(
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            )
+        )
+        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "soon")])
+        soon_cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(issuer)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+            .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=5))
+            .sign(key, hashes.SHA256())
+        )
+        cert_path = tmp_path / "cert.pem"
+        cert_path.write_bytes(soon_cert.public_bytes(serialization.Encoding.PEM))
+
+        from src.services import tls_service as svc
+
+        with caplog.at_level(logging.WARNING, logger="src.services.tls_service"):
+            svc.resolve_tls(
+                {
+                    "enabled": True,
+                    "strategy": "manual",
+                    "cert_path": str(cert_path),
+                    "key_path": str(key_path),
+                    "expiry_warn_days": 30,
+                }
+            )
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("expires in" in m for m in warning_msgs)
+
+    def test_no_expiry_warning_for_fresh_cert(self, tmp_path, caplog):
+        """A cert with ample validity remaining does NOT trigger a WARNING."""
+        pytest.importorskip("cryptography")
+        cert_path, key_path = _make_self_signed_pem(tmp_path)  # 90-day cert
+
+        from src.services import tls_service as svc
+
+        with caplog.at_level(logging.WARNING, logger="src.services.tls_service"):
+            svc.resolve_tls(
+                {
+                    "enabled": True,
+                    "strategy": "manual",
+                    "cert_path": str(cert_path),
+                    "key_path": str(key_path),
+                    "expiry_warn_days": 30,
+                }
+            )
+
+        warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("expires in" in m for m in warning_msgs)

--- a/tests/unit/test_ui_config.py
+++ b/tests/unit/test_ui_config.py
@@ -1,15 +1,12 @@
 """Tests for GET /api/v1/system/ui-config endpoint."""
 
-import os
-from unittest.mock import patch
 from fastapi.testclient import TestClient
 from src.api.main import app
 
 
 def test_ui_config_all_false_when_empty():
     app.state.ui_config = {}
-    with patch.dict(os.environ, {"ENABLE_FILE_DOWNLOADER": "false"}):
-        r = TestClient(app).get("/api/v1/system/ui-config")
+    r = TestClient(app).get("/api/v1/system/ui-config")
     assert r.status_code == 200
     tabs = r.json()["tabs"]
     assert tabs["quick"] is False
@@ -19,10 +16,10 @@ def test_ui_config_all_false_when_empty():
 def test_ui_config_returns_configured_values():
     app.state.ui_config = {
         "tabs": {"quick": True, "runs": True, "mapping": False,
-                 "tester": True, "dbcompare": True, "downloader": True}
+                 "tester": True, "dbcompare": True, "downloader": True},
+        "downloader": {"enabled": True},
     }
-    with patch.dict(os.environ, {"ENABLE_FILE_DOWNLOADER": "true"}):
-        r = TestClient(app).get("/api/v1/system/ui-config")
+    r = TestClient(app).get("/api/v1/system/ui-config")
     assert r.status_code == 200
     tabs = r.json()["tabs"]
     assert tabs["quick"] is True
@@ -31,7 +28,17 @@ def test_ui_config_returns_configured_values():
 
 
 def test_ui_config_downloader_forced_false_when_flag_off():
+    """downloader tab is False when downloader.enabled is False in ui.yml."""
+    app.state.ui_config = {
+        "tabs": {"downloader": True},
+        "downloader": {"enabled": False},
+    }
+    r = TestClient(app).get("/api/v1/system/ui-config")
+    assert r.json()["tabs"]["downloader"] is False
+
+
+def test_ui_config_downloader_false_when_enabled_missing():
+    """downloader tab is False when downloader section is absent from ui.yml."""
     app.state.ui_config = {"tabs": {"downloader": True}}
-    with patch.dict(os.environ, {"ENABLE_FILE_DOWNLOADER": "false"}):
-        r = TestClient(app).get("/api/v1/system/ui-config")
+    r = TestClient(app).get("/api/v1/system/ui-config")
     assert r.json()["tabs"]["downloader"] is False


### PR DESCRIPTION
## Summary

Implements 4 enterprise hardening issues in 3 commits:

- **#365** Remove env-based file download config — `ui.yml` is now the single source of truth (`ENABLE_FILE_DOWNLOADER` and `DOWNLOADER_LOG_PATH` env vars removed)
- **#366** Recursive archive search with wildcard support — `search_archives()` walks directory trees via `rglob`, matches archive filenames and internal members with `fnmatch`; supports `.zip`, `.tar.gz`, `.tar`; new `POST /api/v1/downloader/search-nested-archives` endpoint
- **#367** Configurable IP whitelist middleware with CIDR range support — `IPWhitelistMiddleware` reads `security.ip_whitelist` from `ui.yml`; uses Python `ipaddress` stdlib; supports `trust_proxy` for `X-Forwarded-For`
- **#368** Config-driven TLS strategy pattern — `TLSStrategy` ABC with `manual`, `self_signed`, and `enterprise_ca` implementations; switching strategies requires only a `ui.yml` change; `valdo serve` resolves cert and passes SSL kwargs to uvicorn

## New files

- `src/api/middleware/ip_whitelist.py` — IP whitelist Starlette middleware
- `src/services/tls_service.py` — TLS strategy resolver
- `tests/unit/test_ip_whitelist_middleware.py` — 10 tests
- `tests/unit/test_tls_service.py` — 18 tests
- `tests/unit/test_downloader_archive_search.py` — 12 tests
- `tests/unit/test_downloader_config_consolidation.py` — 6 tests

## Test plan

- [x] `python3 -m pytest tests/unit/ -q` — 1957 passed, 82% coverage
- [x] 1 pre-existing failure (`test_trend_service`) unrelated to these changes
- [x] All new tests green: archive search, IP whitelist, TLS strategies, config consolidation
- [x] `config/ui.yml` contains all 3 new config sections: `downloader`, `security`, `tls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)